### PR TITLE
Adopt version 0.0.19 of the language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -367,6 +367,17 @@
           ],
           "description": "Controls the diagnostic severity for JSON instructions that are written incorrectly with single quotes."
         },
+        "docker.languageserver.diagnostics.instructionWorkdirRelative": {
+          "scope": "resource",
+          "type": "string",
+          "default": "warning",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "description": "Controls the diagnostic severity for WORKDIR instructions that do not point to an absolute path."
+        },
         "docker.attachShellCommand.linuxContainer": {
           "type": "string",
           "default": "/bin/sh",
@@ -594,7 +605,7 @@
     "azure-arm-containerregistry": "^2.3.0",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",
-    "dockerfile-language-server-nodejs": "^0.0.18",
+    "dockerfile-language-server-nodejs": "^0.0.19",
     "dockerode": "^2.5.1",
     "fs-extra": "^6.0.1",
     "glob": "7.1.2",


### PR DESCRIPTION
I released version 0.0.19 of the language server this morning.

It includes:
- folding support for comments
- fix for #338
- support for handling SCTP ports in `EXPOSE` instructions per Docker CE 18.03
- optional warning/error for `WORKDIR` instructions that are not absolute paths (to try to enforce good practices per the official [guidelines and recommendations document](https://github.com/docker/docker.github.io/blob/c0be65e755be1d8155891fb5d1b457e52bed6cf1/develop/develop-images/dockerfile_best-practices.md) for Dockerfiles

As always, please use the following Dockerfile to test before and after behaviours!

```Dockerfile
# this is a
# long comment
# you can now fold this!

# try hitting F1
# and then typing >> Fold All Block Comments

# this is all gone!
# you don't need to read this
# fold and bye!
FROM node

# quoted multiline LABELs shouldn't be an error, see #338
LABEL "a"="b" \
    "c"="d" \
    "e"="f"

# quoted multiline ENVs shouldn't be an error, see #338
ENV "a"="b" \
    "c"="d" \
    "e"="f"

# EXPOSE should be capable of handling SCTP, new in Docker CE 18.03
EXPOSE 8080/sctp

# WORKDIR instructions that are not variables or are not absolute paths
# will now be a warning, toggle the setting below to change this
# docker.languageserver.diagnostics.instructionWorkdirRelative = "ignore" / "warning" / "error"
# defaults to "warning"
WORKDIR abc
WORKDIR $abc
WORKDIR /abc
WORKDIR C:\\abc
```