### PR TITLE
Adding completion/hover support for compose v2 files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,6 @@
 	"search.exclude": {
 		"out": true
 	}
+,
+"typescript.check.workspaceVersion": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,4 @@
 	"search.exclude": {
 		"out": true
 	}
-,
-"typescript.check.workspaceVersion": false
 }

--- a/dockerCompose/dockerComposeCompletionItemProvider.ts
+++ b/dockerCompose/dockerComposeCompletionItemProvider.ts
@@ -19,8 +19,8 @@ export class DockerComposeCompletionItemProvider implements CompletionItemProvid
 
         // Determine the schema version of the current compose file,
         // based on the existence of a top-level "version" property.
-        var versionMatch = document.getText().match(/^version:\s*["'](\d+(\.\d)?)["']\s*/im);
-        var version = versionMatch ? versionMatch[1] : "1";
+        var versionMatch = document.getText().match(/^version:\s*(["'])(\d+(\.\d)?)\1/im);
+        var version = versionMatch ? versionMatch[2] : "1";
 
         // Get the line where intellisense was invoked on (e.g. 'image: u').
         var line = document.lineAt(position.line).text;

--- a/dockerCompose/dockerComposeCompletionItemProvider.ts
+++ b/dockerCompose/dockerComposeCompletionItemProvider.ts
@@ -5,8 +5,8 @@
 'use strict';
 
 import {TextDocument, Position, CancellationToken, CompletionItem, CompletionItemProvider, CompletionItemKind, Uri} from 'vscode';
+import composeVersions from './dockerComposeKeyInfo';
 import helper = require('../helpers/suggestSupportHelper');
-import {DOCKER_COMPOSE_V1_KEY_INFO, DOCKER_COMPOSE_V2_KEY_INFO} from './dockerComposeKeyInfo';
 import hub = require('../dockerHubApi');
 
 export class DockerComposeCompletionItemProvider implements CompletionItemProvider {
@@ -19,14 +19,15 @@ export class DockerComposeCompletionItemProvider implements CompletionItemProvid
 
         // Determine the schema version of the current compose file,
         // based on the existence of a top-level "version" property.
-        var isV2Document = /^version:/im.test(document.getText());
+        var versionMatch = document.getText().match(/^version:\s*["'](\d+(\.\d)?)["']\s*/im);
+        var version = versionMatch ? versionMatch[1] : "1";
 
         // Get the line where intellisense was invoked on (e.g. 'image: u').
         var line = document.lineAt(position.line).text;
 
         if (line.length === 0) {
             // empty line
-            return Promise.resolve(this.suggestKeys('', isV2Document));
+            return Promise.resolve(this.suggestKeys('', version));
         }
 
         let range = document.getWordRangeAtPosition(position);
@@ -37,7 +38,7 @@ export class DockerComposeCompletionItemProvider implements CompletionItemProvid
         var textBefore = line.substring(0, position.character);
         if (/^\s*[\w_]*$/.test(textBefore)) {
             // on the first token
-            return Promise.resolve(this.suggestKeys(word, isV2Document));
+            return Promise.resolve(this.suggestKeys(word, version));
         }
 
         // Matches strings like: 'image: "ubuntu'
@@ -59,8 +60,10 @@ export class DockerComposeCompletionItemProvider implements CompletionItemProvid
         return Promise.resolve([]);
     }
 
-    private suggestKeys(word: string, useV2Schema: boolean = false): CompletionItem[] {
-        const keys = useV2Schema ? DOCKER_COMPOSE_V2_KEY_INFO : DOCKER_COMPOSE_V1_KEY_INFO;
+    private suggestKeys(word: string, version: string): CompletionItem[] {
+        // Attempt to grab the keys for the requested schema version, 
+        // otherwise, fall back to showing a composition of all possible keys.
+        const keys = composeVersions[`v${version}`] || composeVersions.All;
 
         return Object.keys(keys).map(ruleName => {
             var completionItem = new CompletionItem(ruleName);

--- a/dockerCompose/dockerComposeCompletionItemProvider.ts
+++ b/dockerCompose/dockerComposeCompletionItemProvider.ts
@@ -60,9 +60,6 @@ export class DockerComposeCompletionItemProvider implements CompletionItemProvid
     }
 
     private suggestKeys(word: string, useV2Schema: boolean = false): CompletionItem[] {
-        // TODO: Now that there is a v2.1 compose format, we shouldn't treat schema
-        // selection as a binary operation long-term. Ideally, we could re-use the
-        // JSON schema files that the compose project maintain.
         const keys = useV2Schema ? DOCKER_COMPOSE_V2_KEY_INFO : DOCKER_COMPOSE_V1_KEY_INFO;
 
         return Object.keys(keys).map(ruleName => {

--- a/dockerCompose/dockerComposeKeyInfo.ts
+++ b/dockerCompose/dockerComposeKeyInfo.ts
@@ -6,7 +6,7 @@ import { ComposeVersionKeys, KeyInfo } from "../dockerExtension";
 
 // Define the keys that are shared between all compose file versions.
 // https://docs.docker.com/compose/yml/
-var DOCKER_COMPOSE_SHARED_KEY_INFO: KeyInfo = {
+const DOCKER_COMPOSE_SHARED_KEY_INFO: KeyInfo = {
     'build': (
         "Path to a directory containing a Dockerfile. When the value supplied is a relative path, it is interpreted as relative to the " +
         "location of the yml file itself. This directory is also the build context that is sent to the Docker daemon.\n\n" +
@@ -168,7 +168,7 @@ var DOCKER_COMPOSE_SHARED_KEY_INFO: KeyInfo = {
 
 // Define the keys which are unique to the v1 format.
 // https://github.com/docker/compose/blob/master/compose/config/config_schema_v1.json
-var DOCKER_COMPOSE_V1_ONLY_KEY_INFO: KeyInfo = {
+const DOCKER_COMPOSE_V1_ONLY_KEY_INFO: KeyInfo = {
     'log_driver': (
         "Specify a logging driver for the service's containers, as with the `--log-driver` option for docker run. The default value is json-file."
     ),
@@ -182,7 +182,7 @@ var DOCKER_COMPOSE_V1_ONLY_KEY_INFO: KeyInfo = {
 
 // Define the keys which are unique to the v2 format.
 // https://github.com/docker/compose/blob/master/compose/config/config_schema_v2.0.json
-var DOCKER_COMPOSE_V2_ONLY_KEY_INFO: KeyInfo = {
+const DOCKER_COMPOSE_V2_ONLY_KEY_INFO: KeyInfo = {
     // Added top-level properties
     'services': (
         "Specify the set of services that your app is composed of."
@@ -288,8 +288,15 @@ var DOCKER_COMPOSE_V2_ONLY_KEY_INFO: KeyInfo = {
     // defined above. We can specialize these by adding context-based completion.
 };
 
+// Merge the specified version-specific keys with the shared
+// keys, in order to create a complete schema for a specic version.
+function composeVersionKeys(...versions: KeyInfo[]): KeyInfo {
+    return Object.assign({}, DOCKER_COMPOSE_SHARED_KEY_INFO, ...versions);
+}
+
+// Create 
 export default <ComposeVersionKeys>{
-    v1: Object.assign({}, DOCKER_COMPOSE_SHARED_KEY_INFO, DOCKER_COMPOSE_V1_ONLY_KEY_INFO),
-    v2: Object.assign({}, DOCKER_COMPOSE_SHARED_KEY_INFO, DOCKER_COMPOSE_V2_ONLY_KEY_INFO),
-    All: Object.assign({}, DOCKER_COMPOSE_SHARED_KEY_INFO, DOCKER_COMPOSE_V1_ONLY_KEY_INFO, DOCKER_COMPOSE_V2_ONLY_KEY_INFO)
+    v1: composeVersionKeys(DOCKER_COMPOSE_V1_ONLY_KEY_INFO),
+    v2: composeVersionKeys(DOCKER_COMPOSE_V2_ONLY_KEY_INFO),
+    All: composeVersionKeys(DOCKER_COMPOSE_V1_ONLY_KEY_INFO, DOCKER_COMPOSE_V2_ONLY_KEY_INFO)
 };

--- a/dockerCompose/dockerComposeKeyInfo.ts
+++ b/dockerCompose/dockerComposeKeyInfo.ts
@@ -218,7 +218,12 @@ export var DOCKER_COMPOSE_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_V
     ),
 
     // Added service/logging-level properties
-    'driver': null, // TODO: This could be a logging driver, a volume driver, a network driver, or a network IPAM driver.
+    // TODO: The "driver" property could be a logging driver, a volume driver,
+    // a network driver, or a network IPAM driver, so we should account for
+    // that when we add context-based completion.
+    'driver': (
+        "Specifies the logging driver to use for the service’s container."
+    ),
     'options': (
         'Options to pass to the specified logging driver, provided as key-value pairs.'
     ),
@@ -243,7 +248,6 @@ export var DOCKER_COMPOSE_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_V
     ),
 
     // Network-level properties
-    // TODO: These properties could be either volume or network
     'driver_opts': (
         "Specify a list of options as key-value pairs to pass to the driver. Those options are driver-dependent - consult the driver’s documentation for more information."
     ),
@@ -255,7 +259,8 @@ export var DOCKER_COMPOSE_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_V
     ),
 
     // Network/external-level properties
-    // TODO: This would also apply to an external volume.
+    // TODO: This would also apply to an external volume,
+    // so we should account for that when we add context-based completion.
     'name': (
         "Specifies the name of the externally defined network."
     ),
@@ -280,8 +285,9 @@ export var DOCKER_COMPOSE_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_V
     ),
 
     // Volume-level properties
-    // TODO: Incudes "driver", "driver_opt", and "external"
-    // properties, which are already defined above.
+    // TODO: Top-level volumes support specifying the "driver",
+    // "driver_opt", and "external" properties, but these are already
+    // defined above. We can specialize these by adding context-based completion.
 });
 
 // Create a v2 only key set by removing the v1 properties that no longer exist. This

--- a/dockerCompose/dockerComposeKeyInfo.ts
+++ b/dockerCompose/dockerComposeKeyInfo.ts
@@ -2,12 +2,11 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import { ComposeVersionKeys, KeyInfo } from "../dockerExtension";
+
+// Define the keys that are shared between all compose file versions.
 // https://docs.docker.com/compose/yml/
-
-import { KeyInfo } from "../dockerExtension";
-
-// https://github.com/docker/compose/blob/master/compose/config/config_schema_v1.json
-export var DOCKER_COMPOSE_V1_KEY_INFO: KeyInfo = {
+var DOCKER_COMPOSE_SHARED_KEY_INFO: KeyInfo = {
     'build': (
         "Path to a directory containing a Dockerfile. When the value supplied is a relative path, it is interpreted as relative to the " +
         "location of the yml file itself. This directory is also the build context that is sent to the Docker daemon.\n\n" +
@@ -97,12 +96,7 @@ export var DOCKER_COMPOSE_V1_KEY_INFO: KeyInfo = {
         "Link to containers in another service. Either specify both the service name and the link alias (`CONTAINER:ALIAS`), or " +
         "just the service name (which will also be used for the alias)."
     ),
-    'log_driver': (
-        "Specify a logging driver for the service's containers, as with the `--log-driver` option for docker run. The default value is json-file."
-    ),
-    'log_opt': (
-        "Specify logging options with `log_opt` for the logging driver, as with the `--log-opt` option for docker run."
-    ),
+
     'mac_address': (
         "Container MAC address (e.g. 92:d0:c6:0a:29:33)."
     ),
@@ -114,9 +108,6 @@ export var DOCKER_COMPOSE_V1_KEY_INFO: KeyInfo = {
     ),
     'mem_swappiness': (
         "Tune container memory swappiness (0 to 100) (default -1)."
-    ),
-    'net': (
-        "Networking mode. Use the same values as the docker client `--net` parameter."
     ),
     'pid': (
         "Sets the PID mode to the host PID mode. This turns on sharing between container and the host operating system the PID address space. " +
@@ -173,12 +164,25 @@ export var DOCKER_COMPOSE_V1_KEY_INFO: KeyInfo = {
     'working_dir': (
         "Working directory inside the container."
     )
-}
+};
 
-// Create a superset definition of both v1 and v2 keys, which can be used by the
-// hover provider to display help text for a property in either schema version.
+// Define the keys which are unique to the v1 format.
+// https://github.com/docker/compose/blob/master/compose/config/config_schema_v1.json
+var DOCKER_COMPOSE_V1_ONLY_KEY_INFO: KeyInfo = {
+    'log_driver': (
+        "Specify a logging driver for the service's containers, as with the `--log-driver` option for docker run. The default value is json-file."
+    ),
+    'log_opt': (
+        "Specify logging options with `log_opt` for the logging driver, as with the `--log-opt` option for docker run."
+    ),
+    'net': (
+        "Networking mode. Use the same values as the docker client `--net` parameter."
+    )
+};
+
+// Define the keys which are unique to the v2 format.
 // https://github.com/docker/compose/blob/master/compose/config/config_schema_v2.0.json
-export var DOCKER_COMPOSE_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_V1_KEY_INFO, {
+var DOCKER_COMPOSE_V2_ONLY_KEY_INFO: KeyInfo = {
     // Added top-level properties
     'services': (
         "Specify the set of services that your app is composed of."
@@ -282,11 +286,10 @@ export var DOCKER_COMPOSE_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_V
     // TODO: Top-level volumes support specifying the "driver",
     // "driver_opt", and "external" properties, but these are already
     // defined above. We can specialize these by adding context-based completion.
-});
+};
 
-// Create a v2 only key set by removing the v1 properties that no longer exist. This
-// allows the completion provider to be accurate when authoring v2 format files.
-export var DOCKER_COMPOSE_V2_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_KEY_INFO);
-["log_driver", "log_opt", "net"].forEach((prop) => {
-    delete DOCKER_COMPOSE_V2_KEY_INFO[prop];
-});
+export default <ComposeVersionKeys>{
+    v1: Object.assign({}, DOCKER_COMPOSE_SHARED_KEY_INFO, DOCKER_COMPOSE_V1_ONLY_KEY_INFO),
+    v2: Object.assign({}, DOCKER_COMPOSE_SHARED_KEY_INFO, DOCKER_COMPOSE_V2_ONLY_KEY_INFO),
+    All: Object.assign({}, DOCKER_COMPOSE_SHARED_KEY_INFO, DOCKER_COMPOSE_V1_ONLY_KEY_INFO, DOCKER_COMPOSE_V2_ONLY_KEY_INFO)
+};

--- a/dockerCompose/dockerComposeKeyInfo.ts
+++ b/dockerCompose/dockerComposeKeyInfo.ts
@@ -196,17 +196,11 @@ export var DOCKER_COMPOSE_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_V
     'depends_on': (
         "Specifies the names of services that this service depends on."
     ),
-    'group_add': (
-        "Add additional groups to join."
-    ),
     'logging': (
         "Logging configuration for the service."
     ),
     'network_mode': (
         "Networking mode. Use the same values as the docker client `--net` parameter."
-    ),
-    'oom_score_adj': (
-        "Tune host's OOM preferences (-1000 to 1000)."
     ),
     'tmpfs': (
         "Mount a temporary file system inside the container. Can be a single value or a list."
@@ -295,7 +289,4 @@ export var DOCKER_COMPOSE_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_V
 export var DOCKER_COMPOSE_V2_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_KEY_INFO);
 ["log_driver", "log_opt", "net"].forEach((prop) => {
     delete DOCKER_COMPOSE_V2_KEY_INFO[prop];
-})
-
-// TODO: Add support for the v2.1 file format
-// https://github.com/docker/compose/blob/master/compose/config/config_schema_v2.1.json
+});

--- a/dockerCompose/dockerComposeKeyInfo.ts
+++ b/dockerCompose/dockerComposeKeyInfo.ts
@@ -3,51 +3,117 @@
  *--------------------------------------------------------*/
 
 // https://docs.docker.com/compose/yml/
-export var DOCKER_COMPOSE_KEY_INFO: { [keyName: string]: string; } = {
-    'image': (
-        "Tag or partial image ID. Can be local or remote - Compose will attempt to pull if it doesn't exist locally."
-    ),
+
+import { KeyInfo } from "../dockerExtension";
+
+// https://github.com/docker/compose/blob/master/compose/config/config_schema_v1.json
+export var DOCKER_COMPOSE_V1_KEY_INFO: KeyInfo = {
     'build': (
         "Path to a directory containing a Dockerfile. When the value supplied is a relative path, it is interpreted as relative to the " +
         "location of the yml file itself. This directory is also the build context that is sent to the Docker daemon.\n\n" +
         "Compose will build and tag it with a generated name, and use that image thereafter."
     ),
+    'cap_add': (
+        "Add or drop container capabilities. See `man 7 capabilities` for a full list."
+    ),
+    'cap_drop': (
+        "Add or drop container capabilities. See `man 7 capabilities` for a full list."
+    ),
+    'cgroup_parent': (
+        "Specify an optional parent cgroup for the container."
+    ),
     'command': (
         "Override the default command."
     ),
-    'links': (
-        "Link to containers in another service. Either specify both the service name and the link alias (`CONTAINER:ALIAS`), or " +
-        "just the service name (which will also be used for the alias)."
+    'container_name': (
+        "Specify custom container name, rather than a generated default name."
+    ),
+    'cpu_shares': (
+        "CPU shares (relative weight)."
+    ),
+    'cpu_quota': (
+        "Limit CPU CFS (Completely Fair Scheduler) quota."
+    ),
+    'cpuset': (
+        "CPUs in which to allow execution."
+    ),
+    'devices': (
+        "List of device mappings. Uses the same format as the `--device` docker client create option."
+    ),
+    'dns': (
+        "Custom DNS servers. Can be a single value or a list."
+    ),
+    'dns_search': (
+        "Custom DNS search domains. Can be a single value or a list."
+    ),
+    'dockerfile': (
+        "Alternate dockerfile. Compose will use an alternate file to build with. Using `dockerfile` together with `image` is not allowed. Attempting to do so results in an error."
+    ),
+    'domainname': (
+        "Container domain name."
+    ),
+    'entrypoint': (
+        "Overwrite the default ENTRYPOINT of the image."
+    ),
+    'env_file': (
+        "Add environment variables from a file. Can be a single value or a list.\n\n" +
+        "If you have specified a Compose file with `docker-compose -f FILE`, paths in `env_file` are relative to the directory that file is in.\n\n" +
+        "Environment variables specified in `environment` override these values."
+    ),
+    'environment': (
+        "Add environment variables. You can use either an array or a dictionary.\n\n" +
+        "Environment variables with only a key are resolved to their values on the machine Compose is running on, which can be helpful for secret or host-specific values."
+    ),
+    'expose': (
+        "Expose ports without publishing them to the host machine - they'll only be accessible to linked services. \n" +
+        "Only the internal port can be specified."
+    ),
+    'extends': (
+        "Extend another service, in the current file or another, optionally overriding configuration.\nYou can use `extends` on any service together with other configuration keys. " +
+        "The `extends` value must be a dictionary defined with a required `service` and an optional `file` key."
     ),
     'external_links': (
         "Link to containers started outside this `docker-compose.yml` or even outside of Compose, especially for containers that " +
         "provide shared or common services. `external_links` follow " +
         "semantics similar to `links` when specifying both the container name and the link alias (`CONTAINER:ALIAS`)."
     ),
-    'ports': (
-        "Expose ports. Either specify both ports (`HOST:CONTAINER`), or just the container port (a random host port will be chosen).\n\n" +
-        "**Note**: When mapping ports in the `HOST:CONTAINER` format, you may experience erroneous results when using a container port " +
-        "lower than 60, because YAML will parse numbers in the format `xx:yy` as sexagesimal (base 60). For this reason, we recommend " +
-        "always explicitly specifying your port mappings as strings."
+    'extra_hosts': (
+        "Add hostname mappings. Use the same values as the docker client `--add-host` parameter."
     ),
-    'expose': (
-        "Expose ports without publishing them to the host machine - they'll only be accessible to linked services. \n" +
-        "Only the internal port can be specified."
+    'hostname': (
+        "Container host name."
     ),
-    'volumes': (
-        "Mount paths as volumes, optionally specifying a path on the host machine (`HOST:CONTAINER`), or an access mode (`HOST:CONTAINER:ro`)."
+    'image': (
+        "Tag or partial image ID. Can be local or remote - Compose will attempt to pull if it doesn't exist locally."
     ),
-    'volumes_from': (
-        "Mount all of the volumes from another service or container."
+    'ipc': (
+        "IPC namespace to use."
     ),
-    'environment': (
-        "Add environment variables. You can use either an array or a dictionary.\n\n" +
-        "Environment variables with only a key are resolved to their values on the machine Compose is running on, which can be helpful for secret or host-specific values."
+    'labels': (
+        "Add metadata to containers using Docker labels. You can either use an array or a dictionary.\n" +
+        "It's recommended that you use reverse-DNS notation to prevent your labels from conflicting with those used by other software."
     ),
-    'env_file': (
-        "Add environment variables from a file. Can be a single value or a list.\n\n" +
-        "If you have specified a Compose file with `docker-compose -f FILE`, paths in `env_file` are relative to the directory that file is in.\n\n" +
-        "Environment variables specified in `environment` override these values."
+    'links': (
+        "Link to containers in another service. Either specify both the service name and the link alias (`CONTAINER:ALIAS`), or " +
+        "just the service name (which will also be used for the alias)."
+    ),
+    'log_driver': (
+        "Specify a logging driver for the service's containers, as with the `--log-driver` option for docker run. The default value is json-file."
+    ),
+    'log_opt': (
+        "Specify logging options with `log_opt` for the logging driver, as with the `--log-opt` option for docker run."
+    ),
+    'mac_address': (
+        "Container MAC address (e.g. 92:d0:c6:0a:29:33)."
+    ),
+    'mem_limit': (
+        "Memory limit."
+    ),
+    'memswap_limit': (
+        "Swap limit equal to memory plus swap: '-1' to enable unlimited swap."
+    ),
+    'mem_swappiness': (
+        "Tune container memory swappiness (0 to 100) (default -1)."
     ),
     'net': (
         "Networking mode. Use the same values as the docker client `--net` parameter."
@@ -56,51 +122,174 @@ export var DOCKER_COMPOSE_KEY_INFO: { [keyName: string]: string; } = {
         "Sets the PID mode to the host PID mode. This turns on sharing between container and the host operating system the PID address space. " +
         "Containers launched with this flag will be able to access and manipulate other containers in the bare-metal machine's namespace and vise-versa."
     ),
-    'dns': (
-        "Custom DNS servers. Can be a single value or a list."
+    'ports': (
+        "Expose ports. Either specify both ports (`HOST:CONTAINER`), or just the container port (a random host port will be chosen).\n\n" +
+        "**Note**: When mapping ports in the `HOST:CONTAINER` format, you may experience erroneous results when using a container port " +
+        "lower than 60, because YAML will parse numbers in the format `xx:yy` as sexagesimal (base 60). For this reason, we recommend " +
+        "always explicitly specifying your port mappings as strings."
     ),
-    'cap_add': (
-        "Add or drop container capabilities. See `man 7 capabilities` for a full list."
+    'privileged': (
+        "Give extended privileges to this container."
     ),
-    'cap_drop': (
-        "Add or drop container capabilities. See `man 7 capabilities` for a full list."
+    'read_only': (
+        "Mount the container's root filesystem as read only."
     ),
-    'dns_search': (
-        "Custom DNS search domains. Can be a single value or a list."
-    ),
-    'cgroup_parent': (
-        "Specify an optional parent cgroup for the container."
-    ),
-    'container_name': (
-        "Specify custom container name, rather than a generated default name."
-    ),
-    'devices': (
-        "List of device mappings. Uses the same format as the `--device` docker client create option."
-    ),
-    'dockerfile': (
-        "Alternate dockerfile. Compose will use an alternate file to build with. Using `dockerfile` together with `image` is not allowed. Attempting to do so results in an error."
-    ),
-    'extends': (
-        "Extend another service, in the current file or another, optionally overriding configuration.\nYou can use `extends` on any service together with other configuration keys. " +
-        "The `extends` value must be a dictionary defined with a required `service` and an optional `file` key."
-    ),
-    'extra_hosts': (
-        "Add hostname mappings. Use the same values as the docker client `--add-host` parameter."
-    ),
-    'labels': (
-        "Add metadata to containers using Docker labels. You can either use an array or a dictionary.\n" +
-        "It's recommended that you use reverse-DNS notation to prevent your labels from conflicting with those used by other software."
-    ),
-    'log_driver': (
-        "Specify a logging driver for the service's containers, as with the `--log-driver` option for docker run. The default value is json-file."
-    ),
-    'log_opt': (
-        "Specify logging options with `log_opt` for the logging driver, as with the `--log-opt` option for docker run."
+    'restart': (
+        "Restart policy to apply when a container exits (default \"no\")."
     ),
     'security_opt': (
         "Override the default labeling scheme for each container."
     ),
+    'shm_size': (
+        "Size of /dev/shm, default value is 64MB."
+    ),
+    'stdin_open': (
+        "Keep STDIN open even if not attached."
+    ),
+    'stop_signal': (
+        "Signal to stop a container, SIGTERM by default."
+    ),
+    'tty': (
+        "Allocate a pseudo-TTY."
+    ),
+    'ulimits': (
+        "Override the default ulimits for a container. You can either specify a single limit as an integer or soft/hard limits as a mapping."
+    ),
+    'user': (
+        "Username or UID (format: <name|uid>[:<group|gid>])."
+    ),
+    'version': (
+        "Specify the compose format that this file conforms to. Omit this property to indicate v1, otherwise, set this to `2`."
+    ),
+    'volumes': (
+        "Mount paths as volumes, optionally specifying a path on the host machine (`HOST:CONTAINER`), or an access mode (`HOST:CONTAINER:ro`)."
+    ),
     'volume_driver': (
         "If you use a volume name (instead of a volume path), you may also specify a `volume_driver`."
+    ),
+    'volumes_from': (
+        "Mount all of the volumes from another service or container."
+    ),
+    'working_dir': (
+        "Working directory inside the container."
     )
 }
+
+// Create a superset definition of both v1 and v2 keys, which can be used by the
+// hover provider to display help text for a property in either schema version.
+// https://github.com/docker/compose/blob/master/compose/config/config_schema_v2.0.json
+export var DOCKER_COMPOSE_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_V1_KEY_INFO, {
+    // Added top-level properties
+    'services': (
+        "Specify the set of services that your app is composed of."
+    ),
+     // TODO: There is now a top-level and service-level volumes/networks setting which conflict.
+     // This will be resolved when we add completion that understands file position context.
+    'networks': (
+        "Specifies the networks to be created as part of your app. This is analogous to running `docker network create`."
+    ),
+    'volumes': (
+        "Specifies the volumes to be created as part of your app. This is analogous to running `docker volume create`."
+    ),
+
+    // Added service-level properties
+    'depends_on': (
+        "Specifies the names of services that this service depends on."
+    ),
+    'group_add': (
+        "Add additional groups to join."
+    ),
+    'logging': (
+        "Logging configuration for the service."
+    ),
+    'network_mode': (
+        "Networking mode. Use the same values as the docker client `--net` parameter."
+    ),
+    'oom_score_adj': (
+        "Tune host's OOM preferences (-1000 to 1000)."
+    ),
+    'tmpfs': (
+        "Mount a temporary file system inside the container. Can be a single value or a list."
+    ),
+
+    // Modified service-level properties
+    'build': (
+        "Configuration options that are applied at build time. Can be specified either as a string containing a path to the build context, or an object with the path specified under `context` and optionally `dockerfile` and `args`."
+    ),
+
+    // Added service/logging-level properties
+    'driver': null, // TODO: This could be a logging driver, a volume driver, a network driver, or a network IPAM driver.
+    'options': (
+        'Options to pass to the specified logging driver, provided as key-value pairs.'
+    ),
+
+    // Added service/build-level properties
+    'args': (
+        "Add build arguments, which are environment variables accessible only during the build process."
+    ),
+    'context': (
+        "Either a path to a directory containing a Dockerfile, or a url to a git repository. This directory will be used as the build context that is sent to the Docker daemon."
+    ),
+
+    // Added service/network-level properties
+    'aliases': (
+        "Alternative hostnames for this service on the network. Other containers on the same network can use either the service name or this alias to connect to one of the service’s containers."
+    ),
+    'ipv4_address': (
+        "Specify a static IPv4 address for containers for this service when joining the network."
+    ),
+    'ipv6_address': (
+        "Specify a static IPv6 address for containers for this service when joining the network."
+    ),
+
+    // Network-level properties
+    // TODO: These properties could be either volume or network
+    'driver_opts': (
+        "Specify a list of options as key-value pairs to pass to the driver. Those options are driver-dependent - consult the driver’s documentation for more information."
+    ),
+    'external': (
+        "If set to true, specifies that this network has been created outside of Compose. `docker-compose up` will not attempt to create it, and will raise an error if it doesn’t exist."
+    ),
+    'ipam': (
+        "Specify custom IPAM config"
+    ),
+
+    // Network/external-level properties
+    // TODO: This would also apply to an external volume.
+    'name': (
+        "Specifies the name of the externally defined network."
+    ),
+
+    // Network/ipam-level properties
+    'config': (
+        "A list with zero or more config blocks."
+    ),
+
+    // Network/ipam/config-level properties
+    'aux_addresses': (
+        "Auxiliary IPv4 or IPv6 addresses used by Network driver, as a mapping from hostname to IP."
+    ),
+    'gateway': (
+        "IPv4 or IPv6 gateway for the master subnet."
+    ),
+    'ip_range': (
+        "Range of IPs from which to allocate container IPs."
+    ),
+    'subnet': (
+        "Subnet in CIDR format that represents a network segment."
+    ),
+
+    // Volume-level properties
+    // TODO: Incudes "driver", "driver_opt", and "external"
+    // properties, which are already defined above.
+});
+
+// Create a v2 only key set by removing the v1 properties that no longer exist. This
+// allows the completion provider to be accurate when authoring v2 format files.
+export var DOCKER_COMPOSE_V2_KEY_INFO: KeyInfo = Object.assign({}, DOCKER_COMPOSE_KEY_INFO);
+["log_driver", "log_opt", "net"].forEach((prop) => {
+    delete DOCKER_COMPOSE_V2_KEY_INFO[prop];
+})
+
+// TODO: Add support for the v2.1 file format
+// https://github.com/docker/compose/blob/master/compose/config/config_schema_v2.1.json

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -6,7 +6,7 @@ import { DockerHoverProvider } from './dockerHoverProvider';
 import { DockerfileCompletionItemProvider } from './dockerfile/dockerfileCompletionItemProvider';
 import { DockerComposeCompletionItemProvider } from './dockerCompose/dockerComposeCompletionItemProvider';
 import { DOCKERFILE_KEY_INFO } from './dockerfile/dockerfileKeyInfo';
-import { DOCKER_COMPOSE_KEY_INFO } from './dockerCompose/dockerComposeKeyInfo';
+import composeVersionKeys from './dockerCompose/dockerComposeKeyInfo';
 import { DockerComposeParser } from './dockerCompose/dockerComposeParser';
 import { DockerfileParser } from './dockerfile/dockerfileParser';
 import vscode = require('vscode');
@@ -21,6 +21,12 @@ import { tagImage } from './commands/tag-image';
 import { composeUp, composeDown } from './commands/docker-compose';
 import { configure, configureLaunchJson } from './configureWorkspace/configure';
 
+export interface ComposeVersionKeys {
+    All: KeyInfo,
+    v1: KeyInfo,
+    v2: KeyInfo
+};
+
 export type KeyInfo = { [keyName: string]: string; };
 
 export function activate(ctx: vscode.ExtensionContext): void {
@@ -30,7 +36,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(DOCKERFILE_MODE_ID, new DockerfileCompletionItemProvider(), '.'));
 
     const YAML_MODE_ID: vscode.DocumentFilter = { language: 'yaml', scheme: 'file', pattern: '**/docker-compose*.yml' };
-    var yamlHoverProvider = new DockerHoverProvider(new DockerComposeParser(), DOCKER_COMPOSE_KEY_INFO);
+    var yamlHoverProvider = new DockerHoverProvider(new DockerComposeParser(), composeVersionKeys.All);
     ctx.subscriptions.push(vscode.languages.registerHoverProvider(YAML_MODE_ID, yamlHoverProvider));
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(YAML_MODE_ID, new DockerComposeCompletionItemProvider(), '.'));
 

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -21,6 +21,8 @@ import { tagImage } from './commands/tag-image';
 import { composeUp, composeDown } from './commands/docker-compose';
 import { configure, configureLaunchJson } from './configureWorkspace/configure';
 
+export type KeyInfo = { [keyName: string]: string; };
+
 export function activate(ctx: vscode.ExtensionContext): void {
     const DOCKERFILE_MODE_ID: vscode.DocumentFilter = { language: 'dockerfile', scheme: 'file' };
     var dockerHoverProvider = new DockerHoverProvider(new DockerfileParser(), DOCKERFILE_KEY_INFO);

--- a/dockerHoverProvider.ts
+++ b/dockerHoverProvider.ts
@@ -5,16 +5,17 @@
 'use strict';
 
 import { Range, TextDocument, Position, CancellationToken, HoverProvider, Hover, MarkedString } from 'vscode';
+import { KeyInfo } from "./dockerExtension";
 import parser = require('./parser');
 import hub = require('./dockerHubApi');
 import suggestHelper = require('./helpers/suggestSupportHelper');
 
 export class DockerHoverProvider implements HoverProvider {
     _parser: parser.Parser;
-    _keyInfo: { [keyName: string]: string; };
+    _keyInfo: KeyInfo;
 
     // Provide the parser you want to use as well as keyinfo dictionary.
-    constructor(wordParser: parser.Parser, keyInfo: { [keyName: string]: string; }) {
+    constructor(wordParser: parser.Parser, keyInfo: KeyInfo) {
         this._parser = wordParser;
         this._keyInfo = keyInfo;
     }


### PR DESCRIPTION
This addresses #17 by updating the completion provider for compose files in the following ways:
1. Updates the set of recommended properties to match the v1 spec (e.g. `hostname`, `cpu_shares`). 
2. Adds support for the new properties in v2 files, and provides the correct completion results depending on the version of the compose file being edited (e.g. If you're editing a v1 file, you won't see a `log_driver` keyword recommendation).

<img width="496" alt="screen shot 2016-10-27 at 12 31 12 pm" src="https://cloud.githubusercontent.com/assets/116461/19782130/57337bde-9c41-11e6-9edf-6f0622741669.png">

<img width="487" alt="screen shot 2016-10-27 at 12 31 30 pm" src="https://cloud.githubusercontent.com/assets/116461/19782139/625b892a-9c41-11e6-8cfa-6799e2da8bc4.png">

Additionally, this updates the hover provider to display the help text for both v1 and v2 keys. 

Longer term, we should investigate improving the way that auto-completion works, so that we can display context-based recommendations, which would make this experience much better and less error-prone. I logged #35 to track this enhancement.

Additionally, it would be great if we could base the completion/hover behavior on the Docker Compose JSON schema files, as opposed to needing to define the schema ourselves. Once we did that, we could also introduce linting support and other nice features.

_NOTE: I also took the liberty of alpha-sorting the schema definition for compose files, which is the cause of a bit of churn in this PR._
