### PR TITLE
Fix missing explorer issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -372,8 +372,7 @@
       "explorer": [
         {
           "id": "dockerExplorer",
-          "name": "Docker",
-          "when": "config.docker.showExplorer == true"
+          "name": "Docker"
         }
       ]
     }


### PR DESCRIPTION
In 6343e3f651c443142b7b6fafb179b8227efc7a3e, the `docker.showExplorer` configuration property is removed, which breaks the docker sash. This PR fix this issue.