### PR TITLE
make the launch.json generation leaner

### DIFF
--- a/configureWorkspace/configDebugProvider.ts
+++ b/configureWorkspace/configDebugProvider.ts
@@ -9,20 +9,14 @@ import * as vscode from 'vscode';
 export class DockerDebugConfigProvider implements vscode.DebugConfigurationProvider {
 
     public provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration[]> {
-
-        const config: vscode.DebugConfiguration = {
-            name: 'Docker: Attach to Node',
-            type: 'node',
-            request: 'attach',
-            port: 9229,
-            address: 'localhost',
-            localRoot: '\${workspaceFolder}',
-            remoteRoot: '/usr/src/app',
-            protocol: 'inspector'
-        };
-
-        return [config];
-
+        return vscode.window.showInputBox({ value: '/usr/src/app', prompt: 'Please enter your Docker remote root'}).then(remoteRoot => {
+            return [{
+                name: 'Docker: Attach to Node',
+                type: 'node',
+                request: 'attach',
+                remoteRoot
+            }];
+        });
     }
 
 }

--- a/configureWorkspace/configDebugProvider.ts
+++ b/configureWorkspace/configDebugProvider.ts
@@ -6,17 +6,17 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import { ext } from '../extensionVariables';
+
 export class DockerDebugConfigProvider implements vscode.DebugConfigurationProvider {
 
-    public provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration[]> {
-        return vscode.window.showInputBox({ value: '/usr/src/app', prompt: 'Please enter your Docker remote root'}).then(remoteRoot => {
-            return [{
-                name: 'Docker: Attach to Node',
-                type: 'node',
-                request: 'attach',
-                remoteRoot
-            }];
-        });
+    public async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
+        const remoteRoot = await ext.ui.showInputBox({ value: '/usr/src/app', prompt: 'Please enter your Docker remote root' });
+        return [{
+            name: 'Docker: Attach to Node',
+            type: 'node',
+            request: 'attach',
+            remoteRoot
+        }];
     }
-
 }

--- a/package.json
+++ b/package.json
@@ -287,11 +287,7 @@
               "type": "node",
               "request": "attach",
               "name": "Docker: Attach to Node",
-              "port": 9229,
-              "address": "localhost",
-              "localRoot": "^\"\\${workspaceFolder}\"",
-              "remoteRoot": "/usr/src/app",
-              "protocol": "inspector"
+              "remoteRoot": "/usr/src/app"
             }
           }
         ]


### PR DESCRIPTION
fixes #612

This PR simplifies the generated `launch.json` in the following ways:
* The snippets do not have the default fields any more, making them more concise. The missing fields should be nicely added by node
* When the initial configuraiton is provided we ask the user for the remoteRoot, making it clearer what is the attribute that users change the most

What still needs to be done imho:
* We should read the dockerfile, such that we see the value of the dockerfile WORKDIR and take that as the default, not the hardcoded `/usr/src/app`
* Read the dockerfile and see if the userconfigured a remote port, if he did than insert the port in the configuration. Currently we do not set any because the node debug will corectly pick the port based on node version
* Tune the wording of the input box, not sure if `Please enter your Docker remote root` is correct here, maybe WORKDIR instead of remote root.
* Simplify the docker .net launch configuraiton in a similar way

@StephenWeatherford let me know what you think. Thanks a lot
fyi @chrisdias 