### PR TITLE
Adopt version 0.0.17 of the language server

### DIFF
--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -26,7 +26,7 @@ import { Reporter } from './telemetry/telemetry';
 import DockerInspectDocumentContentProvider, { SCHEME as DOCKER_INSPECT_SCHEME } from './documentContentProviders/dockerInspect';
 import { DockerExplorerProvider } from './explorer/dockerExplorer';
 import { removeContainer } from './commands/remove-container';
-import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, Middleware, Proposed, ProposedFeatures, DidChangeConfigurationNotification } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, Middleware, ConfigurationParams, DidChangeConfigurationNotification } from 'vscode-languageclient';
 import { WebAppCreator } from './explorer/deploy/webAppCreator';
 import { AzureImageNode, AzureRegistryNode, AzureRepositoryNode } from './explorer/models/azureRegistryNodes';
 import { DockerHubImageNode, DockerHubRepositoryNode, DockerHubOrgNode } from './explorer/models/dockerHubNodes';
@@ -150,7 +150,7 @@ namespace Configuration {
 
     let configurationListener: vscode.Disposable;
 
-    export function computeConfiguration(params: Proposed.ConfigurationParams): vscode.WorkspaceConfiguration[] {
+    export function computeConfiguration(params: ConfigurationParams): vscode.WorkspaceConfiguration[] {
         if (!params.items) {
             return null;
         }
@@ -192,7 +192,7 @@ function activateLanguageClient(ctx: vscode.ExtensionContext) {
         debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
     }
 
-    let middleware: ProposedFeatures.ConfigurationMiddleware | Middleware = {
+    let middleware: Middleware = {
         workspace: {
             configuration: Configuration.computeConfiguration
         }
@@ -207,8 +207,6 @@ function activateLanguageClient(ctx: vscode.ExtensionContext) {
     }
 
     client = new LanguageClient("dockerfile-langserver", "Dockerfile Language Server", serverOptions, clientOptions);
-    // enable the proposed workspace/configuration feature
-    client.registerProposedFeatures();
     client.onReady().then(() => {
         // attach the VS Code settings listener
         Configuration.initialize();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-docker",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -629,30 +629,82 @@
       }
     },
     "dockerfile-ast": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.1.tgz",
-      "integrity": "sha1-0b09ju5fJmiilLck/ZCm4BKs+5Y=",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.3.tgz",
+      "integrity": "sha1-RnpnKRpqLBnnMgDfR1n4xECVrl4=",
       "requires": {
-        "vscode-languageserver-types": "3.5.0"
+        "vscode-languageserver-types": "3.7.1"
       }
     },
     "dockerfile-language-server-nodejs": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.13.tgz",
-      "integrity": "sha1-5zJv/cyVIjEZYf/oUr9jmDaRpLA=",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.17.tgz",
+      "integrity": "sha512-4hFsCKgLdqHAMAzt2hodoBNjlDuPLOrdWhX52zSG8CWff2CqFlGFozkvD/lQDEeZn6piBWrQmh+wL+UALqdahw==",
       "requires": {
-        "dockerfile-ast": "0.0.1",
-        "dockerfile-utils": "0.0.5",
-        "vscode-languageserver": "3.5.0"
+        "dockerfile-ast": "0.0.3",
+        "dockerfile-language-service": "0.0.4",
+        "dockerfile-utils": "0.0.8",
+        "vscode-languageserver": "4.1.2"
+      }
+    },
+    "dockerfile-language-service": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.4.tgz",
+      "integrity": "sha512-5f8CyQMIUtuNSdO6nGU58sbAnI9EEycV/n9dozYryasf83l/3kwR+NyTaN8S6ZktIMQMdPlAuJHm0r4QtR9pFg==",
+      "requires": {
+        "dockerfile-ast": "0.0.3",
+        "dockerfile-utils": "0.0.9",
+        "vscode-languageserver-types": "3.7.1"
+      },
+      "dependencies": {
+        "dockerfile-utils": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.9.tgz",
+          "integrity": "sha512-yNsWQn6Umv7Wp94hxpwQMcKV3u0ig52dTP0duSe4eJUVieNLFc+UQ2OCpBNTiygfC4gvTB0ymldaPMj5LuSc3Q==",
+          "requires": {
+            "dockerfile-ast": "0.0.4",
+            "vscode-languageserver-types": "3.5.0"
+          },
+          "dependencies": {
+            "dockerfile-ast": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.4.tgz",
+              "integrity": "sha512-eOmS/ygp2tGOiUrBW7XcHqYeUhHePjxCTpboS6tbXA3nE5be78QxdhzM9fSR7paKAIq2xaV5eSVsEixUNVk9bQ==",
+              "requires": {
+                "vscode-languageserver-types": "3.5.0"
+              }
+            },
+            "vscode-languageserver-types": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
+              "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+            }
+          }
+        }
       }
     },
     "dockerfile-utils": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.5.tgz",
