### PR TITLE
Make python dockerfile a bit more resilient

### DIFF
--- a/configureWorkspace/configure.ts
+++ b/configureWorkspace/configure.ts
@@ -153,7 +153,7 @@ LABEL Name=${serviceName} Version=${version}
 EXPOSE ${port}
 
 WORKDIR /app
-ADD . /app
+COPY . .
 
 # Using pip:
 RUN python3 -m pip install -r requirements.txt

--- a/configureWorkspace/configure.ts
+++ b/configureWorkspace/configure.ts
@@ -155,13 +155,15 @@ EXPOSE ${port}
 WORKDIR /app
 COPY . .
 
+# install dependencies if dependencies file is present
+RUN python3 -m pip install -r requirements.txt || echo ‘No requirements.txt - skipping pip install’
+
 # Using pip:
-RUN python3 -m pip install -r requirements.txt
 CMD ["python3", "-m", "${serviceName}"]
 
 # Using pipenv:
-#RUN python3 -m pip install pipenv
-#RUN pipenv install --ignore-pipfile
+#RUN python3 -m pip install pipenv  || echo ‘No requirements.txt - skipping pip install’
+#RUN pipenv install --ignore-pipfile  || echo ‘No requirements.txt - skipping pip install’
 #CMD ["pipenv", "run", "python3", "-m", "${serviceName}"]
 
 # Using miniconda (make sure to replace 'myenv' w/ your environment name):


### PR DESCRIPTION
The [recommended approach](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) when adding to a dockerfile is to use `COPY` and not `ADD`, since `ADD` will extract `gz` files etc. 

I've also made the `pip install -r requirements.txt` step not fail when the file does not exist.