### PR TITLE
Adopt version 0.0.18 of the language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -639,7 +639,7 @@
     "azure-arm-containerregistry": "^1.0.0-preview",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",
-    "dockerfile-language-server-nodejs": "^0.0.17",
+    "dockerfile-language-server-nodejs": "^0.0.18",
     "dockerode": "^2.5.1",
     "gradle-to-js": "^1.0.1",
     "moment": "^2.19.3",
@@ -647,7 +647,7 @@
     "pom-parser": "^1.1.1",
     "request-promise": "^4.2.2",
     "vscode-extension-telemetry": "^0.0.6",
-    "vscode-languageclient": "^4.0.0",
+    "vscode-languageclient": "^4.2.1",
     "glob": "7.1.2"
   }
 }


### PR DESCRIPTION
I released a new release of my Dockerfile language server on Saturday. This release includes long-awaited fixes for the code completion error in #271 and the linting error related to private registries in #269, #280, and #288. As always, thank you to the vscode-docker community for your bug reports!

To test the new bug fixes and features of this release, please use the following four Dockerfiles to compare the behaviour of 0.0.17 and 0.0.18!

```Dockerfile
# see #271
# use ctrl+space at the end of this instruction and
# select one of the option, the code completion
# should insert the tag correctly
FROM microsoft/dotnet:2.1-

# these instructions that reference a private registry
# should have no linting errors
# see #269, #280, and #288
FROM example.registry.com:12345/base/image:1.0.0
FROM repository.mycompany:5000/tomcat:8.0
FROM my.private.repo.com:5000/some-image:latest
FROM host:5000/abc:9.0.0

# this is not a valid variable reference because
# ${bbb:x} does not have a valid modifier set
# for its variable substitution text
ARG bbb=value
ARG aaa=${bbb:x}

# this ARG has no name, it should be an error
ARG =value

# the parser should handle quotes in variable substitutions
ARG BUNDLE_WITHOUT
ENV BUNDLE_WITHOUT=${bundle_without:-'development test'}


# these two errors variables should cause errors
# due to quote parsing
ENV "a.b.c=xyz"
ENV "a.b.c=xyz
```
```Dockerfile
ARG image=scratch
# variables should be usable in FROMs and not
# cause any errors
FROM ${image:-alpine}
```
```Dockerfile
ARG ver=latest
FROM busybox:$ver
ARG ver
# hovering over $ver should show >> latest
RUN echo $ver
```
```Dockerfile
# this file should not have any errors
FROM scratch
ARG var=value \
# var2=value2
```