### PR TITLE
Support additional Docker build and run customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Customize the Docker container run process by adding properties under the `docke
 | Property | Description | Default |
 | --- | --- | --- |
 | `containerName` | The name of the container. | `<Application Name>-dev` |
+| `env` | Environment variables applied to the container. | None |
 
 ## Configuration Settings
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Customize the Docker container run process by adding properties under the `docke
 | `containerName` | The name of the container. | `<Application Name>-dev` |
 | `env` | Environment variables applied to the container. | None |
 | `envFiles` | Files of environment variables read in and applied to the container. Environment variables are specified one per line, in `<name>=<value>` format. | None |
+| `labels` | The set of labels added to the container. | `com.microsoft.created-by` = `visual-studio-code` |
 
 Example run customization:
 
@@ -217,7 +218,11 @@ Example run customization:
                 },
                 "envFiles": [
                     "${workspaceFolder}/staging.env"
-                ]
+                ],
+                "labels": {
+                    "label1": "value1",
+                    "label2": "value2"
+                }
             }
         }
     ]

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Customize the Docker image build process by adding properties under the `dockerB
 
 | Property | Description | Default |
 | --- | --- | --- |
+| `args` | Build arguments applied to the image. | None |
 | `context` | The Docker context used during the build process. | The workspace folder, if the same as the application folder; otherwise, the application's parent (i.e. solution) folder |
 | `dockerfile` | The path to the Dockerfile used to build the image. | The file `Dockerfile` in the application folder |
 | `labels` | The set of labels added to the image. | `com.microsoft.created-by` = `visual-studio-code` |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Customize the Docker image build process by adding properties under the `dockerB
 | --- | --- | --- |
 | `context` | The Docker context used during the build process. | The workspace folder, if the same as the application folder; otherwise, the application's parent (i.e. solution) folder |
 | `dockerfile` | The path to the Dockerfile used to build the image. | The file `Dockerfile` in the application folder |
+| `labels` | The set of labels added to the image. | `com.microsoft.created-by` = `visual-studio-code` |
 | `tag` | The tag added to the image. | `<Application Name>:dev` |
 | `target` | The target (stage) of the Dockerfile from which to build the image. | `base`
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,34 @@ Customize the Docker image build process by adding properties under the `dockerB
 | `tag` | The tag added to the image. | `<Application Name>:dev` |
 | `target` | The target (stage) of the Dockerfile from which to build the image. | `base`
 
+Example build customizations:
+
+```json
+{
+    "configurations": [
+        {
+            "name": "Launch .NET Core in Docker",
+            "type": "docker-coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "dockerBuild": {
+                "args": {
+                    "arg1": "value1",
+                    "arg2": "value2"
+                },
+                "context": "${workspaceFolder}/src",
+                "dockerfile": "${workspaceFolder}/src/Dockerfile",
+                "labels": {
+                    "label1": "value1",
+                    "label2": "value2"
+                },
+                "tag": "mytag",
+                "target": "publish"
+            }
+        }
+    ]
+}
+```
 
 ### Docker Run Customization
 
@@ -169,6 +197,32 @@ Customize the Docker container run process by adding properties under the `docke
 | --- | --- | --- |
 | `containerName` | The name of the container. | `<Application Name>-dev` |
 | `env` | Environment variables applied to the container. | None |
+| `envFiles` | Files of environment variables read in and applied to the container. Environment variables are specified one per line, in `<name>=<value>` format. | None |
+
+Example run customization:
+
+```json
+{
+    "configurations": [
+        {
+            "name": "Launch .NET Core in Docker",
+            "type": "docker-coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "dockerRun": {
+                "containerName": "my-container",
+                "env": {
+                    "var1": "value1",
+                    "var2": "value2"
+                },
+                "envFiles": [
+                    "${workspaceFolder}/staging.env"
+                ]
+            }
+        }
+    ]
+}
+```
 
 ## Configuration Settings
 

