### PR TITLE
Add valueSelection -> highlights path in tag image inputbox

### DIFF
--- a/commands/tag-image.ts
+++ b/commands/tag-image.ts
@@ -42,11 +42,14 @@ export async function tagImage(context?: ImageNode): Promise<void> {
             imageName = defaultRegistry + '/' + imageName;
         }
 
+        let separatorLastIndex: number = imageName.lastIndexOf('/');
+
         let opt: vscode.InputBoxOptions = {
             ignoreFocusOut: true,
             placeHolder: imageName,
             prompt: 'Tag image as...',
-            value: imageName
+            value: imageName,
+            valueSelection: [0, separatorLastIndex]
         };
 
         const value: string = await vscode.window.showInputBox(opt);

--- a/commands/tag-image.ts
+++ b/commands/tag-image.ts
@@ -42,14 +42,12 @@ export async function tagImage(context?: ImageNode): Promise<void> {
             imageName = defaultRegistry + '/' + imageName;
         }
 
-        let separatorLastIndex: number = imageName.lastIndexOf('/');
-
         let opt: vscode.InputBoxOptions = {
             ignoreFocusOut: true,
             placeHolder: imageName,
             prompt: 'Tag image as...',
             value: imageName,
-            valueSelection: [0, separatorLastIndex]
+            valueSelection: [0, defaultRegistryPath.length]
         };
 
         const value: string = await vscode.window.showInputBox(opt);


### PR DESCRIPTION
Fixes #406 

I don't expect a merge conflict here. 

Heads-up: The separatorLastIndex can be -1 (when there's no slash in the imageName). I tested for that, and the range given then highlights the whole input (mirroring previous behavior). It works, and I feel the extra effort in clarifying it here may not be warranted. If you feel differently, I'll make that change too. 