### PR TITLE
Change promptOnSystemPrune default

### DIFF
--- a/package.json
+++ b/package.json
@@ -423,7 +423,7 @@
         },
         "docker.promptOnSystemPrune": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Prompt for confirmation when running System Prune command"
         },
         "docker.dockerComposeBuild": {


### PR DESCRIPTION
Relates to #183

Clicking System Prune does not produce the necessary warnings that Docker normally products when you run a system prune. The icon is also unlabelled and easy to mis-click so close the to the Refresh and resize grabber. It also insufficiently explains purpose.

This will restore the prompt that was there before as a default but allow those that are fully aware of consequences to disable the prompt, so that any new users are fully informed of consequences. Might be worth checking the messaging explains that volumes are removed too as that was a little unexpected.