### PR TITLE
Support workspace folders for the language server's settings

### DIFF
--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -25,7 +25,7 @@ import { Reporter } from './telemetry/telemetry';
 import DockerInspectDocumentContentProvider, { SCHEME as DOCKER_INSPECT_SCHEME } from './documentContentProviders/dockerInspect';
 import { DockerExplorerProvider } from './explorer/dockerExplorer';
 import { removeContainer } from './commands/remove-container';
-import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, Middleware, Proposed, ProposedFeatures, DidChangeConfigurationNotification } from 'vscode-languageclient';
 import { WebAppCreator } from './explorer/deploy/webAppCreator';
 import { AzureImageNode } from './explorer/models/azureRegistryNodes';
 import { DockerHubImageNode, DockerHubRepositoryNode, DockerHubOrgNode } from './explorer/models/dockerHubNodes';
@@ -49,6 +49,8 @@ export interface ComposeVersionKeys {
     v1: KeyInfo,
     v2: KeyInfo
 };
+
+let client: LanguageClient;
 
 export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     const DOCKERFILE_MODE_ID: vscode.DocumentFilter = { language: 'dockerfile', scheme: 'file' };
@@ -122,6 +124,52 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     activateLanguageClient(ctx);
 }
 
+export function deactivate(): Thenable<void> {
+    if (!client) {
+        return undefined;
+    }
+    // perform cleanup
+    Configuration.dispose();
+    return client.stop();
+}
+
+namespace Configuration {
+
+    let configurationListener: vscode.Disposable;
+
+    export function computeConfiguration(params: Proposed.ConfigurationParams): vscode.WorkspaceConfiguration[] {
+        if (!params.items) {
+            return null;
+        }
+        let result: vscode.WorkspaceConfiguration[] = [];
+        for (let item of params.items) {
+            let config = null;
+
+            if (item.scopeUri) {
+                config = vscode.workspace.getConfiguration(item.section, client.protocol2CodeConverter.asUri(item.scopeUri));
+            } else {
+                config = vscode.workspace.getConfiguration(item.section);
+            }
+            result.push(config);
+        }
+        return result;
+    }
+
+    export function initialize() {
+        configurationListener = vscode.workspace.onDidChangeConfiguration(() => {
+            // notify the language server that settings have change
+            client.sendNotification(DidChangeConfigurationNotification.type, { settings: null });
+        });
+    }
+
+    export function dispose() {
+        if (configurationListener) {
+            // remove this listener when disposed
+            configurationListener.dispose();
+        }
+    }
+}
+
 function activateLanguageClient(ctx: vscode.ExtensionContext) {
     let serverModule = ctx.asAbsolutePath(path.join("node_modules", "dockerfile-language-server-nodejs", "lib", "server.js"));
     let debugOptions = { execArgv: ["--nolazy", "--debug=6009"] };
@@ -131,15 +179,26 @@ function activateLanguageClient(ctx: vscode.ExtensionContext) {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     }
 
+    let middleware: ProposedFeatures.ConfigurationMiddleware | Middleware = {
+        workspace: {
+            configuration: Configuration.computeConfiguration
+        }
+    };
+
     let clientOptions: LanguageClientOptions = {
         documentSelector: ['dockerfile'],
         synchronize: {
-            configurationSection: 'docker.languageserver',
-            // detect configuration changes
             fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
-        }
+        },
+        middleware: middleware as Middleware
     }
 
-    let disposable = new LanguageClient("dockerfile-langserver", "Dockerfile Language Server", serverOptions, clientOptions).start();
-    ctx.subscriptions.push(disposable);
+    client = new LanguageClient("dockerfile-langserver", "Dockerfile Language Server", serverOptions, clientOptions);
+    // enable the proposed workspace/configuration feature
+    client.registerProposedFeatures();
+    client.onReady().then(() => {
+        // attach the VS Code settings listener
+        Configuration.initialize();
+    });
+    client.start();
 }

--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
           "description": "Explorer refresh interval, default is 1000ms."
         },
         "docker.languageserver.diagnostics.deprecatedMaintainer": {
+          "scope": "resource",
           "type": "string",
           "default": "warning",
           "enum": [
@@ -253,6 +254,7 @@
           "description": "Controls the diagnostic severity for the deprecated MAINTAINER instruction."
         },
         "docker.languageserver.diagnostics.emptyContinuationLine": {
+          "scope": "resource",
           "type": "string",
           "default": "warning",
           "enum": [
@@ -263,6 +265,7 @@
           "description": "Controls the diagnostic severity for flagging empty continuation lines found in instructions that span multiple lines."
         },
         "docker.languageserver.diagnostics.directiveCasing": {
+          "scope": "resource",
           "type": "string",
           "default": "warning",
           "enum": [
@@ -273,6 +276,7 @@
           "description": "Controls the diagnostic severity for parser directives that are not written in lowercase."
         },
         "docker.languageserver.diagnostics.instructionCasing": {
+          "scope": "resource",
           "type": "string",
           "default": "warning",
           "enum": [
@@ -283,6 +287,7 @@
           "description": "Controls the diagnostic severity for instructions that are not written in uppercase."
         },
         "docker.languageserver.diagnostics.instructionCmdMultiple": {
+          "scope": "resource",
           "type": "string",
           "default": "warning",
           "enum": [
@@ -293,6 +298,7 @@
           "description": "Controls the diagnostic severity for flagging a Dockerfile with multiple CMD instructions."
         },
         "docker.languageserver.diagnostics.instructionEntrypointMultiple": {
+          "scope": "resource",
           "type": "string",
           "default": "warning",
           "enum": [
@@ -303,6 +309,7 @@
           "description": "Controls the diagnostic severity for flagging a Dockerfile with multiple ENTRYPOINT instructions."
         },
         "docker.languageserver.diagnostics.instructionHealthcheckMultiple": {
+          "scope": "resource",
           "type": "string",
           "default": "warning",
           "enum": [
@@ -469,10 +476,10 @@
     "@types/keytar": "^4.0.1"
   },
   "dependencies": {
-    "dockerfile-language-server-nodejs": "^0.0.9",
+    "dockerfile-language-server-nodejs": "^0.0.10",
     "dockerode": "^2.5.1",
     "vscode-extension-telemetry": "^0.0.6",
-    "vscode-languageclient": "3.3.0",
+    "vscode-languageclient": "^3.5.0-next.4",
     "azure-arm-containerregistry": "^1.0.0-preview",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",


### PR DESCRIPTION
VS Code's workspace feature will now allow resources to have settings that are scoped to the given resource's folder hierarchy. We need to add support to the `workspace/configuration` language server protocol request that's currently being proposed so that the extension can send changes to scoped settings to the language server.