### PR TITLE
Update to the 0.0.13 release of the language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -606,7 +606,7 @@
     "azure-arm-containerregistry": "^1.0.0-preview",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",
-    "dockerfile-language-server-nodejs": "^0.0.11",
+    "dockerfile-language-server-nodejs": "^0.0.13",
     "dockerode": "^2.5.1",
     "moment": "^2.19.3",
     "opn": "^5.1.0",


### PR DESCRIPTION
The documentation for the `--chown` flag for `ADD` and `COPY` was finally published to the Docker website so I've extracted a small blurb from the documentation and added it to the language server.

I also fixed a bug with parameter hints showing up in a comment that is embedded in a multiline instruction.

Please verify the behaviour with the following Dockerfile before and after upgrading. Thanks!

```Dockerfile
FROM scratch
# invoke Intellisense at the end,
# you should see documentation for the --chown flag
ADD --cho
COPY --cho
# you should see hover documentation over the chown flag
ADD --chown=root . .
COPY --chown=root . .
ENV a=b \
# pressing space in the next line's comment should not show parameter hints
# 
c=d
```