### PR TITLE
Fix the dependency to ms-vscode.azure-account

### DIFF
--- a/explorer/deploy/azureAccountWrapper.ts
+++ b/explorer/deploy/azureAccountWrapper.ts
@@ -18,7 +18,7 @@ export class AzureAccountWrapper {
     readonly accountApi: AzureAccount;
 
     constructor(readonly extensionConext: ExtensionContext) {
-        this.accountApi = extensions.getExtension<AzureAccount>('ms-vscode.azure-account')!.exports;
+        this.accountApi = extensions.getExtension<AzureAccount>('bradygaster.azuretoolsforvscode')!.exports;
     }
 
     getAzureSessions(): AzureSession[] {

--- a/explorer/models/azureRegistryNodes.ts
+++ b/explorer/models/azureRegistryNodes.ts
@@ -8,7 +8,7 @@ import { SubscriptionClient, ResourceManagementClient, SubscriptionModels } from
 import { AzureAccount, AzureSession } from '../../typings/azure-account.api';
 import { RegistryType } from './registryType';
 
-const azureAccount: AzureAccount = vscode.extensions.getExtension<AzureAccount>('ms-vscode.azure-account')!.exports;
+const azureAccount: AzureAccount = vscode.extensions.getExtension<AzureAccount>('bradygaster.azuretoolsforvscode')!.exports;
 
 export class AzureRegistryNode extends NodeBase {
 

--- a/explorer/models/registryRootNode.ts
+++ b/explorer/models/registryRootNode.ts
@@ -15,7 +15,7 @@ import { SubscriptionClient, ResourceManagementClient, SubscriptionModels } from
 
 const ContainerRegistryManagement = require('azure-arm-containerregistry');
 
-const azureAccount: AzureAccount = vscode.extensions.getExtension<AzureAccount>('ms-vscode.azure-account')!.exports;
+const azureAccount: AzureAccount = vscode.extensions.getExtension<AzureAccount>('bradygaster.azuretoolsforvscode')!.exports;
 
 export class RegistryRootNode extends NodeBase {
     private _keytar: typeof keytarType;

--- a/package.json
+++ b/package.json
@@ -423,7 +423,7 @@
   "extensionDependencies": [
     "vscode.docker",
     "vscode.yaml",
-    "ms-vscode.azure-account"
+    "bradygaster.azuretoolsforvscode"
   ],
   "devDependencies": {
     "vscode": "^1.0.0",


### PR DESCRIPTION
Fix #139 by changing the dependency from the unpublished `ms-vscode.azure-account` to `bradygaster.azuretoolsforvscode`.