### PR TITLE
Add Support for Dockerfile.<some-env>

### DIFF
--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -41,7 +41,7 @@ import { browseAzurePortal } from './explorer/utils/azureUtils';
 
 export const FROM_DIRECTIVE_PATTERN = /^\s*FROM\s*([\w-\/:]*)(\s*AS\s*[a-z][a-z0-9-_\\.]*)?$/i;
 export const COMPOSE_FILE_GLOB_PATTERN = '**/[dD]ocker-[cC]ompose*.{yaml,yml}';
-export const DOCKERFILE_GLOB_PATTERN = '**/{*.dockerfile,[dD]ocker[fF]ile}';
+export const DOCKERFILE_GLOB_PATTERN = '**/{*.dockerfile,[dD]ocker[fF]ile,[Dd]ockerfile*}';
 
 export var diagnosticCollection: vscode.DiagnosticCollection;
 export var dockerExplorerProvider: DockerExplorerProvider;


### PR DESCRIPTION
I _think_ this closes #102 and #192 

It should add icon and syntax support for `Dockerfile.<some-env>`

Before:
![screen shot 2018-04-10 at 3 53 21 pm](https://user-images.githubusercontent.com/4664374/38580277-89c0e270-3cd7-11e8-9f46-0556c262cf79.png)

After:
![screen shot 2018-04-10 at 3 53 05 pm](https://user-images.githubusercontent.com/4664374/38580262-7cc03f4e-3cd7-11e8-9077-87491608c6cf.png)
