### PR TITLE
Automatically publish exposed ports when running a container

### DIFF
--- a/commands/utils/docker-endpoint.ts
+++ b/commands/utils/docker-endpoint.ts
@@ -57,6 +57,15 @@ class DockerClient {
         return Promise.resolve(DockerEngineType.Linux);
     }
 
+    public getExposedPorts(imageId: string) : Thenable<string[]> {
+        return new Promise((resolve, reject) => {
+            this.getImage(imageId).inspect((error, { Config: { ExposedPorts = {} }}) => {
+                const ports = Object.keys(ExposedPorts).map((port) => port.split("/")[0]);
+                resolve(ports);
+            });
+        });
+    }
+
     public getImage(id:string): Docker.Image {
         return this.endPoint.getImage(id);
     }

--- a/configureWorkspace/configure.ts
+++ b/configureWorkspace/configure.ts
@@ -20,17 +20,14 @@ function genDockerFile(serviceName: string, imageName: string, platform: string,
     switch (platform.toLowerCase()) {
         case 'node.js':
 
-            return `
-FROM node:6-slim
-LABEL Name=${serviceName} Version=${version} 
-COPY package.json /tmp/package.json
-RUN cd /tmp && npm install --production
-RUN mkdir -p /usr/src/app && mv /tmp/node_modules /usr/src
-WORKDIR /usr/src/app
-COPY . /usr/src/app
-EXPOSE ${port}
-CMD ${cmd}
-`;
+            return `FROM node:6-alpine
++LABEL Name=${serviceName} Version=${version}
++WORKDIR /usr/src/app 
++COPY package.json package.json
++RUN npm install --only=prod
++COPY . .
+ EXPOSE ${port}
+-CMD ${cmd}`;
 
         case 'go':
 

--- a/configureWorkspace/configure.ts
+++ b/configureWorkspace/configure.ts
@@ -21,13 +21,13 @@ function genDockerFile(serviceName: string, imageName: string, platform: string,
         case 'node.js':
 
             return `FROM node:6-alpine
-+LABEL Name=${serviceName} Version=${version}
-+WORKDIR /usr/src/app 
-+COPY package.json package.json
-+RUN npm install --only=prod
-+COPY . .
- EXPOSE ${port}
--CMD ${cmd}`;
+LABEL Name=${serviceName} Version=${version}
+WORKDIR /usr/src/app 
+COPY package.json package.json
+RUN npm install --only=prod
+COPY . .
+EXPOSE ${port}
+CMD ${cmd}`;
 
         case 'go':
 

--- a/typings/dockerode.d.ts
+++ b/typings/dockerode.d.ts
@@ -53,6 +53,7 @@ declare module Docker {
 
 	class Image {
 		name: string;
+		inspect(cb: (err: Error, data: any) => void): void;
 		remove(options: any, cb: (err: Error, exec: Exec)=>void): void;
 		tag(options: any, cb: (err: Error, exec: Exec)=>void): void;
 	}

--- a/typings/dockerode.d.ts
+++ b/typings/dockerode.d.ts
@@ -52,8 +52,8 @@ declare module Docker {
 	}
 
 	class Image {
-		name: string;
 		inspect(cb: (err: Error, data: any) => void): void;
+		name: string;
 		remove(options: any, cb: (err: Error, exec: Exec)=>void): void;
 		tag(options: any, cb: (err: Error, exec: Exec)=>void): void;
 	}


### PR DESCRIPTION
This PR updates the `Run` commands, so that they automatically infer the ports the image is exposing, and publishes them on the host machine. This makes the basic `Run` experience simpler, and provides a little more value-add on top of the developer simply executing `docker run` from the integrated terminal.

In addition, I simplified the generated `Dockerfile` for Node.js a bit, by removing the need for the temp folder for NPM installation, and removing some superfluous whitespace. I also updated the default image to use `alpine` instead of `slim`, which is much smaller.