### PR TITLE
Switch to shared telemetry

### DIFF
--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -67,14 +67,15 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     let azureAccount: AzureAccount;
 
     // Set up extension variables
-    ctx.subscriptions.push(new Reporter(ctx));
     if (!ext.ui) {
         // This allows for standard interactions with the end user (as opposed to test input)
         ext.ui = new AzureUserInput(ctx.globalState);
     }
     ext.context = ctx;
-    ext.reporter = reporter;
     registerUIExtensionVariables(ext);
+
+    initializeTelemetryReporter(createTelemetryReporter(ctx));
+    ext.reporter = reporter;
 
     // tslint:disable-next-line:prefer-for-of // Grandfathered in
     for (let i = 0; i < installedExtensions.length; i++) {
@@ -88,10 +89,6 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
             break;
         }
     }
-
-    registerUIExtensionVariables(ext);
-    initializeTelemetryReporter(createTelemetryReporter(ctx));
-    ext.reporter = reporter;
 
     dockerExplorerProvider = new DockerExplorerProvider(azureAccount);
     vscode.window.registerTreeDataProvider('dockerExplorer', dockerExplorerProvider);

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -5,7 +5,7 @@
 import * as opn from 'opn';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { AzureUserInput } from 'vscode-azureextensionui';
+import { AzureUserInput, registerCommand, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient';
 import { buildImage } from './commands/build-image';
 import { composeDown, composeRestart, composeUp } from './commands/docker-compose';
@@ -38,7 +38,7 @@ import { DockerHubImageNode, DockerHubOrgNode, DockerHubRepositoryNode } from '.
 import { browseAzurePortal } from './explorer/utils/azureUtils';
 import { browseDockerHub, dockerHubLogout } from './explorer/utils/dockerHubUtils';
 import { ext } from "./extensionVariables";
-import { Reporter } from './telemetry/telemetry';
+import { Reporter, reporter } from './telemetry/telemetry';
 import { AzureAccount } from './typings/azure-account.api';
 
 export const FROM_DIRECTIVE_PATTERN = /^\s*FROM\s*([\w-\/:]*)(\s*AS\s*[a-z][a-z0-9-_\\.]*)?$/i;
@@ -66,8 +66,15 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     const outputChannel = util.getOutputChannel();
     let azureAccount: AzureAccount;
 
-    // This allows for standard interactions with the end user (as opposed to test input)
-    ext.ui = new AzureUserInput(ctx.globalState);
+    // Set up extension variables
+    ctx.subscriptions.push(new Reporter(ctx));
+    if (!ext.ui) {
+        // This allows for standard interactions with the end user (as opposed to test input)
+        ext.ui = new AzureUserInput(ctx.globalState);
+    }
+    ext.context = ctx;
+    ext.reporter = reporter;
+    registerUIExtensionVariables(ext);
 
     // tslint:disable-next-line:prefer-for-of // Grandfathered in
     for (let i = 0; i < installedExtensions.length; i++) {
@@ -82,11 +89,9 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
         }
     }
 
-    ctx.subscriptions.push(new Reporter(ctx));
-
     dockerExplorerProvider = new DockerExplorerProvider(azureAccount);
     vscode.window.registerTreeDataProvider('dockerExplorer', dockerExplorerProvider);
-    vscode.commands.registerCommand('vscode-docker.explorer.refresh', () => dockerExplorerProvider.refresh());
+    registerCommand('vscode-docker.explorer.refresh', () => dockerExplorerProvider.refresh());
 
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(DOCUMENT_SELECTOR, new DockerfileCompletionItemProvider(), '.'));
 
