### PR TITLE
Fixing hover/completion bug for image names in a multi-stage build

### DIFF
--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -24,6 +24,8 @@ import { scheduleValidate } from './linting/dockerLinting';
 import { systemPrune } from './commands/system-prune';
 import { Reporter } from './telemetry/telemetry';
 
+export const FROM_DIRECTIVE_PATTERN = /^\s*FROM\s*([\w-\/:]*)(\s*AS\s*[a-z][a-z0-9-_\\.]*)?$/i;
+
 export const COMPOSE_FILE_GLOB_PATTERN = '**/[dD]ocker-[cC]ompose*.{yaml,yml}';
 export const DOCKERFILE_GLOB_PATTERN = '**/[dD]ocker[fF]ile*';
 

--- a/dockerfile/dockerfileCompletionItemProvider.ts
+++ b/dockerfile/dockerfileCompletionItemProvider.ts
@@ -18,8 +18,8 @@ export class DockerfileCompletionItemProvider implements CompletionItemProvider 
 
         var textLine = document.lineAt(position.line);
 
-        // Matches strings like: 'FROM imagename'
-        var fromTextDocker = textLine.text.match(/^\s*FROM\s*([^"]*)$/);
+        // Matches strings like: 'FROM imagename', and strips the optional alias
+        var fromTextDocker = textLine.text.match(/^\s*FROM\s*([\w-\/:]*)(\s*AS\s*\w+)?$/i);
 
         if (fromTextDocker) {
             return dockerSuggestSupport.suggestImages(fromTextDocker[1]);

--- a/dockerfile/dockerfileCompletionItemProvider.ts
+++ b/dockerfile/dockerfileCompletionItemProvider.ts
@@ -6,6 +6,7 @@
 
 import { CompletionItemProvider, TextDocument, Position, CancellationToken, CompletionItem } from 'vscode';
 import helper = require('../helpers/suggestSupportHelper');
+import { FROM_DIRECTIVE_PATTERN } from "../dockerExtension";
 
 // IntelliSense
 export class DockerfileCompletionItemProvider implements CompletionItemProvider {
@@ -18,8 +19,7 @@ export class DockerfileCompletionItemProvider implements CompletionItemProvider 
 
         var textLine = document.lineAt(position.line);
 
-        // Matches strings like: 'FROM imagename', and strips the optional alias
-        var fromTextDocker = textLine.text.match(/^\s*FROM\s*([\w-\/:]*)(\s*AS\s*\w+)?$/i);
+        var fromTextDocker = textLine.text.match(FROM_DIRECTIVE_PATTERN);
 
         if (fromTextDocker) {
             return dockerSuggestSupport.suggestImages(fromTextDocker[1]);

--- a/helpers/suggestSupportHelper.ts
+++ b/helpers/suggestSupportHelper.ts
@@ -82,7 +82,14 @@ export class SuggestSupportHelper {
         }
         var keyName = _parser.keyNameFromKeyToken(keyToken);
         if (keyName === 'image' || keyName === 'FROM') {
-            var imageName = originalValue.replace(/^"/, '').replace(/"$/, '');
+            var imageName = originalValue.replace(/^"/, '').replace(/"$/, ''); 
+            
+            // Strip off the optional alias that may be
+            // specified when performing a multi-stage build
+            if (keyName === 'FROM') {
+                imageName = imageName.replace(/\s*AS\s*\w+$/i, '');
+            }
+
             return this.searchImageInRegistryHub(imageName).then((results) => {
                 if (results[0] && results[1]) {
                     return ['**DockerHub:**', results[0], '**DockerRuntime**', results[1]];

--- a/helpers/suggestSupportHelper.ts
+++ b/helpers/suggestSupportHelper.ts
@@ -7,6 +7,7 @@
 import vscode = require('vscode');
 import hub = require('../dockerHubApi');
 import parser = require('../parser');
+import { FROM_DIRECTIVE_PATTERN } from "../dockerExtension";
 
 export class SuggestSupportHelper {
     suggestImages(word: string): Promise<vscode.CompletionItem[]> {
@@ -82,12 +83,12 @@ export class SuggestSupportHelper {
         }
         var keyName = _parser.keyNameFromKeyToken(keyToken);
         if (keyName === 'image' || keyName === 'FROM') {
-            var imageName = originalValue.replace(/^"/, '').replace(/"$/, ''); 
-            
-            // Strip off the optional alias that may be
-            // specified when performing a multi-stage build
+            let imageName;
+
             if (keyName === 'FROM') {
-                imageName = imageName.replace(/\s*AS\s*\w+$/i, '');
+                imageName = line.match(FROM_DIRECTIVE_PATTERN)[1];
+            } else {
+                imageName = originalValue.replace(/^"/, '').replace(/"$/, '');
             }
 
             return this.searchImageInRegistryHub(imageName).then((results) => {
@@ -96,9 +97,10 @@ export class SuggestSupportHelper {
                 }
 
                 if (results[0]) {
-                    return results[0];
+                    return [results[0]];
                 }
-                return results[1];
+                
+                return [results[1]];
             });
         }
     }


### PR DESCRIPTION
This PR simply fixes a bug with the `FROM` directive's hover and auto-completion support in `Dockerfiles`, when an image alias is added (for multi-stage builds). Without this fix, when you hover over an image name (or request auto-completion) that includes an alias, the extension would attempt to search for that string on DockerHub (e.g. `foo AS bar` instead of simply `foo`), which could lead to unpredictable results.

Sometimes the search will actually return the expected result, however, sometimes it doesn't, so this fix ensures it always returns a reasonable result (e.g. hovering over `FROM nodesource/nsolid AS build` returns info for the ASP.NET Core image, hovering over `FROM mhart/alpine-node AS base` returns info for the R-Base image).
