### PR TITLE
Use an SPDX license ID in the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "PeterJausovec",
   "displayName": "Docker",
   "description": "Adds syntax highlighting, snippets, commands, hover tips, and linting for Dockerfile and docker-compose files.",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "icon": "images/docker_icon.png",
   "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
   "galleryBanner": {


### PR DESCRIPTION
The [npm website](https://docs.npmjs.com/files/package.json#license) suggests that an SPDX license ID be used in the `package.json` file if possible. Since the vscode-docker project is licensed under the MIT license, which does have a corresponding SPDX license ID, we should use that ID in the `package.json` file.