### PR TITLE
Adding yaml detection

### DIFF
--- a/commands/docker-compose.ts
+++ b/commands/docker-compose.ts
@@ -1,6 +1,6 @@
-import vscode = require('vscode');
-import * as path from "path";
-
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { COMPOSE_FILE_GLOB_PATTERN } from '../dockerExtension';
 
 function hasWorkspaceFolder() : boolean {
     return vscode.workspace.rootPath ? true : false;
@@ -10,7 +10,7 @@ function getDockerComposeFileUris(): Thenable<vscode.Uri[]>{
     if (!hasWorkspaceFolder()) {
         return Promise.resolve(null);
     }
-    return Promise.resolve(vscode.workspace.findFiles('{**/[dD]ocker-[cC]ompose.*.yml,**/[dD]ocker-[cC]ompose.yml}', null, 9999, null));
+    return Promise.resolve(vscode.workspace.findFiles(COMPOSE_FILE_GLOB_PATTERN, null, 9999, null));
 }
 
 interface Item extends vscode.QuickPickItem {
@@ -19,7 +19,7 @@ interface Item extends vscode.QuickPickItem {
 }
 
 function createItem(uri: vscode.Uri): Item {
-    let filePath = hasWorkspaceFolder() ? path.join(".", uri.fsPath.substr(vscode.workspace.rootPath.length)) : uri.fsPath;
+    let filePath = hasWorkspaceFolder() ? path.join('.', uri.fsPath.substr(vscode.workspace.rootPath.length)) : uri.fsPath;
 
     return <Item>{
         description: null,

--- a/commands/docker-compose.ts
+++ b/commands/docker-compose.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { COMPOSE_FILE_GLOB_PATTERN } from '../dockerExtension';
 
 function hasWorkspaceFolder() : boolean {

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -40,7 +40,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
     ctx.subscriptions.push(vscode.languages.registerHoverProvider(DOCKERFILE_MODE_ID, dockerHoverProvider));
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(DOCKERFILE_MODE_ID, new DockerfileCompletionItemProvider(), '.'));
 
-    const YAML_MODE_ID: vscode.DocumentFilter = { language: 'yaml', scheme: 'file', pattern: '**/docker-compose*.yml' };
+    const YAML_MODE_ID: vscode.DocumentFilter = { language: 'yaml', scheme: 'file', pattern: '**/docker-compose*.{yml,yaml}' };
     var yamlHoverProvider = new DockerHoverProvider(new DockerComposeParser(), composeVersionKeys.All);
     ctx.subscriptions.push(vscode.languages.registerHoverProvider(YAML_MODE_ID, yamlHoverProvider));
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(YAML_MODE_ID, new DockerComposeCompletionItemProvider(), '.'));

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -23,8 +23,10 @@ import { configure, configureLaunchJson } from './configureWorkspace/configure';
 import { scheduleValidate } from './linting/dockerLinting';
 import { systemPrune } from './commands/system-prune';
 
+export const COMPOSE_FILE_GLOB_PATTERN = '**/docker-compose*.{yaml,yml}';
 export var diagnosticCollection: vscode.DiagnosticCollection;
 
+export type KeyInfo = { [keyName: string]: string; };
 
 export interface ComposeVersionKeys {
     All: KeyInfo,
@@ -32,15 +34,13 @@ export interface ComposeVersionKeys {
     v2: KeyInfo
 };
 
-export type KeyInfo = { [keyName: string]: string; };
-
 export function activate(ctx: vscode.ExtensionContext): void {
     const DOCKERFILE_MODE_ID: vscode.DocumentFilter = { language: 'dockerfile', scheme: 'file' };
     var dockerHoverProvider = new DockerHoverProvider(new DockerfileParser(), DOCKERFILE_KEY_INFO);
     ctx.subscriptions.push(vscode.languages.registerHoverProvider(DOCKERFILE_MODE_ID, dockerHoverProvider));
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(DOCKERFILE_MODE_ID, new DockerfileCompletionItemProvider(), '.'));
 
-    const YAML_MODE_ID: vscode.DocumentFilter = { language: 'yaml', scheme: 'file', pattern: '**/docker-compose*.{yml,yaml}' };
+    const YAML_MODE_ID: vscode.DocumentFilter = { language: 'yaml', scheme: 'file', pattern: COMPOSE_FILE_GLOB_PATTERN };
     var yamlHoverProvider = new DockerHoverProvider(new DockerComposeParser(), composeVersionKeys.All);
     ctx.subscriptions.push(vscode.languages.registerHoverProvider(YAML_MODE_ID, yamlHoverProvider));
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(YAML_MODE_ID, new DockerComposeCompletionItemProvider(), '.'));
@@ -70,6 +70,4 @@ export function activate(ctx: vscode.ExtensionContext): void {
     vscode.workspace.textDocuments.forEach((doc) => scheduleValidate(doc));
     vscode.workspace.onDidOpenTextDocument((doc) => scheduleValidate(doc), ctx.subscriptions);
     vscode.workspace.onDidCloseTextDocument((doc) => diagnosticCollection.delete(doc.uri), ctx.subscriptions);
-
-
 }


### PR DESCRIPTION
This simply resolves #70 by adding support for the `.yaml` extension for `docker-compose` files, in addition to the existing `.yml` support.