### PR TITLE
Update to version 0.0.14 of the language server

### DIFF
--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -26,7 +26,7 @@ import { Reporter } from './telemetry/telemetry';
 import DockerInspectDocumentContentProvider, { SCHEME as DOCKER_INSPECT_SCHEME } from './documentContentProviders/dockerInspect';
 import { DockerExplorerProvider } from './explorer/dockerExplorer';
 import { removeContainer } from './commands/remove-container';
-import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, Middleware, Proposed, ProposedFeatures, DidChangeConfigurationNotification } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, Middleware, DidChangeConfigurationNotification, ConfigurationParams } from 'vscode-languageclient';
 import { WebAppCreator } from './explorer/deploy/webAppCreator';
 import { AzureImageNode, AzureRegistryNode, AzureRepositoryNode } from './explorer/models/azureRegistryNodes';
 import { DockerHubImageNode, DockerHubRepositoryNode, DockerHubOrgNode } from './explorer/models/dockerHubNodes';
@@ -150,7 +150,7 @@ namespace Configuration {
 
     let configurationListener: vscode.Disposable;
 
-    export function computeConfiguration(params: Proposed.ConfigurationParams): vscode.WorkspaceConfiguration[] {
+    export function computeConfiguration(params: ConfigurationParams): vscode.WorkspaceConfiguration[] {
         if (!params.items) {
             return null;
         }
@@ -192,7 +192,7 @@ function activateLanguageClient(ctx: vscode.ExtensionContext) {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     }
 
-    let middleware: ProposedFeatures.ConfigurationMiddleware | Middleware = {
+    let middleware: Middleware = {
         workspace: {
             configuration: Configuration.computeConfiguration
         }
@@ -207,8 +207,6 @@ function activateLanguageClient(ctx: vscode.ExtensionContext) {
     }
 
     client = new LanguageClient("dockerfile-langserver", "Dockerfile Language Server", serverOptions, clientOptions);
-    // enable the proposed workspace/configuration feature
-    client.registerProposedFeatures();
     client.onReady().then(() => {
         // attach the VS Code settings listener
         Configuration.initialize();

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,30 +483,82 @@
       }
     },
     "dockerfile-ast": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.1.tgz",
-      "integrity": "sha1-0b09ju5fJmiilLck/ZCm4BKs+5Y=",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.3.tgz",
+      "integrity": "sha1-RnpnKRpqLBnnMgDfR1n4xECVrl4=",
       "requires": {
-        "vscode-languageserver-types": "3.5.0"
+        "vscode-languageserver-types": "3.6.0"
       }
     },
     "dockerfile-language-server-nodejs": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.13.tgz",
-      "integrity": "sha1-5zJv/cyVIjEZYf/oUr9jmDaRpLA=",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.14.tgz",
+      "integrity": "sha512-7YOtBsGGhHTDxUNSyiNs8vmsBayqO1tOvXOxuMOrNdg9kiU485MrdVPSTHhxLP47vXa80hoUxIaefBlQdEJCaQ==",
       "requires": {
-        "dockerfile-ast": "0.0.1",
-        "dockerfile-utils": "0.0.5",
-        "vscode-languageserver": "3.5.0"
+        "dockerfile-ast": "0.0.3",
+        "dockerfile-language-service": "0.0.2",
+        "dockerfile-utils": "0.0.6",
+        "vscode-languageserver": "4.0.0"
+      }
+    },
+    "dockerfile-language-service": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.2.tgz",
+      "integrity": "sha512-G5Cl+0JUxBzldLugRagTcEFUfFTvNqA0D8nGUmmHyvJbK/CeNMSCTiKnXsRs96/vMWuDBgN367LrBICxc1vGmA==",
+      "requires": {
+        "dockerfile-ast": "0.0.3",
+        "dockerfile-utils": "0.0.7",
+        "vscode-languageserver-types": "3.6.0"
+      },
+      "dependencies": {
+        "dockerfile-utils": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.7.tgz",
+          "integrity": "sha1-37dpwRfo+moNtQhQKW9MkYH9mIk=",
+          "requires": {
+            "dockerfile-ast": "0.0.2",
+            "vscode-languageserver-types": "3.5.0"
+          },
+          "dependencies": {
+            "dockerfile-ast": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.2.tgz",
+              "integrity": "sha1-g0U5EiTvCN8eexWRbjRqygVLTKg=",
+              "requires": {
+                "vscode-languageserver-types": "3.5.0"
+              }
+            },
+            "vscode-languageserver-types": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
+              "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+            }
+          }
+        }
       }
     },
     "dockerfile-utils": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.5.tgz",
-      "integrity": "sha1-cSl6hRXJ2/1WKI9NJ6otO8Hc8tw=",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.6.tgz",
+      "integrity": "sha1-L/+YZaGvhqU6yAVSZrkXriClvLY=",
       "requires": {
-        "dockerfile-ast": "0.0.1",
+        "dockerfile-ast": "0.0.2",
         "vscode-languageserver-types": "3.5.0"
+      },
+      "dependencies": {
+        "dockerfile-ast": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.2.tgz",
+          "integrity": "sha1-g0U5EiTvCN8eexWRbjRqygVLTKg=",
+          "requires": {
+            "vscode-languageserver-types": "3.5.0"
+          }
+        },
+        "vscode-languageserver-types": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
+          "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+        }
       }
     },
     "dockerode": {
@@ -2819,45 +2871,45 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-      "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.0.tgz",
+      "integrity": "sha512-PqHHjuTlz3ks0vyZv3IkdduJReA/lqe6OP5zRl5nXn2ptMLW++fBotNyayyZEQLIF6nNrx/Rn6WhMSHElf02Yw=="
     },
     "vscode-languageclient": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-3.5.0.tgz",
