### PR TITLE
Prompt user on first push (containing a prefix) to store the path; combine defaultRegistry&defaultRegistryPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The Docker extension comes with a number of useful configuration settings allowi
 | `docker.attachShellCommand.windowsContainer` | Attach command to use for Windows containers | `powershell`
 | `docker.dockerComposeBuild` | Run docker-compose with the --build argument, defaults to true | `true`
 | `docker.dockerComposeDetached` | Run docker-compose with the --d (detached) argument, defaults to true | `true`
-| `docker.defaultRegistry` | Default registry when tagging an image, empty string will target Docker Hub when pushing. | `""`
+| `docker.defaultRegistry` | (Deprecated) Default registry when tagging an image, empty string will target Docker Hub when pushing. | `""`
 | `docker.defaultRegistryPath` | Path within registry to push to. | `""`
 | `docker.explorerRefreshInterval` | Explorer refresh interval, default is 1000ms. | `1000`
 | `docker.imageBuildContextPath` | Build context PATH to pass to Docker build command. | `""`

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The Docker extension comes with a number of useful configuration settings allowi
 | `docker.attachShellCommand.windowsContainer` | Attach command to use for Windows containers | `powershell`
 | `docker.dockerComposeBuild` | Run docker-compose with the --build argument, defaults to true | `true`
 | `docker.dockerComposeDetached` | Run docker-compose with the --d (detached) argument, defaults to true | `true`
-| `docker.defaultRegistry` | (Deprecated) Default registry when tagging an image, empty string will target Docker Hub when pushing. | `""`
 | `docker.defaultRegistryPath` | Path within registry to push to. | `""`
 | `docker.explorerRefreshInterval` | Explorer refresh interval, default is 1000ms. | `1000`
 | `docker.imageBuildContextPath` | Build context PATH to pass to Docker build command. | `""`

