### PR TITLE
Add "Dockerfile.something" as supported names for dockerfiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -291,7 +291,8 @@
         ],
         "filenamePatterns": [
           "*.dockerfile",
-          "Dockerfile"
+          "Dockerfile",
+          "Dockerfile.*"
         ]
       }
     ],


### PR DESCRIPTION
Absolutely evident change to support dockerfiles with names in the form "Dockerfile.something". This PR is a proposal to fix #192.