### PR TITLE
Add HEALTHCHECK instruction

### DIFF
--- a/snippets/dockerfile.json
+++ b/snippets/dockerfile.json
@@ -114,7 +114,7 @@
     "HEALTHCHECK": {
         "prefix": "HEALTHCHECK",
         "body": [
-            "HEALTHCHECK --interval=30s --timeout=30s --retries=3 CMD ${command}"
+            "HEALTHCHECK CMD ${command}"
             "$0"
         ],
         "description": "HEALTHCHECK"

--- a/snippets/dockerfile.json
+++ b/snippets/dockerfile.json
@@ -110,5 +110,14 @@
             "$0"
         ],
         "description": "ONBUILD"
+    },
+    "HEALTHCHECK": {
+        "prefix": "HEALTHCHECK",
+        "body": [
+            "HEALTHCHECK --interval=30s --timeout=30s --retries=3 CMD ${command}"
+            "$0"
+        ],
+        "description": "HEALTHCHECK"
     }
+}
 }


### PR DESCRIPTION
This update should only add in support for the new "HEALTHCHECK" instruction introduced in Docker 1.12.  This will close #23 that I opened.
