### PR TITLE
Update to the 0.0.11 release of the language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -529,7 +529,7 @@
     "azure-arm-containerregistry": "^1.0.0-preview",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",
-    "dockerfile-language-server-nodejs": "^0.0.10",
+    "dockerfile-language-server-nodejs": "^0.0.11",
     "dockerode": "^2.5.1",
     "opn": "^5.1.0",
     "request-promise": "^4.2.2",


### PR DESCRIPTION
While there have been no new features added to the 0.0.11 release, this new release includes fixes for both #165 and #167.

Please use the following Dockerfile to verify the two fixes.
```Dockerfile
FROM openjdk:8-jre-alpine
ENV ZOO_PORT=2181
# no suggestions should appear when inserting
# a space in the next commented line
#
EXPOSE $ZOO_PORT
```