### PR TITLE
Fix broken link to the Dockerfile reference

### DIFF
--- a/dockerfile/dockerfileKeyInfo.ts
+++ b/dockerfile/dockerfileKeyInfo.ts
@@ -4,7 +4,7 @@
 
 import { KeyInfo } from "../dockerExtension";
 
-// https://docs.docker.com/reference/builder/
+// https://docs.docker.com/engine/reference/builder/
 export const DOCKERFILE_KEY_INFO: KeyInfo = {
     'ADD': (
         "The **ADD** instruction copies new files, directories or remote file URLs from `src` and adds them " +


### PR DESCRIPTION
The TypeScript file references a non-existent link on the Docker website. I've fixed it to point at the new link to the Dockerfile reference documentation.