### PR TITLE
Update to the 0.0.9 release of the language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,6 +229,16 @@
           ],
           "description": "Controls the diagnostic severity for the deprecated MAINTAINER instruction."
         },
+        "docker.languageserver.diagnostics.emptyContinuationLine": {
+          "type": "string",
+          "default": "warning",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "description": "Controls the diagnostic severity for flagging empty continuation lines found in instructions that span multiple lines."
+        },
         "docker.languageserver.diagnostics.directiveCasing": {
           "type": "string",
           "default": "warning",
@@ -432,10 +442,10 @@
     "@types/keytar": "^4.0.1"
   },
   "dependencies": {
-    "dockerfile-language-server-nodejs": "^0.0.7",
+    "dockerfile-language-server-nodejs": "^0.0.9",
     "dockerode": "^2.5.1",
     "vscode-extension-telemetry": "^0.0.6",
-    "vscode-languageclient": "^3.1.0",
+    "vscode-languageclient": "3.3.0",
     "azure-arm-containerregistry": "^1.0.0-preview",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",


### PR DESCRIPTION
Although there aren't [that many changes](https://github.com/rcjsuen/dockerfile-language-server-nodejs/blob/a7ff955d293efb6aa9f33c3e925c71a7374a2c4d/CHANGELOG.md) between versions 0.0.7 and 0.0.9, 0.0.8 and 0.0.9 includes two features that have been added to the builder in Docker CE 17.09.

0.0.8 adds support for the `--chown` flag that has been added for `ADD` and `COPY` and will fix #133 and 0.0.9 adds support for warning the user about empty continuation lines.

Please use the following Dockerfile to try out some of the new features.
```Dockerfile
FROM node
# code action to convert unknown flag x to known HEALTHCHECK flags
HEALTHCHECK --flag=5 CMD ls

RUN echo "a" && \
     
# empty line above should be flagged as a warning
echo "b"

run x

# code action to convert unknown flag x to multistage --from
COPY --flag=x . .

# ctrl+space here should prompt the new --chown flag in Docker CE 17.09,
# the item has no documentation support as the docs haven't been finalized
# yet, see https://github.com/docker/cli/pull/467
ADD --
COPY --
```