### PR TITLE
Update extension dependency to use version 0.0.7 of the language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -396,7 +396,7 @@
     "@types/node": "^6.0.40"
   },
   "dependencies": {
-    "dockerfile-language-server-nodejs": "^0.0.6",
+    "dockerfile-language-server-nodejs": "^0.0.7",
     "dockerode": "^2.3.2",
     "vscode-extension-telemetry": "^0.0.6",
     "vscode-languageclient": "^3.1.0"


### PR DESCRIPTION
Hi all, I published version 0.0.7 of my language server to npm yesterday.

You can get a quick overview of the changes [here](https://github.com/rcjsuen/dockerfile-language-server-nodejs/blob/8098d8231b667ac112ea300b36b029198a5428a4/CHANGELOG.md). Probably the most interesting changes are support for signature help as well as the suggestion of image tags in `FROM` instructions (requested in #26).

This is not an exhaustive list but please feel free to use the following Dockerfile for trying out the new features.
```Dockerfile
FROM alpine AS base

# diagnostic to warn that a build stage name can't start with a symbol
FROM busybox AS #invalid

# invoke code completion (Ctrl+Space) after the colon for image tags
FROM ubuntu: AS ubuntu-stage
FROM fedora: AS fedora-stage
FROM node: AS node-stage

# add a space after these instructions for signature help
ADD
ARG
CMD
FROM
RUN
SHELL
USER

# add an equals sign at the end for signature help,
# make sure you append it right after the word
ARG name
COPY --from
HEALTHCHECK --interval

# invoke code completion here (Ctrl+Space) to suggest the --from
COPY --

# invoke code completion here (Ctrl+Space) to suggest build stage names
COPY --from=
```