### PR TITLE
Make sure Node.js uses internal certificates if neither certificates …

### DIFF
--- a/utils/getTrustedCertificates.ts
+++ b/utils/getTrustedCertificates.ts
@@ -16,16 +16,27 @@ let _systemCertificates: (string | Buffer)[] | undefined;
 
 export async function getTrustedCertificates(): Promise<(string | Buffer)[]> {
     // tslint:disable-next-line:no-function-expression
-    return callWithTelemetryAndErrorHandling('docker.certificates', async function (this: IActionContext): Promise<(string | Buffer)[]> {
+    return callWithTelemetryAndErrorHandling('docker.certificates', async function (this: IActionContext): Promise<(string | Buffer)[] | undefined> {
         this.suppressTelemetry = true;
 
         let useCertificateStore: boolean = !!vscode.workspace.getConfiguration('docker').get<boolean>('useCertificateStore');
         this.properties.useCertStore = String(useCertificateStore);
-        let systemCerts: (string | Buffer)[] = useCertificateStore ? getCertificatesFromSystem() : [];
+        let systemCerts: (string | Buffer)[] | undefined = useCertificateStore ? getCertificatesFromSystem() : undefined;
 
-        let certificatePaths: string[] = vscode.workspace.getConfiguration('docker').get<string[] | undefined>('certificatePaths') || [];
-        this.properties.certPathsCount = String(certificatePaths.length);
-        let filesCerts = certificatePaths ? await getCertificatesFromPaths(certificatePaths) : [];
+        let certificatePaths: string[] = vscode.workspace.getConfiguration('docker').get<string[] | null>('certificatePaths');
+        let filesCerts: Buffer[] | undefined;
+        if (Array.isArray(certificatePaths)) {
+            this.properties.certPathsCount = String(certificatePaths.length);
+            filesCerts = await getCertificatesFromPaths(certificatePaths);
+        }
+
+        if (systemCerts === undefined && filesCerts === undefined) {
+            // If neither setting is set, be sure to return undefined to get Node.js's default list of trusted certificates
+            return undefined;
+        }
+
+        systemCerts = systemCerts || [];
+        filesCerts = filesCerts || [];
 
         this.properties.systemCertsCount = String(systemCerts.length);
         this.properties.fileCertsCount = String(filesCerts.length);


### PR DESCRIPTION
…option specified

Fixes #629 

Apparently if we pass in an empty array to agentOptions.ca, Node.js will not use it hard-coded internal list of certificates, which breaks exploring ACR.