@@ -97,26 +102,26 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 
     ctx.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(DOCKER_INSPECT_SCHEME, new DockerInspectDocumentContentProvider()));
 
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.configure', configure));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.image.build', buildImage));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.image.inspect', inspectImage));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.image.remove', removeImage));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.image.push', pushImage));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.image.tag', tagImage));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.start', startContainer));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.start.interactive', startContainerInteractive));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.start.azurecli', startAzureCLI));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.stop', stopContainer));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.restart', restartContainer));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.show-logs', showLogsContainer));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.open-shell', openShellContainer));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.container.remove', removeContainer));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.compose.up', composeUp));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.compose.down', composeDown));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.compose.restart', composeRestart));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.system.prune', systemPrune));
+    registerCommand('vscode-docker.configure', configure);
+    registerCommand('vscode-docker.image.build', buildImage);
+    registerCommand('vscode-docker.image.inspect', inspectImage);
+    registerCommand('vscode-docker.image.remove', removeImage);
+    registerCommand('vscode-docker.image.push', pushImage);
+    registerCommand('vscode-docker.image.tag', tagImage);
+    registerCommand('vscode-docker.container.start', startContainer);
+    registerCommand('vscode-docker.container.start.interactive', startContainerInteractive);
+    registerCommand('vscode-docker.container.start.azurecli', startAzureCLI);
+    registerCommand('vscode-docker.container.stop', stopContainer);
+    registerCommand('vscode-docker.container.restart', restartContainer);
+    registerCommand('vscode-docker.container.show-logs', showLogsContainer);
+    registerCommand('vscode-docker.container.open-shell', openShellContainer);
+    registerCommand('vscode-docker.container.remove', removeContainer);
+    registerCommand('vscode-docker.compose.up', composeUp);
+    registerCommand('vscode-docker.compose.down', composeDown);
+    registerCommand('vscode-docker.compose.restart', composeRestart);
+    registerCommand('vscode-docker.system.prune', systemPrune);
 
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.createWebApp', async (context?: AzureImageNode | DockerHubImageNode) => {
+    registerCommand('vscode-docker.createWebApp', async (context?: AzureImageNode | DockerHubImageNode) => {
         if (context) {
             if (azureAccount) {
                 const azureAccountWrapper = new AzureAccountWrapper(ctx, azureAccount);
@@ -130,15 +135,15 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
                 }
             }
         }
-    }));
+    });
 
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.dockerHubLogout', dockerHubLogout));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.browseDockerHub', (context?: DockerHubImageNode | DockerHubRepositoryNode | DockerHubOrgNode) => {
+    registerCommand('vscode-docker.dockerHubLogout', dockerHubLogout);
+    registerCommand('vscode-docker.browseDockerHub', (context?: DockerHubImageNode | DockerHubRepositoryNode | DockerHubOrgNode) => {
         browseDockerHub(context);
-    }));
-    ctx.subscriptions.push(vscode.commands.registerCommand('vscode-docker.browseAzurePortal', (context?: AzureRegistryNode | AzureRepositoryNode | AzureImageNode) => {
+    });
+    registerCommand('vscode-docker.browseAzurePortal', (context?: AzureRegistryNode | AzureRepositoryNode | AzureImageNode) => {
         browseAzurePortal(context);
-    }));
+    });
 
     ctx.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('docker', new DockerDebugConfigProvider()));
 

--- a/package.json
+++ b/package.json
@@ -678,7 +678,7 @@
     "pom-parser": "^1.1.1",
     "request-promise": "^4.2.2",
     "vscode-azureextensionui": "^0.16.6",
-    "vscode-extension-telemetry": "^0.0.6",
-    "vscode-languageclient": "4.4.0"
+    "vscode-extension-telemetry": "0.0.18",
+    "vscode-languageclient": "^4.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -677,7 +677,7 @@
     "opn": "^5.1.0",
     "pom-parser": "^1.1.1",
     "request-promise": "^4.2.2",
-    "vscode-azureextensionui": "~0.15.0",
+    "vscode-azureextensionui": "~0.16.4",
     "vscode-extension-telemetry": "^0.0.6",
     "vscode-languageclient": "4.4.0"
   }


### PR DESCRIPTION
Part of #347

@chrisdias just FYI mostly.  The shared registerCommand code has several advantages:
1) It records success and failures
2) It takes care of error handling and other things
3) Each command gets its own event name (rather than eventname='command' + property), which makes analyzing telemetry easier
4) We'll get better synchronization with the dashboard (e.g. event and error tracking)
5) It's automatically done for every event registered with registerCommand

This doesn't yet remove the old telemetry calls, that still needs to be done.  Right now we get both, e.g.:
```
NEW EVENTS >>>
** TELEMETRY("vscode-docker/vscode-docker.explorer.refresh", 0.1.1-alpha) properties={"isActivationEvent":"false","cancelStep":"","result":"Succeeded","error":"","errorMessage":""}, measures={"duration":0.001}
** TELEMETRY("vscode-docker/vscode-docker.container.start", 0.1.1-alpha) properties={"isActivationEvent":"false","cancelStep":"","result":"Succeeded","error":"","errorMessage":""}, measures={"duration":0.002}
OLD EVENT >>>
** TELEMETRY("vscode-docker/command", 0.1.1-alpha) properties={"command":"vscode-docker.container.start"}, measures={}
```