### PR TITLE
Tie .NET core image versions with the host Windows version

### DIFF
--- a/configureWorkspace/configure_dotnetcore.ts
+++ b/configureWorkspace/configure_dotnetcore.ts
@@ -227,7 +227,7 @@ function genDockerFile(serviceNameAndRelativePath: string, platform: Platform, o
         .replace(/\$copy_project_commands\$/g, copyProjectCommands);
 
     // Remove multiple empty lines, as might be produced if there's no EXPOSE statement
-    contents = contents.replace(/$$/gm, nodeOs.EOL);
+    contents = contents.replace(new RegExp(`${nodeOs.EOL}\{3\}`, 'g'), `${nodeOs.EOL}${nodeOs.EOL}`);
 
     let unreplacedToken = extractRegExGroups(contents, /(\$[a-z_]+\$)/, ['']);
     if (unreplacedToken[0]) {

--- a/extensionVariables.ts
+++ b/extensionVariables.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as osNode from 'os';
 import { RequestAPI, RequiredUriUrl } from 'request';
 import { RequestPromise, RequestPromiseOptions } from 'request-promise-native';
 import { ExtensionContext, OutputChannel, Terminal } from "vscode";
@@ -27,4 +28,12 @@ export namespace ext {
      * A version of 'request-promise' which should be used for all direct request calls (it has the user agent set up properly)
      */
     export let request: requestPromise;
+
+    /**
+     * An test-injectable structure defining the current operating system and version
+     */
+    export let os = {
+        platform: osNode.platform(),
+        release: osNode.release()
+    };
 }

--- a/helpers/windowsVersion.ts
+++ b/helpers/windowsVersion.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as semver from 'semver';
+import { ext } from '../extensionVariables';
+
+// Minimum Windows RS3 version number
+const windows10RS3MinVersion = '10.0.16299';
+
+// Minimum Windows RS4 version number
+const windows10RS4MinVersion = '10.0.17134';
+
+export function isWindows(): boolean {
+    return ext.os.platform === 'win32';
+}
+
+export function isWindows10RS4OrNewer(): boolean {
+    if (!isWindows()) {
+        return false;
+    }
+
+    return semver.gte(ext.os.release, windows10RS4MinVersion);
+}
+
+export function isWindows10RS3OrNewer(): boolean {
+    if (!isWindows()) {
+        return false;
+    }
+
+    return semver.gte(ext.os.release, windows10RS3MinVersion);
+}

--- a/test/windowsVersion.test.ts
+++ b/test/windowsVersion.test.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ext } from "../extensionVariables";
+import * as assert from 'assert';
+import { isWindows10RS4OrNewer, isWindows10RS3OrNewer } from "../helpers/windowsVersion";
+
+suite("windowsVersion", () => {
+    let previousOs: typeof ext.os;
+
+    function testIsWindows10RS4OrNewer(release: string, expectedResult: boolean): void {
+        test(`isWindows10RS4OrNewer: ${release}`, () => {
+            let previousOs = ext.os;
+            try {
+                ext.os = {
+                    platform: 'win32',
+                    release
+                };
+
+                let result = isWindows10RS4OrNewer();
+                assert.equal(result, expectedResult);
+            } finally {
+                ext.os = previousOs;
+            }
+        });
+    }
+
+    function testIsWindows10RS3OrNewer(release: string, expectedResult: boolean): void {
+        test(`isWindows10RS4OrNewer: ${release}`, () => {
+            let previousOs = ext.os;
+            try {
+                ext.os = {
+                    platform: 'win32',
+                    release
+                };
+
+                let result = isWindows10RS3OrNewer();
+                assert.equal(result, expectedResult);
+            } finally {
+                ext.os = previousOs;
+            }
+        });
+    }
+
+    suite('isWindows10RS4OrNewer', () => {
+        testIsWindows10RS4OrNewer('10.0.17134', true);
+        testIsWindows10RS4OrNewer('10.0.17135', true);
+        testIsWindows10RS4OrNewer('10.0.17133', false);
+        testIsWindows10RS4OrNewer('10.0.17133', false);
+        testIsWindows10RS4OrNewer('9.9.17135', false);
+        testIsWindows10RS4OrNewer('10.1.0', true);
+        testIsWindows10RS4OrNewer('11.1.0', true);
+    });
+
+    suite('isWindows10RS3OrNewer', () => {
+        testIsWindows10RS3OrNewer('10.0.16299', true);
+        testIsWindows10RS3OrNewer('10.0.16300', true);
+        testIsWindows10RS3OrNewer('10.0.16298', false);
+    });
+});

--- a/test/windowsVersion.test.ts
+++ b/test/windowsVersion.test.ts
@@ -52,11 +52,17 @@ suite("windowsVersion", () => {
         testIsWindows10RS4OrNewer('9.9.17135', false);
         testIsWindows10RS4OrNewer('10.1.0', true);
         testIsWindows10RS4OrNewer('11.1.0', true);
+
+        testIsWindows10RS4OrNewer('10.0.14393', false); // Windows Server 2016
+        testIsWindows10RS4OrNewer('10.0.17134', true); // Windows 10 Version 1803 (build 17134.285)
     });
 
     suite('isWindows10RS3OrNewer', () => {
         testIsWindows10RS3OrNewer('10.0.16299', true);
         testIsWindows10RS3OrNewer('10.0.16300', true);
         testIsWindows10RS3OrNewer('10.0.16298', false);
+
+        testIsWindows10RS3OrNewer('10.0.14393', false); // Windows Server 2016
+        testIsWindows10RS3OrNewer('10.0.17134', true); // Windows 10 Version 1803 (build 17134.285)
     });
 });


### PR DESCRIPTION
1) Get images based on host Windows version
2) Update templates to match correct VS ones (double quotes, deal with missing port)