### PR TITLE
Enclose absolute path in "" for build & compose to work across terminals

### DIFF
--- a/commands/build-image.ts
+++ b/commands/build-image.ts
@@ -106,7 +106,7 @@ export async function buildImage(dockerFileUri?: vscode.Uri): Promise<void> {
     if (!value) { return; }
 
     const terminal: vscode.Terminal = createTerminal('Docker');
-    terminal.sendText(`docker build --rm -f ${uri.file} -t ${value} ${contextPath}`);
+    terminal.sendText(`docker build --rm -f "${uri.file}" -t ${value} ${contextPath}`);
     terminal.show();
 
     if (reporter) {

--- a/commands/docker-compose.ts
+++ b/commands/docker-compose.ts
@@ -82,7 +82,7 @@ async function compose(commands: ('up' | 'down')[], message: string, dockerCompo
     terminal.sendText(`cd "${folder.uri.fsPath}"`);
     for (let command of commands) {
         selectedItems.forEach((item: Item) => {
-            terminal.sendText(command.toLowerCase() === 'up' ? `docker-compose -f ${item.file} ${command} ${detached} ${build}` : `docker-compose -f ${item.file} ${command}`);
+            terminal.sendText(command.toLowerCase() === 'up' ? `docker-compose -f "${item.file}" ${command} ${detached} ${build}` : `docker-compose -f "${item.file}" ${command}`);
         });
         terminal.show();
         if (reporter) {


### PR DESCRIPTION
Fixes #274 

Instead of trying to replace one '\' with '//', enclosing the path in quotes seems to work similarly. 

