### PR TITLE
Adding hover help support for Docker 1.12 directives

### DIFF
--- a/dockerfile/dockerfileKeyInfo.ts
+++ b/dockerfile/dockerfileKeyInfo.ts
@@ -2,32 +2,19 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import { KeyInfo } from "../dockerExtension";
+
 // https://docs.docker.com/reference/builder/
-export var DOCKERFILE_KEY_INFO: { [keyName: string]: string; } = {
-    'FROM': (
-        "Sets the **Base Image** for subsequent instructions."
-    ),
-    'MAINTAINER': (
-        "Set the **Author** field of the generated images."
-    ),
-    'RUN': (
-        "Executes any commands in a new layer on top of the current image and commits the results."
-    ),
-    'CMD': (
-        "Provides defaults for an executing container."
-    ),
-    'LABEL': (
-        "Adds metadata to an image. A **LABEL** is a key-value pair."
-    ),
-    'EXPOSE': (
-        "Informs Docker that the container will listen on the specified network ports at runtime."
-    ),
-    'ENV': (
-        "Sets the environment variable `key` to the value `value`."
-    ),
+export const DOCKERFILE_KEY_INFO: KeyInfo = {
     'ADD': (
         "The **ADD** instruction copies new files, directories or remote file URLs from `src` and adds them " +
         "to the filesystem of the container at the path `dest`."
+    ),
+    'ARG': (
+        "Defines a variable that users can specify at build-time, by means of the **--build-arg <varname>=<value>** flag of the **docker build** command."
+    ),
+    'CMD': (
+        "Provides defaults for an executing container."
     ),
     'COPY': (
         "Copies new files or directories from `src` and adds them to the filesystem of the container at the path `dest`."
@@ -35,22 +22,46 @@ export var DOCKERFILE_KEY_INFO: { [keyName: string]: string; } = {
     'ENTRYPOINT': (
         "Configures a container that will run as an executable."
     ),
-    'VOLUME': (
-        "Creates a mount point with the specified name and marks it as holding externally mounted volumes " +
-        "from native host or other containers."
+    'ENV': (
+        "Sets the environment variable `key` to the value `value`."
     ),
-    'USER': (
-        "Sets the user name or UID to use when running the image and for any `RUN`, `CMD` and `ENTRYPOINT` " +
-        "instructions that follow it in the Dockerfile."
+    'EXPOSE': (
+        "Informs Docker that the container will listen on the specified network ports at runtime."
     ),
-    'WORKDIR': (
-        "Sets the working directory for any `RUN`, `CMD`, `ENTRYPOINT`, `COPY` and `ADD` instructions that follow it in the Dockerfile."
+    'FROM': (
+        "Sets the **Base Image** for subsequent instructions."
+    ),
+    'HEALTHCHECK': (
+        "Specifies a command that Docker should run within the container, in order to determine whether it's functioning properly."
+    ),
+    'LABEL': (
+        "Adds metadata to an image. A **LABEL** is a key-value pair."
+    ),
+    'MAINTAINER': (
+        "Set the **Author** field of the generated images."
     ),
     'ONBUILD': (
         "Adds to the image a trigger instruction to be executed at a later time, when the image is used as the " +
         "base for another build."
     ),
+    'RUN': (
+        "Executes any commands in a new layer on top of the current image and commits the results."
+    ),
+    'SHELL': (
+        "Specifies the default shell that should be used for commands which are written in shell-form (e.g. **RUN npm install**)."
+    ),
     'STOPSIGNAL': (
         "Sets the system call signal that will be sent to the container to exit."
+    ),
+    'USER': (
+        "Sets the user name or UID to use when running the image and for any `RUN`, `CMD` and `ENTRYPOINT` " +
+        "instructions that follow it in the Dockerfile."
+    ),
+    'VOLUME': (
+        "Creates a mount point with the specified name and marks it as holding externally mounted volumes " +
+        "from native host or other containers."
+    ),
+    'WORKDIR': (
+        "Sets the working directory for any `RUN`, `CMD`, `ENTRYPOINT`, `COPY` and `ADD` instructions that follow it in the Dockerfile."
     )
-}
+};


### PR DESCRIPTION
This simply adds hover help support for the `ARG`, `HEALTHCHECK` and `SHELL` directives that were added in Docker 1.12. I also re-organized the directives alphabetically, which is the cause of the majority of the churn in this PR.

#25 adds a snippet for the `HEALTHCHECK` directive, but doesn't include support for the hover provider.