--- a/debugging/coreclr/commandLineBuilder.ts
+++ b/debugging/coreclr/commandLineBuilder.ts
@@ -6,9 +6,7 @@ export class CommandLineBuilder {
     public static create(...args: (undefined | string | CommandLineArgFactory)[]): CommandLineBuilder {
         let builder = new CommandLineBuilder();
 
-        for (let i = 0; i < args.length; i++) {
-            const arg = args[i];
-
+        for (let arg of args) {
             if (arg) {
                 if (typeof arg === 'string') {
                     builder = builder.withArg(arg);
@@ -29,7 +27,7 @@ export class CommandLineBuilder {
         return this.withArgFactory(() => arg);
     }
 
-    public withArrayArgs<T>(name: string, values: T[] | undefined, formatter?: (T) => string): CommandLineBuilder {
+    public withArrayArgs<T>(name: string, values: T[] | undefined, formatter?: (value: T) => string): CommandLineBuilder {
         formatter = formatter || ((value: T) => value.toString());
 
         return this.withArgFactory(() => values ? values.map(value => `${name} "${formatter(value)}"`).join(' ') : undefined);
@@ -43,7 +41,7 @@ export class CommandLineBuilder {
         return this;
     }
 
-    public withFlagArg(name: string, value: boolean | undefined) {
+    public withFlagArg(name: string, value: boolean | undefined): CommandLineBuilder {
         return this.withArgFactory(() => value ? name : undefined);
     }
 
@@ -65,7 +63,7 @@ export class CommandLineBuilder {
         return this.withArgFactory(() => value ? `${name} "${value}"` : undefined);
     }
 
-    public withQuotedArg(value: string | undefined) {
+    public withQuotedArg(value: string | undefined): CommandLineBuilder {
         return this.withArgFactory(() => value ? `"${value}"` : undefined);
     }
 }

--- a/debugging/coreclr/commandLineBuilder.ts
+++ b/debugging/coreclr/commandLineBuilder.ts
@@ -1,0 +1,71 @@
+export type CommandLineArgFactory = () => (string | undefined);
+
+export class CommandLineBuilder {
+    private readonly args: CommandLineArgFactory[] = [];
+
+    public static create(...args: (undefined | string | CommandLineArgFactory)[]): CommandLineBuilder {
+        let builder = new CommandLineBuilder();
+
+        for (let i = 0; i < args.length; i++) {
+            const arg = args[i];
+
+            if (arg) {
+                if (typeof arg === 'string') {
+                    builder = builder.withArg(arg);
+                } else {
+                    builder = builder.withArgFactory(arg);
+                }
+            }
+        }
+
+        return builder;
+    }
+
+    public build(): string {
+        return this.args.map(arg => arg()).filter(arg => arg !== undefined).join(' ');
+    }
+
+    public withArg(arg: string | undefined): CommandLineBuilder {
+        return this.withArgFactory(() => arg);
+    }
+
+    public withArrayArgs<T>(name: string, values: T[] | undefined, formatter?: (T) => string): CommandLineBuilder {
+        formatter = formatter || ((value: T) => value.toString());
+
+        return this.withArgFactory(() => values ? values.map(value => `${name} "${formatter(value)}"`).join(' ') : undefined);
+    }
+
+    public withArgFactory(factory: CommandLineArgFactory): CommandLineBuilder {
+        this.args.push(factory);
+
+        return this;
+    }
+
+    public withFlagArg(name: string, value: boolean | undefined) {
+        return this.withArgFactory(() => value ? name : undefined);
+    }
+
+    public withKeyValueArgs(name: string, values: { [key: string]: string }): CommandLineBuilder {
+        return this.withArgFactory(() => {
+            if (values) {
+                const keys = Object.keys(values);
+
+                if (keys.length > 0) {
+                    return keys.map(key => `${name} "${key}=${values[key]}"`).join(' ');
+                }
+            }
+
+            return undefined;
+        });
+    }
+
+    public withNamedArg(name: string, value: string | undefined): CommandLineBuilder {
+        return this.withArgFactory(() => value ? `${name} "${value}"` : undefined);
+    }
+
+    public withQuotedArg(value: string | undefined) {
+        return this.withArgFactory(() => value ? `"${value}"` : undefined);
+    }
+}
+
+export default CommandLineBuilder;

--- a/debugging/coreclr/commandLineBuilder.ts
+++ b/debugging/coreclr/commandLineBuilder.ts
@@ -35,8 +35,10 @@ export class CommandLineBuilder {
         return this.withArgFactory(() => values ? values.map(value => `${name} "${formatter(value)}"`).join(' ') : undefined);
     }
 
-    public withArgFactory(factory: CommandLineArgFactory): CommandLineBuilder {
-        this.args.push(factory);
+    public withArgFactory(factory: CommandLineArgFactory | undefined): CommandLineBuilder {
+        if (factory) {
+            this.args.push(factory);
+        }
 
         return this;
     }

--- a/debugging/coreclr/commandLineBuilder.ts
+++ b/debugging/coreclr/commandLineBuilder.ts
@@ -1,4 +1,8 @@
-export type CommandLineArgFactory = () => (string | undefined);
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+ export type CommandLineArgFactory = () => (string | undefined);
 
 export class CommandLineBuilder {
     private readonly args: CommandLineArgFactory[] = [];

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -6,6 +6,7 @@ import { LineSplitter } from "./lineSplitter";
 import { ProcessProvider } from "./processProvider";
 
 export type DockerBuildImageOptions = {
+    args?: { [key: string]: string };
     context?: string;
     dockerfile?: string;
     labels?: { [key: string]: string };
@@ -63,6 +64,10 @@ export class CliDockerClient implements DockerClient {
 
         if (options && options.dockerfile) {
             command += ` -f ${options.dockerfile}`;
+        }
+
+        if (options && options.args) {
+            command += Object.keys(options.args).map(arg => ` --build-arg "${arg}=${options.args[arg]}"`).join(' ');
         }
 
         if (options && options.labels) {

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -36,6 +36,7 @@ export type DockerRunContainerOptions = {
     command?: string;
     containerName?: string;
     entrypoint?: string;
+    env?: { [key: string]: string };
     volumes?: DockerContainerVolume[];
 };
 
@@ -196,6 +197,10 @@ export class CliDockerClient implements DockerClient {
 
         if (options && options.containerName) {
             command += ` --name ${options.containerName}`;
+        }
+
+        if (options && options.env) {
+            command += Object.keys(options.env).map(envvar => ` -e "${envvar}=${options.env[envvar]}"`).join(' ');
         }
 
         if (options && options.volumes) {

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -37,6 +37,7 @@ export type DockerRunContainerOptions = {
     containerName?: string;
     entrypoint?: string;
     env?: { [key: string]: string };
+    envFiles?: string[];
     volumes?: DockerContainerVolume[];
 };
 
@@ -68,11 +69,11 @@ export class CliDockerClient implements DockerClient {
         }
 
         if (options && options.args) {
-            command += Object.keys(options.args).map(arg => ` --build-arg "${arg}=${options.args[arg]}"`).join(' ');
+            command += Object.keys(options.args).map(arg => ` --build-arg "${arg}=${options.args[arg]}"`).join('');
         }
 
         if (options && options.labels) {
-            command += Object.keys(options.labels).map(label => ` --label "${label}=${options.labels[label]}"`).join(' ');
+            command += Object.keys(options.labels).map(label => ` --label "${label}=${options.labels[label]}"`).join('');
         }
 
         if (options && options.tag) {
@@ -200,7 +201,11 @@ export class CliDockerClient implements DockerClient {
         }
 
         if (options && options.env) {
-            command += Object.keys(options.env).map(envvar => ` -e "${envvar}=${options.env[envvar]}"`).join(' ');
+            command += Object.keys(options.env).map(envvar => ` -e "${envvar}=${options.env[envvar]}"`).join('');
+        }
+
+        if (options && options.envFiles) {
+            command += options.envFiles.map(envFile => ` --env-file "${envFile}"`).join('');
         }
 
         if (options && options.volumes) {

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -8,6 +8,7 @@ import { ProcessProvider } from "./processProvider";
 export type DockerBuildImageOptions = {
     context?: string;
     dockerfile?: string;
+    labels?: { [key: string]: string };
     tag?: string;
     target?: string;
 };
@@ -62,6 +63,10 @@ export class CliDockerClient implements DockerClient {
 
         if (options && options.dockerfile) {
             command += ` -f ${options.dockerfile}`;
+        }
+
+        if (options && options.labels) {
+            command += Object.keys(options.labels).map(label => ` --label "${label}=${options.labels[label]}"`).join(' ');
         }
 
         if (options && options.tag) {

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -38,6 +38,7 @@ export type DockerRunContainerOptions = {
     entrypoint?: string;
     env?: { [key: string]: string };
     envFiles?: string[];
+    labels?: { [key: string]: string };
     volumes?: DockerContainerVolume[];
 };
 
@@ -206,6 +207,10 @@ export class CliDockerClient implements DockerClient {
 
         if (options && options.envFiles) {
             command += options.envFiles.map(envFile => ` --env-file "${envFile}"`).join('');
+        }
+
+        if (options && options.labels) {
+            command += Object.keys(options.labels).map(label => ` --label "${label}=${options.labels[label]}"`).join('');
         }
 
         if (options && options.volumes) {

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -2,10 +2,9 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import CommandLineBuilder from "./commandLineBuilder";
 import { LineSplitter } from "./lineSplitter";
 import { ProcessProvider } from "./processProvider";
-import CommandLineBuilder from "./commandLineBuilder";
-import { Command } from "vscode-languageclient";
 
 export type DockerBuildImageOptions = {
     args?: { [key: string]: string };

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -14,6 +14,7 @@ import { OSProvider } from './osProvider';
 import { Prerequisite } from './prereqManager';
 
 interface DockerDebugBuildOptions {
+    args?: { [key: string]: string };
     context?: string;
     dockerfile?: string;
     labels?: { [key: string]: string };
@@ -130,6 +131,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         const appOutput = await this.inferAppOutput(debugConfiguration, os, resolvedAppProject);
 
+        const args = debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.args;
         const labels = (debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.labels)
             || { 'com.microsoft.created-by': 'visual-studio-code' };
 
@@ -137,6 +139,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
             appFolder: resolvedAppFolder,
             appOutput,
             build: {
+                args,
                 context: resolvedContext,
                 dockerfile,
                 labels,

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -25,6 +25,7 @@ interface DockerDebugBuildOptions {
 interface DockerDebugRunOptions {
     containerName?: string;
     env?: { [key: string]: string };
+    envFiles?: string[];
     os?: PlatformOS;
 }
 
@@ -137,6 +138,10 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         const labels = (debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.labels)
             || { 'com.microsoft.created-by': 'visual-studio-code' };
 
+        const envFiles = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.envFiles
+            ? debugConfiguration.dockerRun.envFiles.map(file => DockerDebugConfigurationProvider.resolveFolderPath(file, folder))
+            : undefined;
+
         const result = await this.dockerManager.prepareForLaunch({
             appFolder: resolvedAppFolder,
             appOutput,
@@ -151,6 +156,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
             run: {
                 containerName,
                 env,
+                envFiles,
                 os,
             }
         });

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -16,6 +16,7 @@ import { Prerequisite } from './prereqManager';
 interface DockerDebugBuildOptions {
     context?: string;
     dockerfile?: string;
+    labels?: { [key: string]: string };
     tag?: string;
     target?: string;
 }
@@ -129,12 +130,16 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         const appOutput = await this.inferAppOutput(debugConfiguration, os, resolvedAppProject);
 
+        const labels = (debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.labels)
+            || { 'com.microsoft.created-by': 'visual-studio-code' };
+
         const result = await this.dockerManager.prepareForLaunch({
             appFolder: resolvedAppFolder,
             appOutput,
             build: {
                 context: resolvedContext,
                 dockerfile,
+                labels,
                 tag,
                 target
             },

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -7,12 +7,11 @@ import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, Prov
 import { callWithTelemetryAndErrorHandling } from 'vscode-azureextensionui';
 import { PlatformOS } from '../../utils/platform';
 import { DebugSessionManager } from './debugSessionManager';
-import { DockerManager, LaunchResult } from './dockerManager';
+import { DockerManager, LaunchBuildOptions, LaunchResult, LaunchRunOptions } from './dockerManager';
 import { FileSystemProvider } from './fsProvider';
 import { NetCoreProjectProvider } from './netCoreProjectProvider';
 import { OSProvider } from './osProvider';
 import { Prerequisite } from './prereqManager';
-import { debug } from 'util';
 
 interface DockerDebugBuildOptions {
     args?: { [key: string]: string };
@@ -52,6 +51,8 @@ interface DockerDebugConfiguration extends DebugConfiguration {
 }
 
 export class DockerDebugConfigurationProvider implements DebugConfigurationProvider {
+    private static readonly defaultLabels: { [key: string]: string } = { 'com.microsoft.created-by': 'visual-studio-code' };
+
     constructor(
         private readonly debugSessionManager: DebugSessionManager,
         private readonly dockerManager: DockerManager,
@@ -105,8 +106,33 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         const resolvedAppProject = DockerDebugConfigurationProvider.resolveFolderPath(appProject, folder);
 
-        const context = this.inferContext(folder, resolvedAppFolder, debugConfiguration);
+        const appName = path.basename(resolvedAppProject, '.csproj');
 
+        const os = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.os
+            ? debugConfiguration.dockerRun.os
+            : 'Linux';
+
+        const appOutput = await this.inferAppOutput(debugConfiguration, os, resolvedAppProject);
+
+        const buildOptions = DockerDebugConfigurationProvider.inferBuildOptions(folder, debugConfiguration, appFolder, resolvedAppFolder, appName);
+        const runOptions = DockerDebugConfigurationProvider.inferRunOptions(folder, debugConfiguration, appName, os);
+
+        const result = await this.dockerManager.prepareForLaunch({
+            appFolder: resolvedAppFolder,
+            appOutput,
+            build: buildOptions,
+            run: runOptions
+        });
+
+        const configuration = this.createConfiguration(debugConfiguration, appFolder, result);
+
+        this.debugSessionManager.startListening();
+
+        return configuration;
+    }
+
+    private static inferBuildOptions(folder: WorkspaceFolder, debugConfiguration: DockerDebugConfiguration, appFolder: string, resolvedAppFolder: string, appName: string): LaunchBuildOptions {
+        const context = DockerDebugConfigurationProvider.inferContext(folder, resolvedAppFolder, debugConfiguration);
         const resolvedContext = DockerDebugConfigurationProvider.resolveFolderPath(context, folder);
 
         let dockerfile = debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.dockerfile
@@ -115,63 +141,49 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         dockerfile = DockerDebugConfigurationProvider.resolveFolderPath(dockerfile, folder);
 
-        const target = debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.target
-            ? debugConfiguration.dockerBuild.target
-            : 'base'; // CONSIDER: Omit target if not specified, or possibly infer from Dockerfile.
+        const args = debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.args;
 
-        const appName = path.basename(resolvedAppProject, '.csproj');
+        const labels = (debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.labels)
+            || DockerDebugConfigurationProvider.defaultLabels;
 
         const tag = debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.tag
             ? debugConfiguration.dockerBuild.tag
             : `${appName.toLowerCase()}:dev`;
 
+        const target = debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.target
+            ? debugConfiguration.dockerBuild.target
+            : 'base'; // CONSIDER: Omit target if not specified, or possibly infer from Dockerfile.
+
+        return {
+            args,
+            context: resolvedContext,
+            dockerfile,
+            labels,
+            tag,
+            target
+        };
+    }
+
+    private static inferRunOptions(folder: WorkspaceFolder, debugConfiguration: DockerDebugConfiguration, appName: string, os: PlatformOS): LaunchRunOptions {
         const containerName = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.containerName
             ? debugConfiguration.dockerRun.containerName
             : `${appName}-dev`; // CONSIDER: Use unique ID instead?
 
-        const os = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.os
-            ? debugConfiguration.dockerRun.os
-            : 'Linux';
-
-        const appOutput = await this.inferAppOutput(debugConfiguration, os, resolvedAppProject);
-
-        const args = debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.args;
         const env = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.env;
         const envFiles = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.envFiles
             ? debugConfiguration.dockerRun.envFiles.map(file => DockerDebugConfigurationProvider.resolveFolderPath(file, folder))
             : undefined;
 
-        const defaultLabels = { 'com.microsoft.created-by': 'visual-studio-code' };
-        const buildLabels = (debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.labels)
-            || defaultLabels;
-        const runLabels = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.labels)
-            || defaultLabels;
+        const labels = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.labels)
+            || DockerDebugConfigurationProvider.defaultLabels;
 
-        const result = await this.dockerManager.prepareForLaunch({
-            appFolder: resolvedAppFolder,
-            appOutput,
-            build: {
-                args,
-                context: resolvedContext,
-                dockerfile,
-                labels: buildLabels,
-                tag,
-                target
-            },
-            run: {
-                containerName,
-                env,
-                envFiles,
-                labels: runLabels,
-                os,
-            }
-        });
-
-        const configuration = this.createConfiguration(debugConfiguration, appFolder, result);
-
-        this.debugSessionManager.startListening();
-
-        return configuration;
+        return {
+            containerName,
+            env,
+            envFiles,
+            labels,
+            os,
+        };
     }
 
     private inferAppFolder(folder: WorkspaceFolder, configuration: DockerDebugConfiguration): string {
@@ -217,7 +229,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         throw new Error('Unable to infer the application project file. Set either the `appFolder` or `appProject` property in the Docker debug configuration.');
     }
 
-    private inferContext(folder: WorkspaceFolder, resolvedAppFolder: string, configuration: DockerDebugConfiguration): string {
+    private static inferContext(folder: WorkspaceFolder, resolvedAppFolder: string, configuration: DockerDebugConfiguration): string {
         return configuration && configuration.dockerBuild && configuration.dockerBuild.context
             ? configuration.dockerBuild.context
             : path.normalize(resolvedAppFolder) === path.normalize(folder.uri.fsPath)

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -24,6 +24,7 @@ interface DockerDebugBuildOptions {
 
 interface DockerDebugRunOptions {
     containerName?: string;
+    env?: { [key: string]: string };
     os?: PlatformOS;
 }
 
@@ -132,6 +133,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         const appOutput = await this.inferAppOutput(debugConfiguration, os, resolvedAppProject);
 
         const args = debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.args;
+        const env = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.env;
         const labels = (debugConfiguration && debugConfiguration.dockerBuild && debugConfiguration.dockerBuild.labels)
             || { 'com.microsoft.created-by': 'visual-studio-code' };
 
@@ -148,6 +150,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
             },
             run: {
                 containerName,
+                env,
                 os,
             }
         });

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -172,6 +172,7 @@ export class DefaultDockerManager implements DockerManager {
                         entrypoint,
                         env: options.env,
                         envFiles: options.envFiles,
+                        labels: options.labels,
                         volumes
                     });
             },

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -31,11 +31,14 @@ export type DockerManagerRunContainerOptions
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
+export type LaunchBuildOptions = Omit<DockerManagerBuildImageOptions, 'appFolder'>;
+export type LaunchRunOptions = Omit<DockerManagerRunContainerOptions, 'appFolder'>;
+
 export type LaunchOptions = {
     appFolder: string;
     appOutput: string;
-    build: Omit<DockerManagerBuildImageOptions, 'appFolder'>;
-    run: Omit<DockerManagerRunContainerOptions, 'appFolder'>;
+    build: LaunchBuildOptions;
+    run: LaunchRunOptions;
 };
 
 export type LaunchResult = {

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -315,6 +315,10 @@ export class DefaultDockerManager implements DockerManager {
             return false;
         }
 
+        if (!DefaultDockerManager.compareDictionary(options1, options2, options => options.args)) {
+            return false;
+        }
+
         if (!DefaultDockerManager.compareProperty(options1, options2, options => options.tag)) {
             return false;
         }

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -171,6 +171,7 @@ export class DefaultDockerManager implements DockerManager {
                         containerName: options.containerName,
                         entrypoint,
                         env: options.env,
+                        envFiles: options.envFiles,
                         volumes
                     });
             },

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -2,6 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import deepEqual = require('deep-equal');
 import * as path from 'path';
 import { Memento } from 'vscode';
 import { PlatformOS } from '../../utils/platform';
@@ -84,27 +85,12 @@ function compareDictionary<T>(obj1: T | undefined, obj2: T | undefined, getter: 
     const dict1 = (obj1 ? getter(obj1) : {}) || {};
     const dict2 = (obj2 ? getter(obj2) : {}) || {};
 
-    const keys1 = Object.keys(dict1).sort();
-    const keys2 = Object.keys(dict2).sort();
-
-    if (keys1.length !== keys2.length) {
-        return false;
-    }
-
-    for (let i = 0; i < keys1.length; i++) {
-        if (keys1[i] !== keys2[i]) {
-            return false;
-        }
-
-        if (dict1[keys1[i]] !== dict2[keys1[i]]) {
-            return false;
-        }
-    }
-
-    return true;
+    return deepEqual(dict1, dict2);
 }
 
 export function compareBuildImageOptions(options1: DockerBuildImageOptions | undefined, options2: DockerBuildImageOptions | undefined): boolean {
+    // NOTE: We do not compare options.dockerfile as it (i.e. the name itself) has no impact on the built image.
+
     if (!compareProperty(options1, options2, options => options.context)) {
         return false;
     }

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -170,20 +170,12 @@ export class DefaultDockerManager implements DockerManager {
                         command,
                         containerName: options.containerName,
                         entrypoint,
+                        env: options.env,
                         volumes
                     });
             },
             id => `Container ${this.dockerClient.trimId(id)} started.`,
             err => `Unable to start container: ${err}`);
-
-        const cache = await this.appCacheFactory.getStorage(options.appFolder);
-
-        await cache.update<LastContainerRunMetadata>(
-            'run',
-            {
-                containerId,
-                options
-            });
 
         return containerId;
     }

--- a/package.json
+++ b/package.json
@@ -349,6 +349,13 @@
                     "additionalProperties": {
                       "type": "string"
                     }
+                  },
+                  "envFiles": {
+                    "type": "array",
+                    "description": "Files of environment variables read in and applied to the Docker container used for debugging.",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
               }

--- a/package.json
+++ b/package.json
@@ -356,6 +356,13 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "description": "Labels applied to the Docker container used for debugging.",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
                   }
                 }
               }

--- a/package.json
+++ b/package.json
@@ -342,6 +342,13 @@
                   "containerName": {
                     "type": "string",
                     "description": "Name of the container used for debugging."
+                  },
+                  "env": {
+                    "type": "object",
+                    "description": "Environment variables applied to the Docker container used for debugging.",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
                   }
                 }
               }

--- a/package.json
+++ b/package.json
@@ -304,6 +304,13 @@
               "dockerBuild": {
                 "description": "Options for building the Docker image used for debugging.",
                 "properties": {
+                  "args": {
+                    "type": "object",
+                    "description": "Build arguments applied to the Docker image used for debugging.",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "context": {
                     "type": "string",
                     "description": "Path to the Docker build context."

--- a/package.json
+++ b/package.json
@@ -772,6 +772,7 @@
   ],
   "devDependencies": {
     "@types/adm-zip": "^0.4.31",
+    "@types/deep-equal": "^1.0.1",
     "@types/dockerode": "^2.5.5",
     "@types/fs-extra": "^5.0.4",
     "@types/glob": "5.0.35",
@@ -795,6 +796,7 @@
     "azure-arm-containerregistry": "^2.3.0",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",
+    "deep-equal": "^1.0.1",
     "dockerfile-language-server-nodejs": "^0.0.19",
     "dockerode": "^2.5.1",
     "fs-extra": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -281,10 +281,8 @@
               "type": "docker-coreclr",
               "request": "launch",
               "preLaunchTask": "build",
-              "dockerBuild": {
-              },
-              "dockerRun": {
-              }
+              "dockerBuild": {},
+              "dockerRun": {}
             }
           }
         ],
@@ -313,6 +311,13 @@
                   "dockerfile": {
                     "type": "string",
                     "description": "Path to the Dockerfile used for the build."
+                  },
+                  "labels": {
+                    "type": "object",
+                    "description": "Labels applied to the Docker image used for debugging.",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
                   },
                   "tag": {
                     "type": "string",

--- a/test/debugging/coreclr/commandLineBuilder.test.ts
+++ b/test/debugging/coreclr/commandLineBuilder.test.ts
@@ -2,47 +2,60 @@ import * as assert from 'assert';
 import CommandLineBuilder from '../../../debugging/coreclr/commandLineBuilder';
 
 suite('debugging/coreclr/CommandLineBuilder', () => {
+    function testBuilder(name: string, builderInitializer: (CommandLineBuilder) => CommandLineBuilder, expected: string, message: string) {
+        test(name, () => {
+            let builder = CommandLineBuilder.create();
+
+            builder = builderInitializer(builder);
+
+            assert.equal(builder.build(), expected, message);
+        });
+    }
+
     suite('create', () => {
         test('No args', () => assert.equal(CommandLineBuilder.create().build(), '', 'No arguments should return an empty command line.'));
+        test('With args', () => assert.equal(CommandLineBuilder.create('--arg1', '--arg2').build(), '--arg1 --arg2', 'The command line should contain the arguments.'));
+        test('With factory', () => assert.equal(CommandLineBuilder.create(() => '--arg1').build(), '--arg1', 'The command line should contain the argument.'));
+        test('With undefined', () => assert.equal(CommandLineBuilder.create(undefined).build(), '', 'No arguments should return an empty command line.'));
     });
 
     suite('withArg', () => {
-        test('With value', () => assert.equal(CommandLineBuilder.create().withArg('value').build(), 'value', 'The command line should contain the value.'));
-        test('With undefined', () => assert.equal(CommandLineBuilder.create().withArg(undefined).build(), '', 'The command line should not contain the value.'));
+        testBuilder('With value', builder => builder.withArg('value'), 'value', 'The command line should contain the value.');
+        testBuilder('With undefined', builder => builder.withArg(undefined), '', 'The command line should not contain the value.');
     });
 
     suite('withArgFactory', () => {
-        test('With factory', () => assert.equal(CommandLineBuilder.create().withArgFactory(() => 'value').build(), 'value', 'The command line should contain the value.'));
-        test('With undefined', () => assert.equal(CommandLineBuilder.create().withArgFactory(undefined).build(), '', 'The command line should not contain the value.'));
+        testBuilder('With factory', builder => builder.withArgFactory(() => 'value'), 'value', 'The command line should contain the value.');
+        testBuilder('With undefined', builder => builder.withArgFactory(undefined), '', 'The command line should not contain the value.');
     });
 
     suite('withArrayArgs', () => {
-        test('With values', () => assert.equal(CommandLineBuilder.create().withArrayArgs('--arg', ['value1', 'value2']).build(), '--arg "value1" --arg "value2"', 'The command line should contain the values.'));
-        test('With value', () => assert.equal(CommandLineBuilder.create().withArrayArgs('--arg', ['value1']).build(), '--arg "value1"', 'The command line should contain the value.'));
-        test('With empty', () => assert.equal(CommandLineBuilder.create().withArrayArgs('--arg', []).build(), '', 'The command line should not contain the value.'));
-        test('With undefined', () => assert.equal(CommandLineBuilder.create().withArrayArgs('--arg', undefined).build(), '', 'The command line should not contain the value.'));
+        testBuilder('With values', builder => builder.withArrayArgs('--arg', ['value1', 'value2']), '--arg "value1" --arg "value2"', 'The command line should contain the values.');
+        testBuilder('With value', builder => builder.withArrayArgs('--arg', ['value1']), '--arg "value1"', 'The command line should contain the value.');
+        testBuilder('With empty', builder => builder.withArrayArgs('--arg', []), '', 'The command line should not contain the value.');
+        testBuilder('With undefined', builder => builder.withArrayArgs('--arg', undefined), '', 'The command line should not contain the value.');
     });
 
     suite('withFlagArg', () => {
-        test('With true', () => assert.equal(CommandLineBuilder.create().withFlagArg('--arg', true).build(), '--arg', 'The command line should contain the value.'));
-        test('With false', () => assert.equal(CommandLineBuilder.create().withFlagArg('--arg', false).build(), '', 'The command line should not contain the value.'));
-        test('With undefined', () => assert.equal(CommandLineBuilder.create().withFlagArg('--arg', undefined).build(), '', 'The command line should not contain the value.'));
+        testBuilder('With true', builder => builder.withFlagArg('--arg', true), '--arg', 'The command line should contain the value.');
+        testBuilder('With false', builder => builder.withFlagArg('--arg', false), '', 'The command line should not contain the value.');
+        testBuilder('With undefined', builder => builder.withFlagArg('--arg', undefined), '', 'The command line should not contain the value.');
     });
 
     suite('withKeyValueArgs', () => {
-        test('With values', () => assert.equal(CommandLineBuilder.create().withKeyValueArgs('--arg', { key1: 'value1', key2: 'value2' }).build(), '--arg "key1=value1" --arg "key2=value2"', 'The command line should contain the values.'));
-        test('With value', () => assert.equal(CommandLineBuilder.create().withKeyValueArgs('--arg', { key1: 'value1' }).build(), '--arg "key1=value1"', 'The command line should contain the value.'));
-        test('With empty', () => assert.equal(CommandLineBuilder.create().withKeyValueArgs('--arg', {}).build(), '', 'The command line should not contain the value.'));
-        test('With undefined', () => assert.equal(CommandLineBuilder.create().withKeyValueArgs('--arg', undefined).build(), '', 'The command line should not contain the value.'));
+        testBuilder('With values', builder => builder.withKeyValueArgs('--arg', { key1: 'value1', key2: 'value2' }), '--arg "key1=value1" --arg "key2=value2"', 'The command line should contain the values.');
+        testBuilder('With value', builder => builder.withKeyValueArgs('--arg', { key1: 'value1' }), '--arg "key1=value1"', 'The command line should contain the value.');
+        testBuilder('With empty', builder => builder.withKeyValueArgs('--arg', {}), '', 'The command line should not contain the value.');
+        testBuilder('With undefined', builder => builder.withKeyValueArgs('--arg', undefined), '', 'The command line should not contain the value.');
     });
 
     suite('withNamedArg', () => {
-        test('With value', () => assert.equal(CommandLineBuilder.create().withNamedArg('--arg', 'value').build(), '--arg "value"', 'The command line should contain the value.'));
-        test('With undefined', () => assert.equal(CommandLineBuilder.create().withNamedArg('--arg', undefined).build(), '', 'The command line should not contain the value.'));
+        testBuilder('With value', builder => builder.withNamedArg('--arg', 'value'), '--arg "value"', 'The command line should contain the value.');
+        testBuilder('With undefined', builder => builder.withNamedArg('--arg', undefined), '', 'The command line should not contain the value.');
     });
 
     suite('withQuotedArg', () => {
-        test('With value', () => assert.equal(CommandLineBuilder.create().withQuotedArg('value').build(), '"value"', 'The command line should contain the value.'));
-        test('With undefined', () => assert.equal(CommandLineBuilder.create().withQuotedArg(undefined).build(), '', 'The command line should not contain the value.'));
+        testBuilder('With value', builder => builder.withQuotedArg('value'), '"value"', 'The command line should contain the value.');
+        testBuilder('With undefined', builder => builder.withQuotedArg(undefined), '', 'The command line should not contain the value.');
     });
 });

--- a/test/debugging/coreclr/commandLineBuilder.test.ts
+++ b/test/debugging/coreclr/commandLineBuilder.test.ts
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
 import * as assert from 'assert';
 import CommandLineBuilder from '../../../debugging/coreclr/commandLineBuilder';
 

--- a/test/debugging/coreclr/commandLineBuilder.test.ts
+++ b/test/debugging/coreclr/commandLineBuilder.test.ts
@@ -1,0 +1,48 @@
+import * as assert from 'assert';
+import CommandLineBuilder from '../../../debugging/coreclr/commandLineBuilder';
+
+suite('debugging/coreclr/CommandLineBuilder', () => {
+    suite('create', () => {
+        test('No args', () => assert.equal(CommandLineBuilder.create().build(), '', 'No arguments should return an empty command line.'));
+    });
+
+    suite('withArg', () => {
+        test('With value', () => assert.equal(CommandLineBuilder.create().withArg('value').build(), 'value', 'The command line should contain the value.'));
+        test('With undefined', () => assert.equal(CommandLineBuilder.create().withArg(undefined).build(), '', 'The command line should not contain the value.'));
+    });
+
+    suite('withArgFactory', () => {
+        test('With factory', () => assert.equal(CommandLineBuilder.create().withArgFactory(() => 'value').build(), 'value', 'The command line should contain the value.'));
+        test('With undefined', () => assert.equal(CommandLineBuilder.create().withArgFactory(undefined).build(), '', 'The command line should not contain the value.'));
+    });
+
+    suite('withArrayArgs', () => {
+        test('With values', () => assert.equal(CommandLineBuilder.create().withArrayArgs('--arg', ['value1', 'value2']).build(), '--arg "value1" --arg "value2"', 'The command line should contain the values.'));
+        test('With value', () => assert.equal(CommandLineBuilder.create().withArrayArgs('--arg', ['value1']).build(), '--arg "value1"', 'The command line should contain the value.'));
+        test('With empty', () => assert.equal(CommandLineBuilder.create().withArrayArgs('--arg', []).build(), '', 'The command line should not contain the value.'));
+        test('With undefined', () => assert.equal(CommandLineBuilder.create().withArrayArgs('--arg', undefined).build(), '', 'The command line should not contain the value.'));
+    });
+
+    suite('withFlagArg', () => {
+        test('With true', () => assert.equal(CommandLineBuilder.create().withFlagArg('--arg', true).build(), '--arg', 'The command line should contain the value.'));
+        test('With false', () => assert.equal(CommandLineBuilder.create().withFlagArg('--arg', false).build(), '', 'The command line should not contain the value.'));
+        test('With undefined', () => assert.equal(CommandLineBuilder.create().withFlagArg('--arg', undefined).build(), '', 'The command line should not contain the value.'));
+    });
+
+    suite('withKeyValueArgs', () => {
+        test('With values', () => assert.equal(CommandLineBuilder.create().withKeyValueArgs('--arg', { key1: 'value1', key2: 'value2' }).build(), '--arg "key1=value1" --arg "key2=value2"', 'The command line should contain the values.'));
+        test('With value', () => assert.equal(CommandLineBuilder.create().withKeyValueArgs('--arg', { key1: 'value1' }).build(), '--arg "key1=value1"', 'The command line should contain the value.'));
+        test('With empty', () => assert.equal(CommandLineBuilder.create().withKeyValueArgs('--arg', {}).build(), '', 'The command line should not contain the value.'));
+        test('With undefined', () => assert.equal(CommandLineBuilder.create().withKeyValueArgs('--arg', undefined).build(), '', 'The command line should not contain the value.'));
+    });
+
+    suite('withNamedArg', () => {
+        test('With value', () => assert.equal(CommandLineBuilder.create().withNamedArg('--arg', 'value').build(), '--arg "value"', 'The command line should contain the value.'));
+        test('With undefined', () => assert.equal(CommandLineBuilder.create().withNamedArg('--arg', undefined).build(), '', 'The command line should not contain the value.'));
+    });
+
+    suite('withQuotedArg', () => {
+        test('With value', () => assert.equal(CommandLineBuilder.create().withQuotedArg('value').build(), '"value"', 'The command line should contain the value.'));
+        test('With undefined', () => assert.equal(CommandLineBuilder.create().withQuotedArg(undefined).build(), '', 'The command line should not contain the value.'));
+    });
+});

--- a/test/debugging/coreclr/dockerManager.test.ts
+++ b/test/debugging/coreclr/dockerManager.test.ts
@@ -1,0 +1,146 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import assert = require("assert");
+import { DockerBuildImageOptions } from "../../../debugging/coreclr/dockerClient";
+import { compareBuildImageOptions } from "../../../debugging/coreclr/dockerManager";
+
+suite('debugging/coreclr/dockerManager', () => {
+    suite('compareBuildImageOptions', () => {
+        function testComparison(name: string, options1: DockerBuildImageOptions | undefined, options2: DockerBuildImageOptions | undefined, expected: boolean, message: string) {
+            test(name, () => assert.equal(compareBuildImageOptions(options1, options2), expected, message));
+        }
+
+        function testComparisonOfProperty<U extends keyof DockerBuildImageOptions>(property: U, included: boolean = true) {
+            suite(property, () => {
+                test('Options undefined', () => {
+                    const options1: DockerBuildImageOptions = {};
+
+                    options1[property] = undefined;
+
+                    const options2: DockerBuildImageOptions = undefined;
+
+                    assert.equal(compareBuildImageOptions(options1, options2), true, 'Property undefined equates to options undefined.');
+                });
+
+                test('Property unspecified', () => {
+                    const options1: DockerBuildImageOptions = {};
+
+                    options1[property] = undefined;
+
+                    const options2: DockerBuildImageOptions = {};
+
+                    assert.equal(compareBuildImageOptions(options1, options2), true, 'Property undefined equates to property unspecified.');
+                });
+
+                test('Properties equal', () => {
+                    const options1: DockerBuildImageOptions = {};
+
+                    options1[property] = 'value';
+
+                    const options2: DockerBuildImageOptions = {};
+
+                    options2[property] = 'value';
+
+                    assert.equal(compareBuildImageOptions(options1, options2), true, 'Equal properties should be equal.');
+                });
+
+                test('Properties different', () => {
+                    const options1: DockerBuildImageOptions = {};
+
+                    options1[property] = 'value1';
+
+                    const options2: DockerBuildImageOptions = {};
+
+                    options2[property] = 'value2';
+
+                    assert.equal(compareBuildImageOptions(options1, options2), !included, 'Different properties should be unequal.');
+                });
+            });
+        }
+
+        function testComparisonOfDictionary<U extends keyof DockerBuildImageOptions>(property: U, included: boolean = true) {
+            suite(property, () => {
+                test('Options undefined', () => {
+                    const options1: DockerBuildImageOptions = {};
+
+                    options1[property] = undefined;
+
+                    const options2: DockerBuildImageOptions = undefined;
+
+                    assert.equal(compareBuildImageOptions(options1, options2), true, 'Dictionary undefined equates to options undefined.');
+                });
+
+                test('Dictionary unspecified', () => {
+                    const options1: DockerBuildImageOptions = {};
+
+                    options1[property] = undefined;
+
+                    const options2: DockerBuildImageOptions = {};
+
+                    assert.equal(compareBuildImageOptions(options1, options2), true, 'Dictionary undefined equates to dictionary unspecified.');
+                });
+
+                test('Dictionary empty', () => {
+                    const options1: DockerBuildImageOptions = {};
+
+                    options1[property] = {};
+
+                    const options2: DockerBuildImageOptions = {};
+
+                    options2[property] = {};
+
+                    assert.equal(compareBuildImageOptions(options1, options2), true, 'Empty dictionaries should be equal.');
+                });
+
+                test('Dictionary equal', () => {
+                    const options1: DockerBuildImageOptions = {};
+
+                    options1[property] = { arg1: 'value1', arg2: 'value2' };
+
+                    const options2: DockerBuildImageOptions = {};
+
+                    options2[property] = { arg1: 'value1', arg2: 'value2' };
+
+                    assert.equal(compareBuildImageOptions(options1, options2), true, 'Equal dictionaries should be equal.');
+                });
+
+                test('Dictionary different keys', () => {
+                    const options1: DockerBuildImageOptions = {};
+
+                    options1[property] = { arg1: 'value1', arg2: 'value2' };
+
+                    const options2: DockerBuildImageOptions = {};
+
+                    options2[property] = { arg2: 'value2', arg3: 'value3' };
+
+                    assert.equal(compareBuildImageOptions(options1, options2), !included, 'Different properties should be unequal.');
+                });
+
+                test('Dictionary different values', () => {
+                    const options1: DockerBuildImageOptions = {};
+
+                    options1[property] = { arg1: 'value1', arg2: 'value2' };
+
+                    const options2: DockerBuildImageOptions = {};
+
+                    options2[property] = { arg1: 'value1', arg2: 'value3' };
+
+                    assert.equal(compareBuildImageOptions(options1, options2), !included, 'Different properties should be unequal.');
+                });
+            });
+        }
+
+        testComparison('Both undefined', undefined, undefined, true, 'Both being undefined are considered equal.');
+        testComparison('One undefined, one empty', undefined, {}, true, 'Undefined and empty are considered equal.');
+        testComparison('Both empty', {}, {}, true, 'Both empty are considered equal.');
+
+        testComparisonOfProperty('context');
+        testComparisonOfProperty('dockerfile', false);
+        testComparisonOfProperty('tag');
+
+        testComparisonOfDictionary('args');
+        testComparisonOfDictionary('labels');
+    });
+});

--- a/test/debugging/coreclr/lineSplitter.test.ts
+++ b/test/debugging/coreclr/lineSplitter.test.ts
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
 import * as assert from 'assert';
 import LineSplitter from '../../../debugging/coreclr/lineSplitter';
 

--- a/test/debugging/coreclr/lineSplitter.test.ts
+++ b/test/debugging/coreclr/lineSplitter.test.ts
@@ -1,45 +1,41 @@
 import * as assert from 'assert';
 import LineSplitter from '../../../debugging/coreclr/lineSplitter';
 
-suite('debugging', () => {
-    suite('coreclr', () => {
-        suite('LineSplitter', () => {
-            const testCase = (name: string, input: string | string[], output: string[]) => {
-                test(name, () => {
-                    const splitter = new LineSplitter();
+suite('debugging/coreclr/LineSplitter', () => {
+    const testCase = (name: string, input: string | string[], output: string[]) => {
+        test(name, () => {
+            const splitter = new LineSplitter();
 
-                    const lines: string[] = [];
+            const lines: string[] = [];
 
-                    splitter.onLine(line => lines.push(line));
+            splitter.onLine(line => lines.push(line));
 
-                    if (typeof input === 'string') {
-                        splitter.write(input);
-                    } else {
-                        for (let i = 0; i < input.length; i++) {
-                            splitter.write(input[i]);
-                        }
-                    }
+            if (typeof input === 'string') {
+                splitter.write(input);
+            } else {
+                for (let i = 0; i < input.length; i++) {
+                    splitter.write(input[i]);
+                }
+            }
 
-                    splitter.close();
+            splitter.close();
 
-                    assert.deepEqual(lines, output, 'The number or contents of the lines are not the same.');
-                });
-            };
-
-            testCase('Empty string', '', []);
-            testCase('Only LF', '\n', ['']);
-            testCase('CR & LF', '\r\n', ['']);
-            testCase('Multiple LFs', '\n\n', ['', '']);
-            testCase('Multiple CR & LFs', '\r\n\r\n', ['', '']);
-            testCase('Single line', 'line one', ['line one']);
-            testCase('Leading LF', '\nline two', ['', 'line two']);
-            testCase('Leading CR & LF', '\r\nline two', ['', 'line two']);
-            testCase('Trailing LF', 'line one\n', ['line one']);
-            testCase('Trailing CR & LF', 'line one\r\n', ['line one']);
-            testCase('Multiple lines with LF', 'line one\nline two', ['line one', 'line two']);
-            testCase('Multiple lines with CR & LF', 'line one\r\nline two', ['line one', 'line two']);
-            testCase('CR & LF spanning writes', ['line one\r', '\nline two'], ['line one', 'line two']);
+            assert.deepEqual(lines, output, 'The number or contents of the lines are not the same.');
         });
-    });
+    };
+
+    testCase('Empty string', '', []);
+    testCase('Only LF', '\n', ['']);
+    testCase('CR & LF', '\r\n', ['']);
+    testCase('Multiple LFs', '\n\n', ['', '']);
+    testCase('Multiple CR & LFs', '\r\n\r\n', ['', '']);
+    testCase('Single line', 'line one', ['line one']);
+    testCase('Leading LF', '\nline two', ['', 'line two']);
+    testCase('Leading CR & LF', '\r\nline two', ['', 'line two']);
+    testCase('Trailing LF', 'line one\n', ['line one']);
+    testCase('Trailing CR & LF', 'line one\r\n', ['line one']);
+    testCase('Multiple lines with LF', 'line one\nline two', ['line one', 'line two']);
+    testCase('Multiple lines with CR & LF', 'line one\r\nline two', ['line one', 'line two']);
+    testCase('CR & LF spanning writes', ['line one\r', '\nline two'], ['line one', 'line two']);
 });
 

--- a/test/debugging/coreclr/prereqManager.test.ts
+++ b/test/debugging/coreclr/prereqManager.test.ts
@@ -12,204 +12,200 @@ import { PlatformOS } from '../../../utils/platform';
 import { DockerClient } from '../../../debugging/coreclr/dockerClient';
 import { DotNetClient } from '../../../debugging/coreclr/dotNetClient';
 
-suite('debugging', () => {
-    suite('coreclr', () => {
-        suite('prereqManager', () => {
-            suite('DockerDaemonIsLinuxPrerequisite', () => {
-                const generateTest = (name: string, result: boolean, os: PlatformOS) => {
-                    test(name, async () => {
-                        let gotVersion = false;
+suite('debugging/coreclr/prereqManager', () => {
+    suite('DockerDaemonIsLinuxPrerequisite', () => {
+        const generateTest = (name: string, result: boolean, os: PlatformOS) => {
+            test(name, async () => {
+                let gotVersion = false;
 
-                        const dockerClient = <DockerClient>{
-                            getVersion: (options) => {
-                                gotVersion = true;
+                const dockerClient = <DockerClient>{
+                    getVersion: (options) => {
+                        gotVersion = true;
 
-                                assert.deepEqual(options, { format: '{{json .Server.Os}}' }, 'The server OS should be requested, in JSON format.');
+                        assert.deepEqual(options, { format: '{{json .Server.Os}}' }, 'The server OS should be requested, in JSON format.');
 
-                                return Promise.resolve(`"${os.toLowerCase()}"`);
-                            }
-                        };
-
-                        let shown = false;
-
-                        const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
-                            shown = true;
-                            return Promise.resolve<vscode.MessageItem | undefined>(undefined);
-                        };
-
-                        const prerequisite = new DockerDaemonIsLinuxPrerequisite(dockerClient, showErrorMessage);
-
-                        const prereqResult = await prerequisite.checkPrerequisite();
-
-                        assert.equal(gotVersion, true, 'The Docker version should have been requested.');
-
-                        assert.equal(prereqResult, result, 'The prerequisite should return `false`.');
-                        assert.equal(shown, !result, `An error message should ${result ? 'not ' : ''} have been shown.`);
-                    });
-                }
-
-                generateTest('Linux daemon', true, 'Linux');
-                generateTest('Windows daemon', false, 'Windows');
-            });
-
-            suite('DotNetSdkInstalledPrerequisite', () => {
-                test('Installed', async () => {
-                    const msBuildClient = <DotNetClient>{
-                        getVersion: () => Promise.resolve('2.1.402')
-                    };
-
-                    let shown = false;
-
-                    const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
-                        shown = true;
-                        return Promise.resolve<vscode.MessageItem | undefined>(undefined);
-                    };
-
-                    const prerequisite = new DotNetSdkInstalledPrerequisite(msBuildClient, showErrorMessage);
-
-                    const prereqResult = await prerequisite.checkPrerequisite();
-
-                    assert.equal(prereqResult, true, 'The prerequisite should pass if the SDK is installed.');
-                    assert.equal(shown, false, 'No error should be shown.');
-                });
-
-                test('Not installed', async () => {
-                    const msBuildClient = <DotNetClient>{
-                        getVersion: () => Promise.resolve(undefined)
-                    };
-
-                    let shown = false;
-
-                    const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
-                        shown = true;
-                        return Promise.resolve<vscode.MessageItem | undefined>(undefined);
-                    };
-
-                    const prerequisite = new DotNetSdkInstalledPrerequisite(msBuildClient, showErrorMessage);
-
-                    const prereqResult = await prerequisite.checkPrerequisite();
-
-                    assert.equal(prereqResult, false, 'The prerequisite should fail if no SDK is installed.');
-                    assert.equal(shown, true, 'An error should be shown.');
-                });
-            });
-
-            suite('LinuxUserInDockerGroupPrerequisite', () => {
-                const generateTest = (name: string, result: boolean, os: PlatformOS, isMac?: boolean, inGroup?: boolean) => {
-                    test(name, async () => {
-                        const osProvider = <OSProvider>{
-                            os,
-                            isMac
-                        }
-
-                        let processProvider = <ProcessProvider>{};
-                        let listed = false;
-
-                        if (os === 'Linux' && !isMac) {
-                            processProvider = <ProcessProvider>{
-                                exec: (command: string, _) => {
-                                    listed = true;
-
-                                    assert.equal(command, 'id -Gn', 'The prerequisite should list the user\'s groups.')
-
-                                    const groups = inGroup ? 'groupA docker groupB' : 'groupA groupB';
-
-                                    return Promise.resolve({ stdout: groups, stderr: ''});
-                                }
-                            };
-                        }
-
-                        let shown = false;
-
-                        const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
-                            shown = true;
-                            return Promise.resolve<vscode.MessageItem | undefined>(undefined);
-                        };
-
-                        const prerequisite = new LinuxUserInDockerGroupPrerequisite(osProvider, processProvider, showErrorMessage);
-
-                        const prereqResult = await prerequisite.checkPrerequisite();
-
-                        if (os === 'Linux' && !isMac) {
-                            assert.equal(listed, true, 'The user\'s groups should have been listed.');
-                        }
-
-                        assert.equal(prereqResult, result, 'The prerequisite should return `false`.');
-                        assert.equal(shown, !result, `An error message should ${result ? 'not ' : ''} have been shown.`);
-                    });
+                        return Promise.resolve(`"${os.toLowerCase()}"`);
+                    }
                 };
 
-                generateTest('Windows: No-op', true, 'Windows');
-                generateTest('Mac: No-op', true, 'Linux', true);
-                generateTest('Linux: In group', true, 'Linux', false, true);
-                generateTest('Linux: Not in group', false, 'Linux', false, false);
+                let shown = false;
+
+                const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
+                    shown = true;
+                    return Promise.resolve<vscode.MessageItem | undefined>(undefined);
+                };
+
+                const prerequisite = new DockerDaemonIsLinuxPrerequisite(dockerClient, showErrorMessage);
+
+                const prereqResult = await prerequisite.checkPrerequisite();
+
+                assert.equal(gotVersion, true, 'The Docker version should have been requested.');
+
+                assert.equal(prereqResult, result, 'The prerequisite should return `false`.');
+                assert.equal(shown, !result, `An error message should ${result ? 'not ' : ''} have been shown.`);
             });
+        }
 
-            suite('MacNuGetFallbackFolderSharedPrerequisite', () => {
-                const generateTest = (name: string, fileContents: string | undefined, result: boolean) => {
-                    const settingsPath = '/Users/User/Library/Group Containers/group.com.docker/settings.json';
+        generateTest('Linux daemon', true, 'Linux');
+        generateTest('Windows daemon', false, 'Windows');
+    });
 
-                    test(name, async () => {
-                        const fsProvider = <FileSystemProvider>{
-                            fileExists: (path: string) => {
-                                assert.equal(settingsPath, path, 'The prerequisite should check for the settings file in the user\'s home directory.');
+    suite('DotNetSdkInstalledPrerequisite', () => {
+        test('Installed', async () => {
+            const msBuildClient = <DotNetClient>{
+                getVersion: () => Promise.resolve('2.1.402')
+            };
 
-                                return Promise.resolve(fileContents !== undefined);
-                            },
-                            readFile: (path: string) => {
-                                if (fileContents === undefined) {
-                                    assert.fail('The prerequisite should not attempt to read a file that does not exist.');
-                                }
+            let shown = false;
 
-                                assert.equal(settingsPath, path, 'The prerequisite should read the settings file in the user\'s home directory.');
+            const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
+                shown = true;
+                return Promise.resolve<vscode.MessageItem | undefined>(undefined);
+            };
 
-                                return Promise.resolve(fileContents);
-                            }
-                        };
+            const prerequisite = new DotNetSdkInstalledPrerequisite(msBuildClient, showErrorMessage);
 
-                        const osProvider = <OSProvider>{
-                            homedir: '/Users/User',
-                            isMac: true
-                        };
+            const prereqResult = await prerequisite.checkPrerequisite();
 
-                        let shown = false;
+            assert.equal(prereqResult, true, 'The prerequisite should pass if the SDK is installed.');
+            assert.equal(shown, false, 'No error should be shown.');
+        });
 
-                        const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
-                            shown = true;
-                            return Promise.resolve<vscode.MessageItem | undefined>(undefined);
-                        };
+        test('Not installed', async () => {
+            const msBuildClient = <DotNetClient>{
+                getVersion: () => Promise.resolve(undefined)
+            };
 
-                        const prereq = new MacNuGetFallbackFolderSharedPrerequisite(fsProvider, osProvider, showErrorMessage);
+            let shown = false;
 
-                        const prereqResult = await prereq.checkPrerequisite();
+            const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
+                shown = true;
+                return Promise.resolve<vscode.MessageItem | undefined>(undefined);
+            };
 
-                        assert.equal(prereqResult, result, 'The prerequisite should return `false`.');
-                        assert.equal(shown, !result, `An error message should ${result ? 'not ' : ''} have been shown.`);
-                    });
+            const prerequisite = new DotNetSdkInstalledPrerequisite(msBuildClient, showErrorMessage);
+
+            const prereqResult = await prerequisite.checkPrerequisite();
+
+            assert.equal(prereqResult, false, 'The prerequisite should fail if no SDK is installed.');
+            assert.equal(shown, true, 'An error should be shown.');
+        });
+    });
+
+    suite('LinuxUserInDockerGroupPrerequisite', () => {
+        const generateTest = (name: string, result: boolean, os: PlatformOS, isMac?: boolean, inGroup?: boolean) => {
+            test(name, async () => {
+                const osProvider = <OSProvider>{
+                    os,
+                    isMac
                 }
 
-                generateTest('Mac: no Docker settings file', undefined, true);
-                generateTest('Mac: no shared folders in Docker settings file', '{}', true);
-                generateTest('Mac: no NuGetFallbackFolder in Docker settings file', '{ "filesharingDirectories": [] }', false);
-                generateTest('Mac: NuGetFallbackFolder in Docker settings file', '{ "filesharingDirectories": [ "/usr/local/share/dotnet/sdk/NuGetFallbackFolder" ] }', true);
+                let processProvider = <ProcessProvider>{};
+                let listed = false;
 
-                test('Non-Mac: No-op', async () => {
-                    const osProvider = <OSProvider>{
-                        isMac: false
+                if (os === 'Linux' && !isMac) {
+                    processProvider = <ProcessProvider>{
+                        exec: (command: string, _) => {
+                            listed = true;
+
+                            assert.equal(command, 'id -Gn', 'The prerequisite should list the user\'s groups.')
+
+                            const groups = inGroup ? 'groupA docker groupB' : 'groupA groupB';
+
+                            return Promise.resolve({ stdout: groups, stderr: ''});
+                        }
                     };
+                }
 
-                    const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
-                        assert.fail('Should not be called on non-Mac.');
-                        return Promise.resolve<vscode.MessageItem | undefined>(undefined);
-                    };
+                let shown = false;
 
-                    const prereq = new MacNuGetFallbackFolderSharedPrerequisite(<FileSystemProvider>{}, osProvider, showErrorMessage);
+                const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
+                    shown = true;
+                    return Promise.resolve<vscode.MessageItem | undefined>(undefined);
+                };
 
-                    const result = await prereq.checkPrerequisite();
+                const prerequisite = new LinuxUserInDockerGroupPrerequisite(osProvider, processProvider, showErrorMessage);
 
-                    assert.equal(true, result, 'The prerequisite should return `true` on non-Mac.');
-                });
+                const prereqResult = await prerequisite.checkPrerequisite();
+
+                if (os === 'Linux' && !isMac) {
+                    assert.equal(listed, true, 'The user\'s groups should have been listed.');
+                }
+
+                assert.equal(prereqResult, result, 'The prerequisite should return `false`.');
+                assert.equal(shown, !result, `An error message should ${result ? 'not ' : ''} have been shown.`);
             });
+        };
+
+        generateTest('Windows: No-op', true, 'Windows');
+        generateTest('Mac: No-op', true, 'Linux', true);
+        generateTest('Linux: In group', true, 'Linux', false, true);
+        generateTest('Linux: Not in group', false, 'Linux', false, false);
+    });
+
+    suite('MacNuGetFallbackFolderSharedPrerequisite', () => {
+        const generateTest = (name: string, fileContents: string | undefined, result: boolean) => {
+            const settingsPath = '/Users/User/Library/Group Containers/group.com.docker/settings.json';
+
+            test(name, async () => {
+                const fsProvider = <FileSystemProvider>{
+                    fileExists: (path: string) => {
+                        assert.equal(settingsPath, path, 'The prerequisite should check for the settings file in the user\'s home directory.');
+
+                        return Promise.resolve(fileContents !== undefined);
+                    },
+                    readFile: (path: string) => {
+                        if (fileContents === undefined) {
+                            assert.fail('The prerequisite should not attempt to read a file that does not exist.');
+                        }
+
+                        assert.equal(settingsPath, path, 'The prerequisite should read the settings file in the user\'s home directory.');
+
+                        return Promise.resolve(fileContents);
+                    }
+                };
+
+                const osProvider = <OSProvider>{
+                    homedir: '/Users/User',
+                    isMac: true
+                };
+
+                let shown = false;
+
+                const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
+                    shown = true;
+                    return Promise.resolve<vscode.MessageItem | undefined>(undefined);
+                };
+
+                const prereq = new MacNuGetFallbackFolderSharedPrerequisite(fsProvider, osProvider, showErrorMessage);
+
+                const prereqResult = await prereq.checkPrerequisite();
+
+                assert.equal(prereqResult, result, 'The prerequisite should return `false`.');
+                assert.equal(shown, !result, `An error message should ${result ? 'not ' : ''} have been shown.`);
+            });
+        }
+
+        generateTest('Mac: no Docker settings file', undefined, true);
+        generateTest('Mac: no shared folders in Docker settings file', '{}', true);
+        generateTest('Mac: no NuGetFallbackFolder in Docker settings file', '{ "filesharingDirectories": [] }', false);
+        generateTest('Mac: NuGetFallbackFolder in Docker settings file', '{ "filesharingDirectories": [ "/usr/local/share/dotnet/sdk/NuGetFallbackFolder" ] }', true);
+
+        test('Non-Mac: No-op', async () => {
+            const osProvider = <OSProvider>{
+                isMac: false
+            };
+
+            const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
+                assert.fail('Should not be called on non-Mac.');
+                return Promise.resolve<vscode.MessageItem | undefined>(undefined);
+            };
+
+            const prereq = new MacNuGetFallbackFolderSharedPrerequisite(<FileSystemProvider>{}, osProvider, showErrorMessage);
+
+            const result = await prereq.checkPrerequisite();
+
+            assert.equal(true, result, 'The prerequisite should return `true` on non-Mac.');
         });
     });
 });

--- a/thirdpartynotices.txt
+++ b/thirdpartynotices.txt
@@ -397,3 +397,24 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+12. deep-equal (https://github.com/substack/node-deep-equal)
+
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+


### PR DESCRIPTION
Allows users to further customize Docker images and containers used during debugging.  

The following build customizations were added:

 - **`args`:** Set or override build arguments (i.e. `ARG`) declared in the `Dockerfile`
 - **`labels`:** Dynamically apply labels to the image

The following run customizations were added:

 - **`env`:** Set or override environment variables applied to the container
 - **`envFiles`:** Apply sets of environment variables, defined in arbitrary files, to the container
 - **`labels`:** Dynamically apply labels to the container

This brings the Docker debugging customizations closer to parity with VS.

> NOTE: This PR adds a dependency on [deep-equal](https://github.com/substack/node-deep-equal)