### PR TITLE
.NET Core debugging with LCOW

### DIFF
--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -128,11 +128,12 @@ export class CliDockerClient implements DockerClient {
     }
 
     public async getInfo(options?: DockerInfoOptions): Promise<string> {
-        let command = 'docker info';
+        options = options || {};
 
-        if (options && options.format) {
-            command += ` --format "${options.format}"`;
-        }
+        const command = CommandLineBuilder
+            .create('docker', 'info')
+            .withNamedArg('--format', options.format)
+            .build();
 
         const result = await this.processProvider.exec(command, {});
 

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -8,9 +8,14 @@ import { ProcessProvider } from "./processProvider";
 export type DockerBuildImageOptions = {
     context?: string;
     dockerfile?: string;
+    platform?: string;
     tag?: string;
     target?: string;
 };
+
+export type DockerInfoOptions = {
+    format?: string;
+}
 
 export type DockerInspectObjectOptions = {
     format?: string;
@@ -34,6 +39,7 @@ export type DockerRunContainerOptions = {
     command?: string;
     containerName?: string;
     entrypoint?: string;
+    platform?: string;
     volumes?: DockerContainerVolume[];
 };
 
@@ -43,6 +49,7 @@ export type DockerVersionOptions = {
 
 export interface DockerClient {
     buildImage(options: DockerBuildImageOptions, progress?: (content: string) => void): Promise<string>;
+    getInfo(options?: DockerInfoOptions): Promise<string>;
     getVersion(options?: DockerVersionOptions): Promise<string>;
     inspectObject(nameOrId: string, options?: DockerInspectObjectOptions): Promise<string | undefined>;
     listContainers(options?: DockerContainersListOptions): Promise<string>;
@@ -62,6 +69,10 @@ export class CliDockerClient implements DockerClient {
 
         if (options && options.dockerfile) {
             command += ` -f ${options.dockerfile}`;
+        }
+
+        if (options && options.platform) {
+            command += ` --platform "${options.platform}"`;
         }
 
         if (options && options.tag) {
@@ -108,6 +119,18 @@ export class CliDockerClient implements DockerClient {
         }
 
         return imageId;
+    }
+
+    public async getInfo(options?: DockerInfoOptions): Promise<string> {
+        let command = 'docker info';
+
+        if (options && options.format) {
+            command += ` --format "${options.format}"`;
+        }
+
+        const result = await this.processProvider.exec(command, {});
+
+        return result.stdout;
     }
 
     public async getVersion(options?: DockerVersionOptions): Promise<string> {
@@ -186,6 +209,10 @@ export class CliDockerClient implements DockerClient {
 
         if (options && options.containerName) {
             command += ` --name ${options.containerName}`;
+        }
+
+        if (options && options.platform) {
+            command += ` --platform "${options.platform}"`;
         }
 
         if (options && options.volumes) {

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -67,6 +67,13 @@ export interface DockerClient {
     trimId(id: string): string;
 }
 
+export async function isLcowEnabled(dockerClient: DockerClient): Promise<boolean> {
+    const driverJson = await dockerClient.getInfo({ format: '{{json .Driver}}' });
+    const driver = <string>JSON.parse(driverJson.trim());
+
+    return  driver.toLowerCase().search('lcow') >= 0;
+}
+
 export class CliDockerClient implements DockerClient {
     constructor(private readonly processProvider: ProcessProvider) {
         // CONSIDER: Use dockerode client as basis for debugging.

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -6,12 +6,14 @@ import CommandLineBuilder from "./commandLineBuilder";
 import { LineSplitter } from "./lineSplitter";
 import { ProcessProvider } from "./processProvider";
 
+export type DockerPlatform = 'linux' | 'windows';
+
 export type DockerBuildImageOptions = {
     args?: { [key: string]: string };
     context?: string;
     dockerfile?: string;
     labels?: { [key: string]: string };
-    platform?: string;
+    platform?: DockerPlatform;
     tag?: string;
     target?: string;
 };
@@ -45,7 +47,7 @@ export type DockerRunContainerOptions = {
     env?: { [key: string]: string };
     envFiles?: string[];
     labels?: { [key: string]: string };
-    platform?: string;
+    platform?: DockerPlatform;
     volumes?: DockerContainerVolume[];
 };
 

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -22,7 +22,6 @@ interface DockerDebugBuildOptions {
 
 interface DockerDebugRunOptions {
     containerName?: string;
-    os?: PlatformOS;
 }
 
 interface DebugConfigurationBrowserBaseOptions {
@@ -123,11 +122,9 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
             ? debugConfiguration.dockerRun.containerName
             : `${appName}-dev`; // CONSIDER: Use unique ID instead?
 
-        const os = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.os
-            ? debugConfiguration.dockerRun.os
-            : 'Linux';
+        const platform: PlatformOS = "Linux"; // NOTE: We only support Linux containers at this time
 
-        const appOutput = await this.inferAppOutput(debugConfiguration, os, resolvedAppProject);
+        const appOutput = await this.inferAppOutput(debugConfiguration, platform, resolvedAppProject);
 
         const result = await this.dockerManager.prepareForLaunch({
             appFolder: resolvedAppFolder,
@@ -138,9 +135,9 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
                 tag,
                 target
             },
+            platform,
             run: {
                 containerName,
-                os,
             }
         });
 

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -107,9 +107,9 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         const appName = path.basename(resolvedAppProject, '.csproj');
 
-        const platform: PlatformOS = "Linux"; // NOTE: We only support Linux containers at this time
+        const os: PlatformOS = "Linux"; // NOTE: We only support Linux containers at this time
 
-        const appOutput = await this.inferAppOutput(debugConfiguration, platform, resolvedAppProject);
+        const appOutput = await this.inferAppOutput(debugConfiguration, os, resolvedAppProject);
 
         const buildOptions = DockerDebugConfigurationProvider.inferBuildOptions(folder, debugConfiguration, appFolder, resolvedAppFolder, appName);
         const runOptions = DockerDebugConfigurationProvider.inferRunOptions(folder, debugConfiguration, appName);
@@ -118,7 +118,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
             appFolder: resolvedAppFolder,
             appOutput,
             build: buildOptions,
-            platform,
+            os,
             run: runOptions
         });
 

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -274,7 +274,7 @@ export class DefaultDockerManager implements DockerManager {
     private async getDockerPlatform(platform: PlatformOS): Promise<string | undefined> {
         if (platform === 'Linux' && this.osProvider.os === 'Windows') {
             const driverJson = await this.dockerClient.getInfo({ format: '{{json .Driver}}' });
-            const driver: string = JSON.parse(driverJson.trim());
+            const driver = <string>JSON.parse(driverJson.trim());
 
             if (driver.toLowerCase().search('lcow') >= 0) {
                 // Docker for Windows is using Windows containers by default but has LCOW enabled, so 'linux' platform must be explicitly specified...

--- a/debugging/coreclr/prereqManager.ts
+++ b/debugging/coreclr/prereqManager.ts
@@ -27,7 +27,7 @@ export class DockerDaemonIsLinuxPrerequisite implements Prerequisite {
 
     public async checkPrerequisite(): Promise<boolean> {
         const daemonOsJson = await this.dockerClient.getVersion({ format: '{{json .Server.Os}}' });
-        const daemonOs: string = JSON.parse(daemonOsJson.trim());
+        const daemonOs = <string>JSON.parse(daemonOsJson.trim());
 
         if (daemonOs === 'linux') {
             return true;
@@ -35,7 +35,7 @@ export class DockerDaemonIsLinuxPrerequisite implements Prerequisite {
 
         if (this.osProvider.os === 'Windows') {
             const driverJson = await this.dockerClient.getInfo({ format: '{{json .Driver}}' });
-            const driver: string = JSON.parse(driverJson.trim());
+            const driver = <string>JSON.parse(driverJson.trim());
 
             if (driver.toLowerCase().search('lcow') >= 0) {
                 // Docker for Windows is using Windows containers by default but has LCOW enabled, allowing Linux containers...

--- a/debugging/coreclr/registerDebugger.ts
+++ b/debugging/coreclr/registerDebugger.ts
@@ -75,6 +75,7 @@ export function registerDebugConfigurationProvider(ctx: vscode.ExtensionContext)
                 new AggregatePrerequisite(
                     new DockerDaemonIsLinuxPrerequisite(
                         dockerClient,
+                        osProvider,
                         vscode.window.showErrorMessage),
                     new DotNetExtensionInstalledPrerequisite(
                         new OpnBrowserClient(),

--- a/test/debugging/coreclr/dockerManager.test.ts
+++ b/test/debugging/coreclr/dockerManager.test.ts
@@ -138,6 +138,7 @@ suite('debugging/coreclr/dockerManager', () => {
 
         testComparisonOfProperty('context');
         testComparisonOfProperty('dockerfile', false);
+        testComparisonOfProperty('platform');
         testComparisonOfProperty('tag');
 
         testComparisonOfDictionary('args');

--- a/test/debugging/coreclr/prereqManager.test.ts
+++ b/test/debugging/coreclr/prereqManager.test.ts
@@ -30,6 +30,8 @@ suite('debugging', () => {
                             }
                         };
 
+                        const osProvider = <OSProvider>{};
+
                         let shown = false;
 
                         const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {
@@ -37,7 +39,7 @@ suite('debugging', () => {
                             return Promise.resolve<vscode.MessageItem | undefined>(undefined);
                         };
 
-                        const prerequisite = new DockerDaemonIsLinuxPrerequisite(dockerClient, showErrorMessage);
+                        const prerequisite = new DockerDaemonIsLinuxPrerequisite(dockerClient, osProvider, showErrorMessage);
 
                         const prereqResult = await prerequisite.checkPrerequisite();
 


### PR DESCRIPTION
Add support for .NET Core debugging when using Docker for Windows with LCOW (Linux Containers On Windows) enabled.  Enabling LCOW allows Linux and Windows containers to be used at the same time. 
 (Without LCOW, only Linux *or* Windows containers can be used at any given time.) However, when this feature is enabled, Docker assumes Windows containers are built/run by default.  To build/run Linux containers, the `--platform Linux` argument must be specified.