### PR TITLE
Run non-interactive containers in the background

### DIFF
--- a/commands/start-container.ts
+++ b/commands/start-container.ts
@@ -10,12 +10,7 @@ function doStartContainer(interactive: boolean) {
     quickPickImage(false).then(function (selectedItem: ImageItem) {
         if (selectedItem) {
             docker.getExposedPorts(selectedItem.label).then((ports: string[]) => {
-                let options = '--rm'
-                
-                if (interactive) {
-                    options += ' -it';
-                }
-
+                let options = `--rm ${interactive ? '-it' : '-d'}`;
                 if (ports.length) {
                     const portMappings = ports.map((port) => `-p ${port}:${port}`);
                     options += ` ${portMappings.join(' ')}`;


### PR DESCRIPTION
This PR simply adds the `-d` flag when running the `Docker: Run` command. This way, you can use `Docker: Run` to spin up background tasks (and use `Docker: Show Logs`, etc. at any time), and `Docker: Run Interactive` to spin up interactive tasks. Otherwise, the non-interactive command captures your terminal, which might not be the expected behavior.

// CC @chrisdias Let me know what you think of this behavior. 

