### PR TITLE
Add simple activation perf telemetry and fix git type

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "multi-root ready"
   ],
   "repository": {
-    "url": "https://github.com/microsoft/vscode-docker.git"
+    "type": "git",
+    "url": "https://github.com/microsoft/vscode-docker"
   },
   "homepage": "https://github.com/Microsoft/vscode-docker/blob/master/README.md",
   "activationEvents": [


### PR DESCRIPTION
> From: Erich Gamma 
> The report issue link is derived from the extension´s package.json and its repository link. It appears that the Docker extension doesn´t include the type property in its repository attribute. This is how it is done in the vscode-tslint extension.
>
>  "repository": {
>    "type": "git",
>    "url": "https://github.com/Microsoft/vscode-tslint.git"
>  },
