### PR TITLE
Make logs command follow stdout

### DIFF
--- a/commands/showlogs-container.ts
+++ b/commands/showlogs-container.ts
@@ -6,7 +6,7 @@ export function showLogsContainer() {
     quickPickContainer().then(function (selectedItem: ContainerItem) {
         if (selectedItem) {
             let terminal = vscode.window.createTerminal(selectedItem.label);
-            terminal.sendText(`docker logs ${selectedItem.ids[0]}`);
+            terminal.sendText(`docker logs -f ${selectedItem.ids[0]}`);
             terminal.show();
         }
     });


### PR DESCRIPTION
This addresses #39 by simply requesting that the underlying `docker logs` command keeps following stdout for the selected container, which makes it easier to monitor a container within VS Code. If a user doesn't want this functionality, they can easily `CTRL+C` or close the terminal window in VS Code, so I feel like it's easier to just always enable following the logs, as opposed to introducing a new option for the `Show Logs` command, or adding another command.

That said, I'm opening this PR for conversation, since I'm not completely sure whether this change is the right behavior for everyone, despite the fact that it's my preference, and that I think we should have a solution for it in some form.

I've been thinking of terminal windows within VS Code as largely disposeable, especially ones that are created via commands (e.g. the `Docker: Show Logs` command), so having a command "capture" it like this, doesn't seem too invasive, however, I'm not sure whether my thinking here is correct or not.

CC @chrisdias