-      "integrity": "sha1-cSl6hRXJ2/1WKI9NJ6otO8Hc8tw=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.8.tgz",
+      "integrity": "sha512-EPKPIbMK638M6O3Gw9H+QOWiRBNC3apnyL7FsgJsHV1YpJXRFQz2TDW424S8gsqhvDwbtHdLURiH2mvymNAziQ==",
       "requires": {
-        "dockerfile-ast": "0.0.1",
+        "dockerfile-ast": "0.0.4",
         "vscode-languageserver-types": "3.5.0"
+      },
+      "dependencies": {
+        "dockerfile-ast": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.4.tgz",
+          "integrity": "sha512-eOmS/ygp2tGOiUrBW7XcHqYeUhHePjxCTpboS6tbXA3nE5be78QxdhzM9fSR7paKAIq2xaV5eSVsEixUNVk9bQ==",
+          "requires": {
+            "vscode-languageserver-types": "3.5.0"
+          }
+        },
+        "vscode-languageserver-types": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
+          "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+        }
       }
     },
     "dockerode": {
@@ -3027,45 +3079,52 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-      "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.1.tgz",
+      "integrity": "sha512-+Eb+Dxf2kC2h079msx61hkblxAKE0S2j78+8QpnigLAO2aIIjkCwTIH34etBrU8E8VItRinec7YEwULx9at5bQ=="
     },
     "vscode-languageclient": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-3.5.0.tgz",
-      "integrity": "sha1-NtAswYaoNlpEZ3GaKQ+yAKmuSQo=",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.1.3.tgz",
+      "integrity": "sha512-3tu79B56apocobPGkHm7YWobjhNKCU7H4cUk+rkVFCNoOSAm2wZlN2J6HdC15/ONALY4ai25BeyQ+aQaFmM1Jg==",
       "requires": {
-        "vscode-languageserver-protocol": "3.5.0"
+        "vscode-languageserver-protocol": "3.7.1"
       }
     },
     "vscode-languageserver": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz",
-      "integrity": "sha1-0oCZvG3dqMHdFrcH5FThsd2uDbo=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.1.2.tgz",
+      "integrity": "sha512-3iej2tuMaI9yirPXF7/fVyIvBhSzbwZ3EWFRb8bP6lc3tGv9SJHDaJLNyQMgo9J8CNpXil6dWarpJvGSA60v/w==",
       "requires": {
-        "vscode-languageserver-protocol": "3.5.0",
-        "vscode-uri": "1.0.1"
+        "vscode-languageserver-protocol": "3.7.1",
+        "vscode-uri": "1.0.3"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz",
-      "integrity": "sha1-Bnxcvidwl5U5jRGWksl+u6FFIgk=",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.7.1.tgz",
+      "integrity": "sha512-AKX9XQ49m/lpiDLZJBypFNc5eAXNlSecunYU5m4o5WIwGgW86TWnXVdziuFm47W2SdigDa/jVbxLPSNUeut9fQ==",
       "requires": {
-        "vscode-jsonrpc": "3.5.0",
-        "vscode-languageserver-types": "3.5.0"
+        "vscode-jsonrpc": "3.6.1",
+        "vscode-languageserver-types": "3.7.1"
+      },
+      "dependencies": {
+        "vscode-languageserver-types": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.7.1.tgz",
+          "integrity": "sha512-ftGfU79AnnI3OHCG7kzCCN47jNI7BjECPAH2yhddtYTiQk0bnFbuFeQKvpXQcyNI3GsKEx5b6kSiBYshTiep6w=="
+        }
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-      "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.7.1.tgz",
+      "integrity": "sha512-ftGfU79AnnI3OHCG7kzCCN47jNI7BjECPAH2yhddtYTiQk0bnFbuFeQKvpXQcyNI3GsKEx5b6kSiBYshTiep6w=="
     },
     "vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI="
     },
     "winreg": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -411,6 +411,17 @@
           ],
           "description": "Controls the diagnostic severity for flagging a Dockerfile with multiple HEALTHCHECK instructions."
         },
+        "docker.languageserver.diagnostics.instructionJSONInSingleQuotes": {
+          "scope": "resource",
+          "type": "string",
+          "default": "warning",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "description": "Controls the diagnostic severity for JSON instructions that are written incorrectly with single quotes."
+        },
         "docker.attachShellCommand.linuxContainer": {
           "type": "string",
           "default": "/bin/sh",
@@ -606,7 +617,7 @@
     "azure-arm-containerregistry": "^1.0.0-preview",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",
-    "dockerfile-language-server-nodejs": "^0.0.13",
+    "dockerfile-language-server-nodejs": "^0.0.17",
     "dockerode": "^2.5.1",
     "gradle-to-js": "^1.0.1",
     "moment": "^2.19.3",
@@ -614,6 +625,6 @@
     "pom-parser": "^1.1.1",
     "request-promise": "^4.2.2",
     "vscode-extension-telemetry": "^0.0.6",
-    "vscode-languageclient": "^3.5.0-next.4"
+    "vscode-languageclient": "^4.0.0"
   }
 }


