### PR TITLE
Updating Azure CLI mounts to support Kubernetes management

### DIFF
--- a/commands/start-container.ts
+++ b/commands/start-container.ts
@@ -63,7 +63,7 @@ export function startAzureCLI() {
 
             // volume map .azure folder so don't have to log in every time
             let homeDir: string = process.platform === 'win32' ? os.homedir().replace(/\\/g, '/') : os.homedir();
-            let vol: string = '-v ' + homeDir + '/.azure:/root/.azure';
+            let vol: string = `-v ${homeDir}/.azure:/root/.azure -v ${homeDir}/.ssh:/root/.ssh -v ${homeDir}/.kube:/root/.kube`;
             let cmd: string = `docker run ${option} ${vol} -it --rm azuresdk/azure-cli-python:latest`;
 
             let terminal: vscode.Terminal = vscode.window.createTerminal('Azure CLI');


### PR DESCRIPTION
This PR simply updates the list of container mounts that are defined when running the Azure CLI. Without this change, the `az acs create` or `az acs kubernetes get-credentials` command can't be run, since they need access to your SSH keys in order to configure/authenticate with the underlying VMs. Additionally, the `az acs kubernetes get-credentials` attempts to write your k8s cluster credentials to the `~/.kube` directory, and therefore, this needs to be mounted into the container as well in order to work.