### PR TITLE
Fixed Dockerfile for Go

### DIFF
--- a/configureWorkspace/configure.ts
+++ b/configureWorkspace/configure.ts
@@ -38,7 +38,7 @@ RUN go-wrapper install    # "go install -v ./..."
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/bin/app /app
-ENTRYPOINT /app
+ENTRYPOINT ["/app"]
 LABEL Name=${serviceName} Version=${version}
 EXPOSE ${port}
 `;

--- a/configureWorkspace/configure.ts
+++ b/configureWorkspace/configure.ts
@@ -38,7 +38,7 @@ RUN go-wrapper install    # "go install -v ./..."
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/bin/app /app
-ENTRYPOINT ./app
+ENTRYPOINT /app
 LABEL Name=${serviceName} Version=${version}
 EXPOSE ${port}
 `;


### PR DESCRIPTION
Fixed the entrypoint in the Dockerfile for Go. Before, it was giving an error saying the command was not found.