### PR TITLE
Add package-lock.json to Node.js Docker template

### DIFF
--- a/configureWorkspace/configure.ts
+++ b/configureWorkspace/configure.ts
@@ -11,7 +11,7 @@ function genDockerFile(serviceName: string, platform: string, port: string, { cm
             return `FROM node:8.9-alpine
 ENV NODE_ENV production
 WORKDIR /usr/src/app
-COPY ["package.json", "npm-shrinkwrap.json*", "./"]
+COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
 RUN npm install --production --silent && mv node_modules ../
 COPY . .
 EXPOSE ${port}


### PR DESCRIPTION
This will ensure that, when present, package-lock.json will be copied in the container and will be used for `npm install`.