### PR TITLE
Change attach command for Linux containers from "/bin/sh" to "sh"

### DIFF
--- a/commands/open-shell-container.ts
+++ b/commands/open-shell-container.ts
@@ -6,7 +6,7 @@ import { reporter } from '../telemetry/telemetry';
 const teleCmdId: string = 'vscode-docker.container.open-shell';
 
 const engineTypeShellCommands = {
-    [DockerEngineType.Linux]: "/bin/sh",
+    [DockerEngineType.Linux]: "sh",
     [DockerEngineType.Windows]: "powershell"
 }
 


### PR DESCRIPTION
This would solve this problem on windows using git-bash:

`oci runtime error: exec failed: container_linux.go:295: starting container process caused "exec: \"C:/Program Files/Git/usr/bin/sh\": stat C:/Program Files/Git/usr/bin/sh: no such file or directory"`

Which is because `git-bash` or `MinGW` is trying to "translate" the "linux path" `/bin/sh` to the "windows path" `C:/Program Files/Git/usr/bin/sh` and not understanding that this path will be used inside the linux docker container and not in your windows environment.

`//bin/sh` would also work since this disables the `MinGW` "smartness" about paths.

EDIT:
Here are the MinGW Posix path conversion rules
http://www.mingw.org/wiki/Posix_path_conversion