### PR TITLE
Fix PR builds from forks

### DIFF
--- a/.azure-pipelines/common/lint.yml
+++ b/.azure-pipelines/common/lint.yml
@@ -7,3 +7,4 @@ steps:
 
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
+  condition: ne(variables['System.PullRequest.IsFork'], 'True')

--- a/.azure-pipelines/common/publish-vsix.yml
+++ b/.azure-pipelines/common/publish-vsix.yml
@@ -16,3 +16,4 @@ steps:
   inputs:
     PathtoPublish: '$(build.artifactstagingdirectory)'
     ArtifactName: vsix
+  condition: ne(variables['System.PullRequest.IsFork'], 'True')


### PR DESCRIPTION
Those builds don't have permissions for "Component Detection" and "Publish artifacts: vsix"

Example build from fork: https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=137&view=logs
Example build from non-fork: https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=136&view=logs

cc @grhm