### PR TITLE
Use docker-machine from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Of course, you will want to have Docker installed on your computer in order to r
 ## Running commands on Linux
 By default, Docker runs as the root user, requiring other users to access it with `sudo`. This extension does not assume root access, so you will need to create a Unix group called docker and add users to it. Instructions can be found here: [Create a Docker group](https://docs.docker.com/engine/installation/linux/ubuntulinux/#/create-a-docker-group)
 
+## Connecting to docker-machine
+The default connection of the extension is to connect to the local docker daemon. You can connect to a docker-machine instance if you launch Visual Studio Code and have the DOCKER_HOST environment variable set to a valid host.
+
 ## Contributing
 There are a couple of ways you can contribute to this repo:
 

--- a/commands/utils/docker-endpoint.ts
+++ b/commands/utils/docker-endpoint.ts
@@ -9,7 +9,10 @@ class DockerClient {
     private endPoint:Docker;
 
     constructor() {
-        if (process.platform === 'win32') {
+        if (process.env.DOCKER_HOST){
+            this.endPoint = new Docker();
+        }
+        else if (process.platform === 'win32') {
             this.endPoint = new Docker({ socketPath: "//./pipe/docker_engine" });
         } else {
             this.endPoint = new Docker({ socketPath: '/var/run/docker.sock' });

--- a/commands/utils/docker-endpoint.ts
+++ b/commands/utils/docker-endpoint.ts
@@ -10,7 +10,7 @@ class DockerClient {
 
     constructor() {
         // Pass no options so that the defaultOpts of docker-modem will be used
-        this.endPoint = new Docker(null);
+        this.endPoint = new Docker();
     }
 
     public getContainerDescriptors(): Thenable<Docker.ContainerDesc[]>{

--- a/commands/utils/docker-endpoint.ts
+++ b/commands/utils/docker-endpoint.ts
@@ -9,14 +9,8 @@ class DockerClient {
     private endPoint:Docker;
 
     constructor() {
-        if (process.env.DOCKER_HOST){
-            this.endPoint = new Docker();
-        }
-        else if (process.platform === 'win32') {
-            this.endPoint = new Docker({ socketPath: "//./pipe/docker_engine" });
-        } else {
-            this.endPoint = new Docker({ socketPath: '/var/run/docker.sock' });
-        }
+        // Pass no options so that the defaultOpts of docker-modem will be used
+        this.endPoint = new Docker(null);
     }
 
     public getContainerDescriptors(): Thenable<Docker.ContainerDesc[]>{

--- a/package.json
+++ b/package.json
@@ -203,6 +203,6 @@
   },
   "dependencies": {
     "dockerfile_lint": "^0.2.6",
-    "dockerode": "^2.3.0"
+    "dockerode": "^2.3.2"
   }
 }

--- a/typings/dockerode.d.ts
+++ b/typings/dockerode.d.ts
@@ -75,7 +75,7 @@ declare module Docker {
 
 declare class Docker {
 	modem: Docker.Modem;
-	constructor(options: Docker.DockerOptions);
+	constructor(options?: Docker.DockerOptions);
 
 	info(cb: (err: Error, data: Docker.EngineInfo) => void): void;
 


### PR DESCRIPTION
The dockerode library that is used by the extension already has the necessary code to connect to docker-machine instances, as long as there is a valid  DOCKER_HOST environment variable set. 

We can take advantage of this fact and let users connect to other docker daemons. 

Tested with VSCode on windows with:
- a secondary local docker-machine (HyperV)
- remote docker (setup on ubuntu and manually connected as a docker-machine)