### PR TITLE
Add a preference option to set docker build context path

### DIFF
--- a/commands/build-image.ts
+++ b/commands/build-image.ts
@@ -51,6 +51,9 @@ async function resolveImageItem(folder: vscode.WorkspaceFolder, dockerFileUri?: 
 }
 
 export async function buildImage(dockerFileUri?: vscode.Uri, ) {
+    const configOptions: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('docker');
+    const defaultContextPath = configOptions.get('imageBuildContextPath', '');
+
     let folder: vscode.WorkspaceFolder;
     if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length === 1) {
         folder = vscode.workspace.workspaceFolders[0];
@@ -68,6 +71,10 @@ export async function buildImage(dockerFileUri?: vscode.Uri, ) {
     }
 
     const uri: Item = await resolveImageItem(folder, dockerFileUri);
+    let contextPath: string = uri.path;
+    if (defaultContextPath && defaultContextPath != '') {
+        contextPath = defaultContextPath;
+    }
 
     if (!uri) return;
 
@@ -97,7 +104,7 @@ export async function buildImage(dockerFileUri?: vscode.Uri, ) {
     if (!value) return;
 
     const terminal: vscode.Terminal = vscode.window.createTerminal('Docker');
-    terminal.sendText(`docker build --rm -f ${uri.file} -t ${value} ${uri.path}`);
+    terminal.sendText(`docker build --rm -f ${uri.file} -t ${value} ${contextPath}`);
     terminal.show();
 
     if (reporter) {

--- a/package.json
+++ b/package.json
@@ -242,6 +242,11 @@
           "default": 1000,
           "description": "Explorer refresh interval, default is 1000ms."
         },
+        "docker.imageBuildContextPath": {
+          "type": "string",
+          "default": "",
+          "description": "Build context PATH to pass to Docker build command."
+        },
         "docker.languageserver.diagnostics.deprecatedMaintainer": {
           "type": "string",
           "default": "warning",


### PR DESCRIPTION
I have a multiple docker project which has common pip requirements.

Project files are:

- docker
   - local
     - app
         - Dockerfile
   - production
     - app
         - Dockerfile
- requirements
    - requirements.txt


And Dockerfile is like:
`
FROM python:3.6
COPY ./requirements /requirements/
RUN pip install -r /requirements/requirements.txt
...
`

I was trying to build image from "Build Image" context menu, 
but build was failed on COPY line with some error:

> "COPY failed: stat /var/lib/docker/tmp/docker-builder282882071/requirements: no such file or directory"

VSCode generated below command:
`
docker build local-app -f docker/local/app/Dockerfile  docker/local/app/Dockerfile
`

Since 'docker build' send files below build context path to docker-machine to build image,
 and do not see parent directories [SO link](https://stackoverflow.com/questions/27068596/how-to-include-files-outside-of-dockers-build-context) , I modified command manually :
`
docker build local-app -f docker/local/app/Dockerfile ./
`
and this time it is succeeded.

If image build context path can be  set from workspace preference, it may be useful.
So I wrote a little patch.
I confirmed this issue in Docker tool box for mac and Mac Docker.

Thank you.