### PR TITLE
Update the description of defaultRegistry config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
         "docker.defaultRegistry": {
           "type": "string",
           "default": "",
-          "description": "Default registry to push to, empty string will push to Dockerhub."
+          "description": "Default registry when tagging an image, empty string will target Dockerhub when pushing."
         },
         "docker.defaultRegistryPath": {
           "type": "string",


### PR DESCRIPTION
Updated the description of the defaultRegistry configuration option to
make it more obvious that it only relates to tagging.

Closes #210