### PR TITLE
Make the shell attach command customizable

### DIFF
--- a/commands/open-shell-container.ts
+++ b/commands/open-shell-container.ts
@@ -5,9 +5,10 @@ import { ContainerNode } from '../explorer/models/containerNode';
 import { reporter } from '../telemetry/telemetry';
 const teleCmdId: string = 'vscode-docker.container.open-shell';
 
+const configOptions: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('docker');
 const engineTypeShellCommands = {
-    [DockerEngineType.Linux]: "/bin/sh",
-    [DockerEngineType.Windows]: "powershell"
+    [DockerEngineType.Linux]: configOptions.get('docker.attachCommand.linuxContainer', '/bin/sh'),
+    [DockerEngineType.Windows]: configOptions.get('docker.attachCommand.windowsContainer', 'powershell')
 }
 
 export async function openShellContainer(context?: ContainerNode) {

--- a/commands/open-shell-container.ts
+++ b/commands/open-shell-container.ts
@@ -7,8 +7,8 @@ const teleCmdId: string = 'vscode-docker.container.open-shell';
 
 const configOptions: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('docker');
 const engineTypeShellCommands = {
-    [DockerEngineType.Linux]: configOptions.get('docker.attachShellCommand.linuxContainer', '/bin/sh'),
-    [DockerEngineType.Windows]: configOptions.get('docker.attachShellCommand.windowsContainer', 'powershell')
+    [DockerEngineType.Linux]: configOptions.get('attachShellCommand.linuxContainer', '/bin/sh'),
+    [DockerEngineType.Windows]: configOptions.get('attachShellCommand.windowsContainer', 'powershell')
 }
 
 export async function openShellContainer(context?: ContainerNode) {

--- a/commands/open-shell-container.ts
+++ b/commands/open-shell-container.ts
@@ -7,8 +7,8 @@ const teleCmdId: string = 'vscode-docker.container.open-shell';
 
 const configOptions: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('docker');
 const engineTypeShellCommands = {
-    [DockerEngineType.Linux]: configOptions.get('docker.attachCommand.linuxContainer', '/bin/sh'),
-    [DockerEngineType.Windows]: configOptions.get('docker.attachCommand.windowsContainer', 'powershell')
+    [DockerEngineType.Linux]: configOptions.get('docker.attachShellCommand.linuxContainer', '/bin/sh'),
+    [DockerEngineType.Windows]: configOptions.get('docker.attachShellCommand.windowsContainer', 'powershell')
 }
 
 export async function openShellContainer(context?: ContainerNode) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-docker",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,6 +38,15 @@
       "integrity": "sha512-fXrYo81BZgbz6KhHU3+dNUSdca35FwbfTMQvSnIIX6qOCsymSmFAjPDSfr4Q/Pt9abjt04kBi4+7FinVPdyEpg==",
       "requires": {
         "@types/node": "8.0.34"
+      }
+    },
+    "JSONStream": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+      "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
+      "requires": {
+        "jsonparse": "0.0.5",
+        "through": "2.3.8"
       }
     },
     "adal-node": {
@@ -454,8 +463,8 @@
       "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.2.tgz",
       "integrity": "sha512-ySYw2FoAIPpNNBYLvvoiwOXHfOVGpVCmXhgSM8gU8HnkGBnperNrm+R2NDgYL6hnUkGU4bIAQzOkwWfttELGRQ==",
       "requires": {
-        "debug": "2.6.9",
         "JSONStream": "0.10.0",
+        "debug": "2.6.9",
         "readable-stream": "1.0.34",
         "split-ca": "1.0.1"
       },
@@ -1535,15 +1544,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
-      "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
-      "requires": {
-        "jsonparse": "0.0.5",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -312,12 +312,12 @@
           ],
           "description": "Controls the diagnostic severity for flagging a Dockerfile with multiple HEALTHCHECK instructions."
         },
-        "docker.attachCommand.linuxContainer": {
+        "docker.attachShellCommand.linuxContainer": {
           "type": "string",
           "default": "/bin/sh",
           "description": "Attach command to use for Linux containers"
         },
-        "docker.attachCommand.windowsContainer": {
+        "docker.attachShellCommand.windowsContainer": {
           "type": "string",
           "default": "powershell",
           "description": "Attach command to use for Windows containers"

--- a/package.json
+++ b/package.json
@@ -311,6 +311,16 @@
             "error"
           ],
           "description": "Controls the diagnostic severity for flagging a Dockerfile with multiple HEALTHCHECK instructions."
+        },
+        "docker.attachCommand.linuxContainer": {
+          "type": "string",
+          "default": "/bin/sh",
+          "description": "Attach command to use for Linux containers"
+        },
+        "docker.attachCommand.windowsContainer": {
+          "type": "string",
+          "default": "powershell",
+          "description": "Attach command to use for Windows containers"
         }
       }
     },


### PR DESCRIPTION
Allows the user to specify the shell command to be used when attaching to containers by using the settings

`docker.attachShellCommand.LinuxContainer` and `docker.attachShellCommand.windowsContainer`

Defaulting to the current commands `/bin/sh` and `powershell`


This closes, or partly closes, #60.
Depending on if you want the user to be able to specify the shell command to run in "runtime" or only using the settings as this PR provides. 
(the former makes the ease of just right clicking a container and pressing `Attach Shell` a bit worse in my opinion since you would then have to specify the attach command anyways)