### PR TITLE
rename app.js to index.js

### DIFF
--- a/configureWorkspace/configure.ts
+++ b/configureWorkspace/configure.ts
@@ -116,7 +116,7 @@ function genDockerComposeDebug(serviceName: string, platform: string, port: stri
                 cmdArray.splice(1, 0, '--inspect=0.0.0.0:9229');  
                 cmd = `command: ${cmdArray.join(' ')}`;
             } else {
-                cmd = '## set your startup file here\n    command: node --inspect app.js';
+                cmd = '## set your startup file here\n    command: node --inspect index.js';
             }
 
             return `version: '2.1'


### PR DESCRIPTION
seems more common in Node.js apps.

ideally, this would be a setting or a snippet-like placeholder

cc @chrisdias 