### PR TITLE
Improve docker-machine documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ By default, Docker runs as the root user, requiring other users to access it wit
 
 The default connection of the extension is to connect to the local docker daemon. You can connect to a docker-machine instance if you launch Visual Studio Code and have the DOCKER_HOST environment variable set to a valid host or if you set the `docker.host` configuration setting.
 
+If the docker daemon is using TLS, the DOCKER_CERT_PATH environment variable must also be set (e.g. `$HOME\.docker\machine\machines\default`).
+
 ## Contributing
 
 There are a couple of ways you can contribute to this repository:


### PR DESCRIPTION
Note the need for a DOCKER_CERT_PATH environment variable when using TLS.

The `docker-machine` section of the README calls out the need for a DOCKER_HOST environment variable, but does not mention the DOCKER_CERT_PATH environment variable.

Failure to have DOCKER_CERT_PATH set when using TLS causes strange looking TLS errors, which are only reported to the user as "Could not connect to docker daemon".  

This seems to cause a fair amount of confusion; see [here](https://github.com/Microsoft/vscode-docker/issues/146), [here](https://github.com/Microsoft/vscode-docker/issues/229), and [here](https://stackoverflow.com/questions/51402080/vscode-docker-extension-cannot-connect-to-docker-machine).