### PR TITLE
pipeline: use jobs instead of only script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,24 +6,33 @@ services:
   - docker
 
 node_js:
-  - 'stable'
+  - "stable"
+  - "7"
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
+    export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+    sh -e /etc/init.d/xvfb start;
+    sleep 3;
     fi
 
-install:
-  - npm install
+jobs:
+  include:
+    - stage: "build"
+      name: Build
+      script: npm run build
 
-script:
-  - npm run build
-  - gulp package
-  - gulp upload-vsix
-  - npm run lint
-  - npm test
+    - stage: "gulp package"
+      name: Gulp package
+      script: gulp package
+
+    - stage: "gulp upload-vsix"
+      name: Gulp upload vsix
+      script: gulp upload-vsix
+
+    - stage: "lint"
+      name: Check lint syntax
+      script: npm run lint
 
 notifications:
   email:


### PR DESCRIPTION
I've updated the travisci pipeline to use jobs instead only a script, because it's faster, cleaner and you can see better the errors in the pipeline.
An example is here -> https://travis-ci.org/wachino/vscode-docker/builds/447113342