### PR TITLE
Specify .dockerignore language

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,6 +279,12 @@
           "*.dockerfile",
           "Dockerfile"
         ]
+      },
+      {
+        "id": "ignore",
+        "filenames": [
+          ".dockerignore"
+        ]
       }
     ],
     "configuration": {


### PR DESCRIPTION
By specifying _.dockerignore_ as an ignore file, support is added for syntax highlighting and toggling of comments.

This is analogous to for example _.gitignore_ and _.eslintignore_.