### PR TITLE
Add Windows support for shell attach

### DIFF
--- a/commands/open-shell-container.ts
+++ b/commands/open-shell-container.ts
@@ -1,12 +1,20 @@
-import vscode = require('vscode');
+import * as vscode from 'vscode';
 import {ContainerItem, quickPickContainer} from './utils/quick-pick-container';
+import {DockerEngineType, docker} from './utils/docker-endpoint';
+
+const engineTypeShellCommands = {
+    [DockerEngineType.Linux]: "/bin/sh",
+    [DockerEngineType.Windows]: "cmd"
+}
 
 export function openShellContainer() {
-    quickPickContainer().then(function (selectedItem: ContainerItem) {
+    quickPickContainer().then((selectedItem: ContainerItem) => {
         if (selectedItem) {
-            let terminal = vscode.window.createTerminal(`sh ${selectedItem.label}`);
-            terminal.sendText(`docker exec -it ${selectedItem.ids[0]} /bin/sh`);
-            terminal.show();
+            docker.getEngineType().then((engineType: DockerEngineType) => {
+                const terminal = vscode.window.createTerminal(`Shell: ${selectedItem.label}`);
+                terminal.sendText(`docker exec -it ${selectedItem.ids[0]} ${engineTypeShellCommands[engineType]}`);
+                terminal.show();
+            });
         }
     });
 }

--- a/commands/open-shell-container.ts
+++ b/commands/open-shell-container.ts
@@ -4,7 +4,7 @@ import {DockerEngineType, docker} from './utils/docker-endpoint';
 
 const engineTypeShellCommands = {
     [DockerEngineType.Linux]: "/bin/sh",
-    [DockerEngineType.Windows]: "cmd"
+    [DockerEngineType.Windows]: "powershell"
 }
 
 export function openShellContainer() {

--- a/commands/utils/docker-endpoint.ts
+++ b/commands/utils/docker-endpoint.ts
@@ -1,8 +1,11 @@
 import * as Docker from 'dockerode';
 
+export enum DockerEngineType {
+    Linux,
+    Windows
+}
 
 class DockerClient {
-
     private endPoint:Docker;
 
     constructor() {
@@ -37,6 +40,24 @@ class DockerClient {
 
     public getContainer(id: string): Docker.Container {
         return this.endPoint.getContainer(id);
+    }
+
+    public getEngineType() : Thenable<DockerEngineType> {
+        if (process.platform === 'win32') {
+            return new Promise((resolve, reject) => {
+                this.endPoint.info((error, info) => {
+                    if (error) {
+                        return reject(error);
+                    }
+
+                    return resolve(info.OSType === "windows" ? DockerEngineType.Windows : DockerEngineType.Linux);
+                });
+            });
+        };
+
+        // On Linux or macOS, this can only ever be linux,
+        // so short-circuit the Docker call entirely.
+        return Promise.resolve(DockerEngineType.Linux);
     }
 
     public getImage(id:string): Docker.Image {

--- a/typings/dockerode.d.ts
+++ b/typings/dockerode.d.ts
@@ -23,6 +23,10 @@ declare module Docker {
 		stdin?: boolean;
 	}
 
+	interface EngineInfo {
+		OSType: string;
+	}
+
 	interface ExecInspectData {
 		ExitCode: number;
 	}
@@ -69,10 +73,11 @@ declare module Docker {
 	}
 }
 
-
 declare class Docker {
 	modem: Docker.Modem;
 	constructor(options: Docker.DockerOptions);
+
+	info(cb: (err: Error, data: Docker.EngineInfo) => void): void;
 
 	listImages(cb: (err:Error , images: Docker.ImageDesc[])=>void): void;
 	getImage(id:string): Docker.Image;


### PR DESCRIPTION
This change updates the `Docker: Attach Shell` command in order to properly support Windows containers. Previously, this command assumed that it could run `/bin/sh` in the selected image, whereas this change will detect a Windows container, and run `cmd` instead.

Beyond this change, we should allow configuring the default shell use, so that Windows users could toggle PowerShell and Linux users could use Bash/etc.