### PR TITLE
Create requirements.txt

### DIFF
--- a/configureWorkspace/configure_python.ts
+++ b/configureWorkspace/configure_python.ts
@@ -32,6 +32,7 @@ WORKDIR /app
 ADD . /app
 
 # Using pip:
+RUN pip3 freeze > requirements.txt
 RUN python3 -m pip install -r requirements.txt
 CMD ["python3", "-m", "${serviceNameAndRelativePath}"]
 


### PR DESCRIPTION
This resolves:
Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
The command '/bin/sh -c python3 -m pip install -r requirements.txt' returned a non-zero code: 1