### PR DESCRIPTION
Previously, version 0.0.14 was adopted in #233 but two bugs were discovered that caused the change to be reverted. These two issues have now been fixed in 0.0.17.

- rcjsuen/dockerfile-language-server-nodejs#216
- rcjsuen/dockerfile-language-server-nodejs#217

Two other issues (#237 and #238) unrelated to the 0.0.14 upgrade were reported and they have also been implemented and fixed. And of course, #218 that was fixed in 0.0.14 has not regressed and is fixed in 0.0.17.

Please use the following Dockerfile to test the update to 0.0.17 from 0.0.13. Thank you!

```Dockerfile
#escape=`
###################################################
### changes from version 0.0.14
###################################################
# it should be possible to Ctrl+Click node and jump to its site on Docker Hub
FROM node
# it should be possible to Ctrl+Click microsoft/dotnet and jump to its site on Docker Hub
FROM microsoft/dotnet
# hover over ARG, it should state that it was added in Docker 1.9
ARG x=y
RUN `
# there should be code actions to remove these empty lines
            
            
            `
            
       ls

# 5s-10ms is an invalid duration, it should be flagged as an error
HEALTHCHECK --interval=5s-10ms CMD ls
# 5s.1ms is a valid duration, it should NOT be flagged as an error
HEALTHCHECK --timeout=5s.1ms CMD ls

# the last argument of a multiargument ADD/COPY must be a directory, z/ or z\
ADD x y z
COPY x y z
# ok
ADD x y z/
COPY x y z/
# ok
ADD x y z\
COPY x y z\

# these digests and tags are all invalid, should be flagged as errors
FROM alpine@
FROM alpine@sha25:x
FROM alpine:
FROM alpine:^
FROM alpine:a66^

# hover over STOPSIGNAL, it says it was added in 1.12 when it should be 1.9
STOPSIGNAL 9
ARG FTP_PROXY
# invoke Intellisense here
# you shouldn't get two capitalized $FTP_PROXY entries
RUN $FTP

FROM scratch
ENV FTP_ABC=y
FROM alpine
# invoke Intellisense here, $FTP_ABC should not be suggested as
# it's a variable from another build stage
RUN echo $F

# $ is an invalid kill code and should be an error
STOPSIGNAL $

# all these instructions are in a different build stage and
# should not be flagged as duplicates as errors
# this fixes issue 218
# https://github.com/Microsoft/vscode-docker/issues/218
FROM alpine
HEALTHCHECK CMD ls
ENTRYPOINT ls
CMD ls
FROM alpine
ENTRYPOINT pwd
CMD pwd
HEALTHCHECK CMD pwd

# trigger parameter hints with Ctrl+Shift+Space after the S in AS
# hit the down key to look at the 2/3 and 3/3 suggestions
# and you will see that the underlined parameter
# is not the AS and is incorrect
FROM node AS

###################################################
### changes from version 0.0.15, 0.0.16, and 0.0.17
###################################################

# JSON cannot be in single quotes, reported by #238
# https://github.com/Microsoft/vscode-docker/issues/238
# default severity as warning, can be toggled
# "docker.languageserver.diagnostics.instructionJSONInSingleQuotes": "warning",
# "docker.languageserver.diagnostics.instructionJSONInSingleQuotes": "error",
# "docker.languageserver.diagnostics.instructionJSONInSingleQuotes": "ignore",
ADD ['x', 'y']
CMD ['x', 'y']
COPY ['x', 'y']
ENTRYPOINT ['x', 'y']
RUN ['x', 'y']
VOLUME ['x', 'y']

# invalid time units
FROM alpine
HEALTHCHECK --interval=5-5s CMD ls
FROM alpine
HEALTHCHECK --timeout=5..5s CMD ls
FROM alpine
HEALTHCHECK --timeout=--5s CMD ls

# validation should parse JSON properly and consider the last JSON string
COPY [ "t1.txt", "t2.txt", "./" ]
ADD [ "t1.txt", "t2.txt", "./" ]

# Docker engine will ignore stuff after the JSON, Docker will build this
# even though it looks wrong so the validator will ignore it too to match
# the behaviour
SHELL [ "bin/sh" ] ]

# validation should parse JSON properly and consider this JSON string
# as multiple arguments even though it's "one" argument word-wise
ADD ["t1.txt","t2.txt"]
COPY ["t1.txt","t2.txt"]

# sample file given in https://github.com/rcjsuen/dockerfile-language-server-nodejs/issues/216
# delete /tmp with the backspace character, and then Ctrl+Z
# no parsing errors should appear
FROM openjdk:8-jdk-alpine
VOLUME /tmp
ARG JAVA_OPTS
ENV JAVA_OPTS=$JAVA_OPTS
ADD stickerapp.jar stickerapp.jar
EXPOSE 3000
ENTRYPOINT exec java $JAVA_OPTS -jar stickerapp.jar
# For Spring-Boot project, use the entrypoint below to reduce Tomcat startup time.
#ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar stickerapp.jar
```