-      "integrity": "sha1-NtAswYaoNlpEZ3GaKQ+yAKmuSQo=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.0.0.tgz",
+      "integrity": "sha512-wW0QguaZ11bZUclacOkCA9QjF4wzsu2hKUP62kuO1j0a1+jXcwKDtdxjyYNVki4ry8aybHPuoYpQ0eq7QVm7jQ==",
       "requires": {
-        "vscode-languageserver-protocol": "3.5.0"
+        "vscode-languageserver-protocol": "3.6.0"
       }
     },
     "vscode-languageserver": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz",
-      "integrity": "sha1-0oCZvG3dqMHdFrcH5FThsd2uDbo=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.0.0.tgz",
+      "integrity": "sha512-bxj9nRadNkXYfVG/fjA5a+KA5WaJCeP1F2Tnj3rYFS0pKALZQCPNqk3KO/LdiGFidjyICMG7xoHvYO9J9xosXg==",
       "requires": {
-        "vscode-languageserver-protocol": "3.5.0",
-        "vscode-uri": "1.0.1"
+        "vscode-languageserver-protocol": "3.6.0",
+        "vscode-uri": "1.0.3"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz",
-      "integrity": "sha1-Bnxcvidwl5U5jRGWksl+u6FFIgk=",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.6.0.tgz",
+      "integrity": "sha512-PN5hVQQQxrtHSZR8UCstqaoI9f2H9JctFTtdIpONWjzQNurWrc48qSXXU/vTfnbSrNou8qrJgkZ4QEZsyozOMA==",
       "requires": {
-        "vscode-jsonrpc": "3.5.0",
-        "vscode-languageserver-types": "3.5.0"
+        "vscode-jsonrpc": "3.6.0",
+        "vscode-languageserver-types": "3.6.0"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-      "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.0.tgz",
+      "integrity": "sha512-GSgQtGmtza4PoNH0+iHWylWg/1sw2DODezqYWRxbN910dPchI3CQaSJN76csKcQGv55wsWgX82T6n74q8mFSpw=="
     },
     "vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI="
     },
     "winreg": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -606,12 +606,12 @@
     "azure-arm-containerregistry": "^1.0.0-preview",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",
-    "dockerfile-language-server-nodejs": "^0.0.13",
+    "dockerfile-language-server-nodejs": "^0.0.14",
     "dockerode": "^2.5.1",
     "moment": "^2.19.3",
     "opn": "^5.1.0",
     "request-promise": "^4.2.2",
     "vscode-extension-telemetry": "^0.0.6",
-    "vscode-languageclient": "^3.5.0-next.4"
+    "vscode-languageclient": "^4.0.0"
   }
 }


### PR DESCRIPTION
It's been two months since version 0.0.13! There are of course both bug fixes and features but the biggest change is probably the internal refactoring that happened inside the npm module. Assuming everything went fine, you shouldn't be able to notice the difference. :) This release includes the fix for #218.

As always, please use the following Dockerfile to test out the latest changes!
```Dockerfile
#escape=`
# it should be possible to Ctrl+Click node and jump to its site on Docker Hub
FROM node
# it should be possible to Ctrl+Click microsoft/dotnet and jump to its site on Docker Hub
FROM microsoft/dotnet
# hover over ARG, it should state that it was added in Docker 1.9
ARG x=y
RUN `
# there should be code actions to remove these empty lines
            
            
            `
            
       ls

# 5s-10ms is an invalid duration, it should be flagged as an error
HEALTHCHECK --interval=5s-10ms CMD ls
# 5s.1ms is a valid duration, it should not be flagged as an error
HEALTHCHECK --timeout=5s.1ms CMD ls

# the last argument of a multiargument ADD/COPY must be a directory, z/ or z\
ADD x y z
COPY x y z
# ok
ADD x y z/
COPY x y z/
# ok
ADD x y z\
COPY x y z\

# these digests and tags are all invalid, should be flagged as errors
FROM alpine@
FROM alpine@sha25:x
FROM alpine:
FROM alpine:^
FROM alpine:a66^

# hover over STOPSIGNAL, it says it was added in 1.12 when it should be 1.9
STOPSIGNAL 9
ARG FTP_PROXY
# invoke Intellisense here
# you shouldn't get two capitalized $FTP_PROXY entries
RUN $FTP

FROM scratch
ENV xyz=y
FROM alpine
# invoke Intellisense here, $xyz should not be suggested as
# it's a variable from another build stage
RUN echo $x

# $ is an invalid kill code and should be an error
STOPSIGNAL $

# all these instructions are in a different build stage and
# should not be flagged as duplicates as errors
# this fixes issue 218
# https://github.com/Microsoft/vscode-docker/issues/218
FROM alpine
HEALTHCHECK CMD ls
ENTRYPOINT ls
CMD ls
FROM alpine
ENTRYPOINT pwd
CMD pwd
HEALTHCHECK CMD pwd

# trigger parameter hints with Ctrl+Shift+Space after the S in AS
# hit the down key to look at the 2/3 and 3/3 suggestions
# and you will see that the underlined parameter
# is not the AS and is incorrect
FROM node AS
```