### PR TITLE
Add 'Restart' command for containers.

### DIFF
--- a/commands/restart-container.ts
+++ b/commands/restart-container.ts
@@ -1,0 +1,64 @@
+import { docker } from './utils/docker-endpoint';
+import { ContainerItem, quickPickContainer } from './utils/quick-pick-container';
+import { reporter } from '../telemetry/telemetry';
+import { ContainerNode } from '../explorer/models/containerNode';
+import { dockerExplorerProvider } from '../dockerExtension';
+
+import vscode = require('vscode');
+
+const teleCmdId: string = 'vscode-docker.container.restart';
+
+
+export async function restartContainer(context?: ContainerNode) {
+
+    let containersToRestart: Docker.ContainerDesc[];
+
+    if (context && context.containerDesc) {
+        containersToRestart = [context.containerDesc];
+    }
+    else {
+        const opts = {
+            "filters": {
+                "status": ["running", "paused", "exited"]
+            }
+        };
+        const selectedItem: ContainerItem = await quickPickContainer(true, opts);
+        if (selectedItem) {
+            if (selectedItem.label.toLocaleLowerCase().includes("all containers")) {
+                containersToRestart = await docker.getContainerDescriptors(opts);
+            }
+            else {
+                containersToRestart = [selectedItem.containerDesc];
+            }
+        }
+    }
+
+    if (containersToRestart) {
+
+        const numContainers: number = containersToRestart.length;
+        let containerCounter: number = 0;
+
+        vscode.window.setStatusBarMessage("Docker: Restarting Container(s)...", new Promise((resolve, reject) => {
+            containersToRestart.forEach((container) => {
+                docker.getContainer(container.Id).restart((err: Error, data: any) => {
+                    containerCounter++;
+                    if (err) {
+                        vscode.window.showErrorMessage(err.message);
+                        dockerExplorerProvider.refreshContainers();
+                        reject();
+                    }
+                    if (containerCounter === numContainers) {
+                        dockerExplorerProvider.refreshContainers();
+                        resolve();
+                    }
+                });
+            });
+        }));
+
+        if (reporter) {
+            reporter.sendTelemetryEvent('command', {
+                command: teleCmdId
+            });
+        }
+    }
+}

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -15,6 +15,7 @@ import { removeImage } from './commands/remove-image';
 import { pushImage } from './commands/push-image';
 import { startContainer, startContainerInteractive, startAzureCLI } from './commands/start-container';
 import { stopContainer } from './commands/stop-container';
+import { restartContainer } from './commands/restart-container';
 import { showLogsContainer } from './commands/showlogs-container';
 import { openShellContainer } from './commands/open-shell-container';
 import { tagImage } from './commands/tag-image';
@@ -91,6 +92,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.start.interactive', startContainerInteractive));
     ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.start.azurecli', startAzureCLI));
     ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.stop', stopContainer));
+    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.restart', restartContainer));    
     ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.show-logs', showLogsContainer));
     ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.open-shell', openShellContainer));
     ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.remove', removeContainer));

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "onCommand:vscode-docker.container.start.interactive",
     "onCommand:vscode-docker.container.start.azurecli",
     "onCommand:vscode-docker.container.stop",
+    "onCommand:vscode-docker.container.restart",
     "onCommand:vscode-docker.container.show-logs",
     "onCommand:vscode-docker.container.open-shell",
     "onCommand:vscode-docker.compose.up",
@@ -143,6 +144,18 @@
         },
         {
           "command": "vscode-docker.container.stop",
+          "when": "view == dockerExplorer && viewItem == containersRootNode"
+        },
+        {
+          "command": "vscode-docker.container.restart",
+          "when": "view == dockerExplorer && viewItem == runningLocalContainerNode"
+        },
+        {
+          "command": "vscode-docker.container.restart",
+          "when": "view == dockerExplorer && viewItem == stoppedLocalContainerNode"
+        },
+        {
+          "command": "vscode-docker.container.restart",
           "when": "view == dockerExplorer && viewItem == containersRootNode"
         },
         {
@@ -367,6 +380,12 @@
         "command": "vscode-docker.container.stop",
         "title": "Stop Container",
         "description": "Stop a running container",
+        "category": "Docker"
+      },
+      {
+        "command": "vscode-docker.container.restart",
+        "title": "Restart Container",
+        "description": "Restart one or more containers",
         "category": "Docker"
       },
       {


### PR DESCRIPTION
Currently user can stop container and remove stopped container from the context menu. To start existing one (stopped) they need to use console command. I propose implementation of 'Restart' command which allows to restart running containers as well as start stopped.