### PR TITLE
Adding build image context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,15 @@
         "path": "./snippets/dockerfile.json"
       }
     ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "vscode-docker.image.build",
+          "group": "navigation",
+          "when": "editorLangId == dockerfile"
+        }
+      ]
+    },
     "debuggers": [
       {
         "type": "docker",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,16 @@
     "menus": {
       "editor/context": [
         {
+          "when": "editorLangId == dockerfile",
           "command": "vscode-docker.image.build",
-          "group": "navigation",
-          "when": "editorLangId == dockerfile"
+          "group": "navigation"
+        }
+      ],
+      "explorer/context": [
+        {
+          "when": "resourceLangId == dockerfile",
+          "command": "vscode-docker.image.build",
+          "group": "navigation@+1"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -54,14 +54,14 @@
         {
           "when": "editorLangId == dockerfile",
           "command": "vscode-docker.image.build",
-          "group": "navigation"
+          "group": "docker"
         }
       ],
       "explorer/context": [
         {
           "when": "resourceLangId == dockerfile",
           "command": "vscode-docker.image.build",
-          "group": "navigation@+1"
+          "group": "docker"
         }
       ]
     },


### PR DESCRIPTION
This introduces a new `Docker: Build Image` context menu item, that simply triggers the existing command, but allows users to execute it from a specific file, as opposed to globally using the command palette.

I chose not to require that a folder be currently opened, and so you could right-click within a loose `Dockerfile` and build it's image, and it will use the parent directory as the build context. Since the convention is typically to place a `Dockerfile` within the directory which represents the build context, this behavior seemed reasonable to me, but I'd be interested in feedback. This change is the source of the churn in the `createItem` method.

cc @chrisdias 