### PR TITLE
Fix lint task warning

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,8 +22,8 @@
 			"args": [
 				"run",
 				"compile",
-				"--loglevel",
-				"silent"
+				//"--loglevel",
+				//"silent"
 			],
 			"isBackground": true,
 			"presentation": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,8 +22,8 @@
 			"args": [
 				"run",
 				"compile",
-				//"--loglevel",
-				//"silent"
+				"--loglevel",
+				"silent"
 			],
 			"isBackground": true,
 			"presentation": {
@@ -34,10 +34,7 @@
 		{
 			"type": "npm",
 			"script": "lint",
-			"problemMatcher": {
-				"base": "$tslint5",
-				"fileLocation": "absolute"
-			}
+			"problemMatcher": "$tslint5"
 		}
 	]
 }


### PR DESCRIPTION
Fix this error from vscode when opening project:

Error: the description can't be converted into a problem matcher:
{
    "base": "$tslint5",
    "fileLocation": "absolute"
}