--- a/commands/push-image.ts
+++ b/commands/push-image.ts
@@ -42,7 +42,7 @@ export async function pushImage(context?: ImageNode): Promise<void> {
         }
         if (userPrefixPreference === DialogResponses.yes) {
             await configOptions.update('defaultRegistryPath', prefix, vscode.ConfigurationTarget.Workspace);
-            await vscode.window.showInformationMessage('You can change this value at any time via the docker.defaultRegistryPath setting.');
+            vscode.window.showInformationMessage('Default registry path saved. You can change this value at any time via the docker.defaultRegistryPath setting.');
         }
     }
     if (imageToPush) {

--- a/commands/tag-image.ts
+++ b/commands/tag-image.ts
@@ -37,11 +37,6 @@ export async function tagImage(context?: ImageNode): Promise<void> {
             imageName = defaultRegistryPath + '/' + imageName;
         }
 
-        const defaultRegistry = configOptions.get('defaultRegistry', '');
-        if (defaultRegistry.length > 0) {
-            imageName = defaultRegistry + '/' + imageName;
-        }
-
         let opt: vscode.InputBoxOptions = {
             ignoreFocusOut: true,
             placeHolder: imageName,

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -187,13 +187,13 @@ function consolidateDefaultRegistrySettings(): void {
     }
 }
 
-export function deactivate(): Thenable<void> {
+export async function deactivate(): Promise<void> {
     if (!client) {
         return undefined;
     }
     // perform cleanup
     Configuration.dispose();
-    return client.stop();
+    return await client.stop();
 }
 
 namespace Configuration {

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -148,7 +148,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     if (azureAccount) {
         AzureUtilityManager.getInstance().setAccount(azureAccount);
     }
-
+    consolidateDefaultRegistrySettings();
     activateLanguageClient(ctx);
 }
 
@@ -177,6 +177,23 @@ function registerComposeCommands(): void {
     registerCommand('vscode-docker.compose.down', composeDown);
     registerCommand('vscode-docker.compose.restart', composeRestart);
     registerCommand('vscode-docker.system.prune', systemPrune);
+}
+
+function consolidateDefaultRegistrySettings(): void {
+    const configOptions: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('docker');
+    let defaultRegistryPath = configOptions.get('defaultRegistryPath', '');
+    let defaultRegistry = configOptions.get('defaultRegistry', '');
+
+    if (defaultRegistry) {
+        if (defaultRegistryPath) { // combine both the settings, then notify the user
+            configOptions.update('defaultRegistryPath', `${defaultRegistry}/${defaultRegistryPath}`, false);
+        }
+        if (!defaultRegistryPath) {// assign defaultRegistry to defaultRegistryPath
+            configOptions.update('defaultRegistryPath', `${defaultRegistry}`, false);
+        }
+        configOptions.update('defaultRegistry', '', false);
+        vscode.window.showInformationMessage("Moving forward, we shall deprecate the use of the defaultRegistry setting, combining it with defaultRegistryPath.")
+    }
 }
 
 export function deactivate(): Thenable<void> {

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -111,7 +111,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     if (azureAccount) {
         AzureUtilityManager.getInstance().setAccount(azureAccount);
     }
-    consolidateDefaultRegistrySettings();
+    await consolidateDefaultRegistrySettings();
     activateLanguageClient(ctx);
 }
 
@@ -170,19 +170,19 @@ function registerDockerCommands(azureAccount: AzureAccount): void {
 
 }
 
-function consolidateDefaultRegistrySettings(): void {
+async function consolidateDefaultRegistrySettings(): Promise<void> {
     const configOptions: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('docker');
     let defaultRegistryPath = configOptions.get('defaultRegistryPath', '');
     let defaultRegistry = configOptions.get('defaultRegistry', '');
 
     if (defaultRegistry) {
         if (defaultRegistryPath) { // combine both the settings, then notify the user
-            configOptions.update('defaultRegistryPath', `${defaultRegistry}/${defaultRegistryPath}`, false);
+            await configOptions.update('defaultRegistryPath', `${defaultRegistry}/${defaultRegistryPath}`, vscode.ConfigurationTarget.Workspace);
         }
         if (!defaultRegistryPath) {// assign defaultRegistry to defaultRegistryPath
-            configOptions.update('defaultRegistryPath', `${defaultRegistry}`, false);
+            await configOptions.update('defaultRegistryPath', `${defaultRegistry}`, vscode.ConfigurationTarget.Workspace);
         }
-        configOptions.update('defaultRegistry', '', false);
+        await configOptions.update('defaultRegistry', '', false);
         vscode.window.showInformationMessage("Moving forward, we shall deprecate the use of the defaultRegistry setting, combining it with defaultRegistryPath.")
     }
 }

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -110,9 +110,9 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     ctx.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(DOCKER_INSPECT_SCHEME, new DockerInspectDocumentContentProvider()));
 
     registerCommand('vscode-docker.configure', configure);
-    await registerImageCommands();
-    await registerContainerCommands();
-    await registerComposeCommands();
+    registerImageCommands();
+    registerContainerCommands();
+    registerComposeCommands();
 
     registerCommand('vscode-docker.createWebApp', async (context?: AzureImageNode | DockerHubImageNode) => {
         if (context) {

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -182,8 +182,8 @@ async function consolidateDefaultRegistrySettings(): Promise<void> {
         if (!defaultRegistryPath) {// assign defaultRegistry to defaultRegistryPath
             await configOptions.update('defaultRegistryPath', `${defaultRegistry}`, vscode.ConfigurationTarget.Workspace);
         }
-        await configOptions.update('defaultRegistry', '', false);
-        vscode.window.showInformationMessage("Moving forward, we shall deprecate the use of the defaultRegistry setting, combining it with defaultRegistryPath.")
+        await configOptions.update('defaultRegistry', undefined, vscode.ConfigurationTarget.Workspace);
+        vscode.window.showInformationMessage("The 'docker.defaultRegistry' setting is now obsolete, and you should just use the 'docker.defaultRegistryPath' setting. Your settings have been updated to reflect this change.")
     }
 }
 

--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -110,23 +110,9 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     ctx.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(DOCKER_INSPECT_SCHEME, new DockerInspectDocumentContentProvider()));
 
     registerCommand('vscode-docker.configure', configure);
-    registerCommand('vscode-docker.image.build', buildImage);
-    registerCommand('vscode-docker.image.inspect', inspectImage);
-    registerCommand('vscode-docker.image.remove', removeImage);
-    registerCommand('vscode-docker.image.push', pushImage);
-    registerCommand('vscode-docker.image.tag', tagImage);
-    registerCommand('vscode-docker.container.start', startContainer);
-    registerCommand('vscode-docker.container.start.interactive', startContainerInteractive);
-    registerCommand('vscode-docker.container.start.azurecli', startAzureCLI);
-    registerCommand('vscode-docker.container.stop', stopContainer);
-    registerCommand('vscode-docker.container.restart', restartContainer);
-    registerCommand('vscode-docker.container.show-logs', showLogsContainer);
-    registerCommand('vscode-docker.container.open-shell', openShellContainer);
-    registerCommand('vscode-docker.container.remove', removeContainer);
-    registerCommand('vscode-docker.compose.up', composeUp);
-    registerCommand('vscode-docker.compose.down', composeDown);
-    registerCommand('vscode-docker.compose.restart', composeRestart);
-    registerCommand('vscode-docker.system.prune', systemPrune);
+    await registerImageCommands();
+    await registerContainerCommands();
+    await registerComposeCommands();
 
     registerCommand('vscode-docker.createWebApp', async (context?: AzureImageNode | DockerHubImageNode) => {
         if (context) {
@@ -164,6 +150,33 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     }
 
     activateLanguageClient(ctx);
+}
+
+function registerContainerCommands(): void {
+    registerCommand('vscode-docker.container.start', startContainer);
+    registerCommand('vscode-docker.container.start.interactive', startContainerInteractive);
+    registerCommand('vscode-docker.container.start.azurecli', startAzureCLI);
+    registerCommand('vscode-docker.container.stop', stopContainer);
+    registerCommand('vscode-docker.container.restart', restartContainer);
+    registerCommand('vscode-docker.container.show-logs', showLogsContainer);
+    registerCommand('vscode-docker.container.open-shell', openShellContainer);
+    registerCommand('vscode-docker.container.remove', removeContainer);
+}
+
+function registerImageCommands(): void {
+    registerCommand('vscode-docker.image.build', buildImage);
+    registerCommand('vscode-docker.image.inspect', inspectImage);
+    registerCommand('vscode-docker.image.remove', removeImage);
+    registerCommand('vscode-docker.image.push', pushImage);
+    registerCommand('vscode-docker.image.tag', tagImage);
+
+}
+
+function registerComposeCommands(): void {
+    registerCommand('vscode-docker.compose.up', composeUp);
+    registerCommand('vscode-docker.compose.down', composeDown);
+    registerCommand('vscode-docker.compose.restart', composeRestart);
+    registerCommand('vscode-docker.system.prune', systemPrune);
 }
 
 export function deactivate(): Thenable<void> {

--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
           "default": "",
           "description": "Default registry and path when tagging an image, empty string will target Docker Hub when pushing"
         },
-        "docker.askToSavePrefix": {
+        "docker.askToSaveRegistryPath": {
           "type": "boolean",
           "default": true,
           "description": "Ask the user whether to store the path prefix in defaultRegsitryPath on first push"

--- a/package.json
+++ b/package.json
@@ -244,6 +244,11 @@
           "default": "",
           "description": "Default registry and path when tagging an image, empty string will target Docker Hub when pushing"
         },
+        "docker.askToSavePrefix": {
+          "type": "boolean",
+          "default": true,
+          "description": "Ask the user whether to store the path prefix in defaultRegsitryPath on first push"
+        },
         "docker.showExplorer": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -239,11 +239,6 @@
       "type": "object",
       "title": "Docker configuration options",
       "properties": {
-        "docker.defaultRegistry": {
-          "type": "string",
-          "default": "",
-          "description": "(Deprecated) Default registry when tagging an image, empty string will target Docker Hub when pushing."
-        },
         "docker.defaultRegistryPath": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -242,12 +242,12 @@
         "docker.defaultRegistry": {
           "type": "string",
           "default": "",
-          "description": "Default registry when tagging an image, empty string will target Docker Hub when pushing."
+          "description": "(Deprecated) Default registry when tagging an image, empty string will target Docker Hub when pushing."
         },
         "docker.defaultRegistryPath": {
           "type": "string",
           "default": "",
-          "description": "Path within registry to push to."
+          "description": "Default registry and path when tagging an image, empty string will target Docker Hub when pushing"
         },
         "docker.showExplorer": {
           "type": "boolean",


### PR DESCRIPTION
Functionally important changes in the title

Chronologically - 
- Refactor RegisterCommand due to the max func length tslint rule - the function was at the limit of the number of lines. This prevents any change from happening there until this was addressed. 
- combine two workspace settings (defaultRegistry&defaultRegistryPath)
- Prompt user on first push (containing a prefix) to store the path

Fix #396 

Addresses #334 