### PR TITLE
Fixes #217: Adopt the usage of ASAR in VSCode

### DIFF
--- a/commands/system-prune.ts
+++ b/commands/system-prune.ts
@@ -1,13 +1,14 @@
 import vscode = require('vscode');
 import { reporter } from '../telemetry/telemetry';
 import { docker } from './utils/docker-endpoint';
+import { getCoreNodeModule } from '../explorer/utils/utils';
 
 const teleCmdId: string = 'vscode-docker.system.prune';
 
 export async function systemPrune() {
     const configOptions: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('docker');
     const terminal = vscode.window.createTerminal("docker system prune");
-    const semver = require(`${vscode.env.appRoot}/node_modules/semver`);
+    const semver = getCoreNodeModule(`semver`);
 
     try {
 

--- a/explorer/models/registryRootNode.ts
+++ b/explorer/models/registryRootNode.ts
@@ -12,6 +12,7 @@ import { NodeBase } from './nodeBase';
 import { RegistryType } from './registryType';
 import { ServiceClientCredentials } from 'ms-rest';
 import { SubscriptionClient, ResourceManagementClient, SubscriptionModels } from 'azure-arm-resource';
+import { getCoreNodeModule } from '../utils/utils';
 
 const ContainerRegistryManagement = require('azure-arm-containerregistry');
 
@@ -26,11 +27,7 @@ export class RegistryRootNode extends NodeBase {
         public readonly azureAccount?: AzureAccount 
     ) {
         super(label);
-        try {
-            this._keytar = require(`${vscode.env.appRoot}/node_modules/keytar`);
-        } catch (e) {
-            // unable to find keytar
-        }
+        this._keytar = getCoreNodeModule(`keytar`);
 
         this._azureAccount = azureAccount;
 

--- a/explorer/utils/dockerHubUtils.ts
+++ b/explorer/utils/dockerHubUtils.ts
@@ -3,6 +3,7 @@ import * as keytarType from 'keytar';
 import * as opn from 'opn';
 import request = require('request-promise');
 import { DockerHubRepositoryNode, DockerHubImageNode, DockerHubOrgNode } from '../models/dockerHubNodes';
+import { getCoreNodeModule } from './utils';
 
 let _token: Token;
 
@@ -79,7 +80,7 @@ export interface Image {
 
 export function dockerHubLogout(): void {
 
-    const keytar: typeof keytarType = require(`${vscode.env.appRoot}/node_modules/keytar`);
+    const keytar: typeof keytarType = getCoreNodeModule(`keytar`);
     if (keytar) {
         keytar.deletePassword('vscode-docker', 'dockerhub.token');
         keytar.deletePassword('vscode-docker', 'dockerhub.password');

--- a/explorer/utils/utils.ts
+++ b/explorer/utils/utils.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 
 export function trimWithElipsis(str: string, max: number = 10): string {
     const elipsis: string = "...";
@@ -11,4 +12,19 @@ export function trimWithElipsis(str: string, max: number = 10): string {
     const back: string = str.substr(len - (len / 2) + (-0.5 * (max - len - 3)));
 
     return front + elipsis + back;
+}
+
+/**
+ * Returns a node module installed with VSCode, or null if it fails.
+ */
+export function getCoreNodeModule(moduleName: string) {
+    try {
+        return require(`${vscode.env.appRoot}/node_modules.asar/${moduleName}`);
+    } catch (err) { }
+
+    try {
+        return require(`${vscode.env.appRoot}/node_modules/${moduleName}`);
+    } catch (err) { }
+
+    return null;
 }


### PR DESCRIPTION
Starting with today's insiders, this extension is no longer functioning correctly!

This fixes #217 and adopts the usage of ASAR when loading node modules which are part of the VS Code installation.