### PR TITLE
Adopt the dockerfile-language-server-nodejs npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,6 +219,42 @@
           "type": "number",
           "default": 1000,
           "description": "Docker explorer refresh interval (default 1000ms)"
+        },
+        "docker.languageserver.diagnostics.deprecatedMaintainer": {
+          "type": "string",
+          "default": "warning",
+          "enum": [ "ignore", "warning", "error" ],
+          "description": "Controls the diagnostic severity for the deprecated MAINTAINER instruction."
+        },
+        "docker.languageserver.diagnostics.directiveCasing": {
+          "type": "string",
+          "default": "warning",
+          "enum": [ "ignore", "warning", "error" ],
+          "description": "Controls the diagnostic severity for parser directives that are not written in lowercase."
+        },
+        "docker.languageserver.diagnostics.instructionCasing": {
+          "type": "string",
+          "default": "warning",
+          "enum": [ "ignore", "warning", "error" ],
+          "description": "Controls the diagnostic severity for instructions that are not written in uppercase."
+        },
+        "docker.languageserver.diagnostics.instructionCmdMultiple": {
+          "type": "string",
+          "default": "warning",
+          "enum": [ "ignore", "warning", "error" ],
+          "description": "Controls the diagnostic severity for flagging a Dockerfile with multiple CMD instructions."
+        },
+        "docker.languageserver.diagnostics.instructionEntrypointMultiple": {
+          "type": "string",
+          "default": "warning",
+          "enum": [ "ignore", "warning", "error" ],
+          "description": "Controls the diagnostic severity for flagging a Dockerfile with multiple ENTRYPOINT instructions."
+        },
+        "docker.languageserver.diagnostics.instructionHealthcheckMultiple": {
+          "type": "string",
+          "default": "warning",
+          "enum": [ "ignore", "warning", "error" ],
+          "description": "Controls the diagnostic severity for flagging a Dockerfile with multiple HEALTHCHECK instructions."
         }
       }
     },
@@ -362,7 +398,9 @@
   },
   "dependencies": {
     "dockerfile_lint": "^0.2.6",
+    "dockerfile-language-server-nodejs": "^0.0.6",
     "dockerode": "^2.3.2",
-    "vscode-extension-telemetry": "^0.0.6"
+    "vscode-extension-telemetry": "^0.0.6",
+    "vscode-languageclient": "^3.1.0"
   }
 }


### PR DESCRIPTION
This PR resolves issue #99 by creating the necessary changes to `package.json` and `dockerExtension.ts` to get the dockerfile-language-server-nodejs npm module integrated into the vscode-docker extension.

Here is how you can test this PR:

1. Pull this PR into your repository.
2. Invoke `npm install` to install the Dockerfile LSP server. This should be relatively quick.
3. Debug > Launch Extension
4. Cross your fingers, open a Dockerfile and see if the installation has completed successfully!

Here is a sample Dockerfile that you can use to get a sense of what is currently possible with this language server. Follow the comments and have fun! Note that you should probably turn off `docker.enableLinting` to more clearly see what the server does and does not provide in terms of validation.

```Dockerfile
#escape=a
# click in the above directive error to convert 'a' to a backslash or backtick
# use Ctrl+Shift+O 'Go to Symbol in File...' to get an overview of the document
FROM alpine AS setup
# invoke completion here to check that the
# dockerhub image suggestions are still displayed
FROM 
ENV var=value
# error here because ENV must have two arguments
ENV var2

# should get a warning about EXPOSE not being written in uppercase
# click in the warning to get a code action to convert it to uppercase
expose 8081

# invoke completion here to get possible ONBUILD trigger instructions
ONBUILD 

# hover over $var to get 'value'
# click in $var and use 'Go to Definition' to jump to the ENV statement
RUN echo $var

# click in setup and use 'Go to Definition' to jump to the FROM statement
COPY --from=setup out/ out/

# click in $var2 to get document highlighting of the references
# try renaming var2 to var3
RUN echo $var2 \
# try formatting the document or a selection here to test newline escape detection
		echo $var2 \
				echo $var2 \
echo $var2 \
				echo $var2 \
		echo $var2
```

