### PR TITLE
Restrict LSP client to files

### DIFF
--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -56,8 +56,9 @@ export interface ComposeVersionKeys {
 
 let client: LanguageClient;
 
+const DOCKERFILE_MODE_ID: vscode.DocumentFilter = { language: 'dockerfile', scheme: 'file' };
+
 export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
-    const DOCKERFILE_MODE_ID: vscode.DocumentFilter = { language: 'dockerfile', scheme: 'file' };
     const installedExtensions: any[] = vscode.extensions.all;
     const outputChannel = util.getOutputChannel();
     let azureAccount: AzureAccount;
@@ -199,7 +200,7 @@ function activateLanguageClient(ctx: vscode.ExtensionContext) {
     };
 
     let clientOptions: LanguageClientOptions = {
-        documentSelector: ['dockerfile'],
+        documentSelector: [DOCKERFILE_MODE_ID],
         synchronize: {
             fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
         },


### PR DESCRIPTION
This PR simply updates the LSP client to use the same file-scheme-based document filter that the `Dockerfile` and YAML completion providers already use. Aside from consistency, this also prepares this extension for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Dockerfiles. This way, when someone has the Docker extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience.