### PR TITLE
Clean up dependencies in preparation for ThirdPartyNotices work

### DIFF
--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -236,14 +236,14 @@ export class DefaultDockerManager implements DockerManager {
         const browserUrl = await this.getContainerWebEndpoint(containerId);
 
         const additionalProbingPaths = options.run.os === 'Windows'
-        ? [
-            'C:\\.nuget\\packages',
-            'C:\\.nuget\\fallbackpackages'
-        ]
-        : [
-            '/root/.nuget/packages',
-            '/root/.nuget/fallbackpackages'
-        ];
+            ? [
+                'C:\\.nuget\\packages',
+                'C:\\.nuget\\fallbackpackages'
+            ]
+            : [
+                '/root/.nuget/packages',
+                '/root/.nuget/fallbackpackages'
+            ];
         const additionalProbingPathsArgs = additionalProbingPaths.map(probingPath => `--additionalProbingPath ${probingPath}`).join(' ');
 
         const containerAppOutput = options.run.os === 'Windows'
@@ -347,7 +347,7 @@ export class DefaultDockerManager implements DockerManager {
         }
 
         const nugetFallbackVolume: DockerContainerVolume = {
-            localPath: this.osProvider.os === 'Windows' ? path.join(<string>programFilesEnvironmentVariable, 'dotnet', 'sdk', 'NuGetFallbackFolder') : MacNuGetPackageFallbackFolderPath,
+            localPath: this.osProvider.os === 'Windows' ? path.join(programFilesEnvironmentVariable, 'dotnet', 'sdk', 'NuGetFallbackFolder') : MacNuGetPackageFallbackFolderPath,
             containerPath: options.os === 'Windows' ? 'C:\\.nuget\\fallbackpackages' : '/root/.nuget/fallbackpackages',
             permissions: 'ro'
         };

--- a/debugging/coreclr/lazy.ts
+++ b/debugging/coreclr/lazy.ts
@@ -19,7 +19,7 @@ export class Lazy<T> {
             this._isValueCreated = true;
         }
 
-        return <T>this._value;
+        return this._value;
     }
 }
 

--- a/debugging/coreclr/tempFileProvider.ts
+++ b/debugging/coreclr/tempFileProvider.ts
@@ -19,6 +19,6 @@ export class OSTempFileProvider implements TempFileProvider {
     }
 
     public getTempFilename(prefix: string = 'temp'): string {
-        return path.join(this.osProvider.tmpdir, `${prefix}_${new Date().valueOf()}_${this.processProvider.pid}_${this.count++}.tmp` );
+        return path.join(this.osProvider.tmpdir, `${prefix}_${new Date().valueOf()}_${this.processProvider.pid}_${this.count++}.tmp`);
     }
 }

--- a/explorer/utils/dockerHubUtils.ts
+++ b/explorer/utils/dockerHubUtils.ts
@@ -124,7 +124,7 @@ export async function dockerHubLogin(): Promise<{ username: string, password: st
         if (password) {
             _token = await login(username, password);
             if (_token) {
-                return { username: username, password: password, token: <string>_token.token };
+                return { username: username, password: password, token: _token.token };
             }
         }
     }
@@ -242,7 +242,7 @@ export async function getRepositoryTags(repository: Repository): Promise<Tag[]> 
         vscode.window.showErrorMessage('Docker: Unable to retrieve Repository Tags');
     }
 
-    return <Tag[]>tagsPage.results;
+    return tagsPage.results;
 }
 
 export function browseDockerHub(node?: DockerHubImageTagNode | DockerHubRepositoryNode | DockerHubOrgNode): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,16 @@
       "integrity": "sha512-Set5ZdrAaKI/qHdFlVMgm/GsAv/wkXhSTuZFkJ+JI7HK+wIkIlOaUXSXieIvJ0+OvGIqtREFoE+NHJtEq0gtEw==",
       "dev": true
     },
+    "@types/xml2js": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz",
+      "integrity": "sha512-Pv2HGRE4gWLs31In7nsyXEH4uVVsd0HNV9i2dyASvtDIlOtSTr1eczPLDpdEuyv5LWH5LT20GIXwPjkshKWI1g==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
@@ -424,12 +434,14 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "ansi-wrap": {
       "version": "0.1.0",
@@ -496,6 +508,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -807,10 +820,23 @@
         "xmlbuilder": "^9.0.7"
       },
       "dependencies": {
+        "sax": {
+          "version": "0.5.8",
+          "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+        },
         "underscore": {
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        },
+        "xml2js": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+          "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+          "requires": {
+            "sax": "0.5.x"
+          }
         }
       }
     },
@@ -984,7 +1010,8 @@
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+      "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
@@ -997,14 +1024,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.x.x"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1255,6 +1274,7 @@
       "version": "1.1.3",
       "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -1517,7 +1537,8 @@
     "commander": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -1651,126 +1672,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "coveralls": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
-      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
-      "requires": {
-        "js-yaml": "3.6.1",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
-        "minimist": "1.2.0",
-        "request": "2.79.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-        }
-      }
-    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -1823,14 +1724,6 @@
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
       "dev": true
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.x.x"
-      }
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -2583,7 +2476,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint-scope": {
       "version": "4.0.0",
@@ -2594,11 +2488,6 @@
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
-    },
-    "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -3716,22 +3605,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "requires": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "^1.0.0"
-      }
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -4934,6 +4807,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -5010,17 +4884,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -5037,11 +4900,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -5393,23 +5251,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-    },
-    "is-my-json-valid": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
-      "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -5468,11 +5309,6 @@
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-relative": {
       "version": "1.0.0",
@@ -5552,15 +5388,6 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
-    "js-yaml": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
-      }
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -5628,11 +5455,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
       "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -5703,11 +5525,6 @@
       "requires": {
         "invert-kv": "^2.0.0"
       }
-    },
-    "lcov-parse": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
     },
     "lead": {
       "version": "1.0.0",
@@ -5931,11 +5748,6 @@
         "lodash._reinterpolate": "^3.0.0",
         "lodash.escape": "^3.0.0"
       }
-    },
-    "log-driver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -7172,12 +6984,14 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -7201,33 +7015,6 @@
         "arr-diff": "^4.0.0",
         "arr-union": "^3.1.0",
         "extend-shallow": "^3.0.2"
-      }
-    },
-    "pom-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pom-parser/-/pom-parser-1.1.1.tgz",
-      "integrity": "sha1-b6tNJJjofIYgcqsgWqiLEgnl+WY=",
-      "requires": {
-        "bluebird": "^3.3.3",
-        "coveralls": "^2.11.3",
-        "traverse": "^0.6.6",
-        "xml2js": "^0.4.9"
-      },
-      "dependencies": {
-        "sax": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-        },
-        "xml2js": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-          "requires": {
-            "sax": ">=0.6.0",
-            "xmlbuilder": "~9.0.1"
-          }
-        }
       }
     },
     "posix-character-classes": {
@@ -7793,9 +7580,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
-      "version": "0.5.8",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "schema-utils": {
       "version": "0.4.7",
@@ -8038,14 +7825,6 @@
         }
       }
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.x.x"
-      }
-    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -8158,7 +7937,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.15.2",
@@ -8395,15 +8175,11 @@
       "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -8487,7 +8263,8 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "sver-compat": {
       "version": "1.5.0",
@@ -8947,11 +8724,6 @@
         }
       }
     },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-    },
     "ts-loader": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.3.1.tgz",
@@ -9094,9 +8866,9 @@
       }
     },
     "tslint-microsoft-contrib": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz",
-      "integrity": "sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz",
+      "integrity": "sha512-R//efwn+34IUjTJeYgNDAJdzG0jyLWIehygPt/PHuZAieTolFVS56FgeFW7DOLap9ghXzMiFPTmDgm54qaL7QA==",
       "dev": true,
       "requires": {
         "tsutils": "^2.27.2 <2.29.0"
@@ -10106,11 +9878,12 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
-      "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "0.5.x"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -895,6 +895,7 @@
     "@types/node": "^8.10.34",
     "@types/request-promise-native": "^1.0.15",
     "@types/semver": "^5.5.0",
+    "@types/xml2js": "^0.4.3",
     "adm-zip": "^0.4.11",
     "clean-webpack-plugin": "^0.1.19",
     "copy-webpack-plugin": "^4.5.4",
@@ -908,7 +909,7 @@
     "ts-loader": "^5.3.0",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
-    "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-microsoft-contrib": "^6.0.0",
     "typescript": "^3.1.1",
     "umd-compat-loader": "^2.1.1",
     "vsce": "^1.51.1",
@@ -917,6 +918,7 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
+    "adal-node": "^0.1.28",
     "azure-arm-containerregistry": "^3.0.0",
     "azure-arm-resource": "^2.0.0-preview",
     "azure-arm-website": "^1.0.0-preview",
@@ -930,13 +932,16 @@
     "gradle-to-js": "^1.0.1",
     "mac-ca": "^1.0.4",
     "moment": "^2.19.3",
+    "ms-rest": "^2.3.8",
+    "ms-rest-azure": "^2.5.9",
     "opn": "^5.2.0",
-    "pom-parser": "^1.1.1",
+    "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
     "semver": "^5.5.1",
     "tar": "^4.4.6",
     "vscode-azureextensionui": "^0.19.0",
     "vscode-languageclient": "^5.1.1",
-    "win-ca": "^2.2.0"
+    "win-ca": "^2.2.0",
+    "xml2js": "^0.4.19"
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,48 +1,14 @@
 {
+    "extends": "tslint-microsoft-contrib",
     "rules": {
-        "insecure-random": true,
-        "no-banned-terms": true,
-        "no-cookies": true,
-        "no-delete-expression": true,
-        "no-disable-auto-sanitization": true,
-        "no-document-domain": true,
-        "no-document-write": true,
-        "no-eval": true,
-        "no-exec-script": true,
-        "no-function-constructor-with-string-args": true,
-        "no-http-string": [
-            true,
-            "http://www.example.com/?.*",
-            "http://www.examples.com/?.*"
-        ],
-        "no-inner-html": true,
-        "no-octal-literal": true,
-        "no-reserved-keywords": false, // changed
-        "no-string-based-set-immediate": true,
-        "no-string-based-set-interval": true,
-        "no-string-based-set-timeout": true,
-        "non-literal-require": true,
-        "possible-timing-attack": true,
-        "react-anchor-blank-noopener": true,
-        "react-iframe-missing-sandbox": true,
-        "react-no-dangerous-html": true,
+        "no-reserved-keywords": false,
         "await-promise": [
             true,
-            "Thenable", // changed
-            "RequestPromise" // changed
+            "Thenable",
+            "RequestPromise"
         ],
-        "forin": true,
-        "jquery-deferred-must-complete": true,
-        "label-position": true,
-        "match-default-export-name": true,
-        "mocha-avoid-only": true,
-        "mocha-no-side-effect-code": true,
-        "no-any": true,
-        "no-arg": true,
-        "no-bitwise": true,
-        "no-conditional-assignment": true,
         "no-console": [
-            false, // changed
+            false,
             "debug",
             "info",
             "log",
@@ -50,139 +16,52 @@
             "timeEnd",
             "trace"
         ],
-        "no-constant-condition": true,
-        "no-control-regex": true,
-        "no-debugger": true,
-        "no-duplicate-switch-case": true,
-        "no-duplicate-super": true,
-        "no-duplicate-variable": true,
-        "no-empty": false, // changed
-        "no-floating-promises": true,
-        "no-for-in-array": true,
-        "no-import-side-effect": true,
-        "no-increment-decrement": false, // changed
-        "no-invalid-regexp": true,
-        "no-invalid-template-strings": true,
-        "no-invalid-this": true,
-        "no-jquery-raw-elements": true,
-        "no-misused-new": true,
-        "no-non-null-assertion": true,
-        "no-reference-import": true,
-        "no-regex-spaces": true,
-        "no-sparse-arrays": true,
-        "no-unnecessary-class": true,
-        "no-string-literal": true,
-        "no-string-throw": true,
-        "no-unnecessary-bind": true,
-        "no-unnecessary-callback-wrapper": true,
-        "no-unnecessary-initializer": true,
-        "no-unnecessary-override": true,
-        "no-unsafe-any": true,
-        "no-unsafe-finally": true,
-        "no-unused-expression": true,
-        "no-use-before-declare": false, // changed (recommended turned off: https://palantir.github.io/tslint/rules/no-use-before-declare/)
-        "no-with-statement": true,
-        "promise-function-async": true,
-        "promise-must-complete": true,
-        "radix": true,
-        "react-this-binding-issue": true,
-        "react-unused-props-and-state": true,
-        "restrict-plus-operands": false, // changed
+        "no-empty": false,
+        "no-increment-decrement": false,
+        "no-use-before-declare": false, // (recommended turned off: https://palantir.github.io/tslint/rules/no-use-before-declare/)
+        "restrict-plus-operands": false,
         "strict-boolean-expressions": [
-            false, // changed
-            "allow-string", // changed
-            "allow-undefined-union", // changed
-            "allow-mix" // changed
+            false,
+            "allow-string",
+            "allow-undefined-union",
+            "allow-mix"
         ],
-        "switch-default": true,
-        "triple-equals": [
-            true,
-            "allow-null-check"
-        ],
-        "use-isnan": true,
-        "use-named-parameter": true,
-        "adjacent-overload-signatures": true,
-        "array-type": [
-            true,
-            "array"
-        ],
-        "arrow-parens": false,
-        "callable-types": true,
-        "chai-prefer-contains-to-index-of": true,
-        "chai-vague-errors": true,
-        "class-name": true,
-        "comment-format": true,
         "completed-docs": [
-            false, // changed
+            false,
             "classes"
         ],
         "export-name": false,
-        "function-name": false, // changed
-        "import-name": false, // changed
-        "interface-name": false, // changed
-        "jsdoc-format": true,
+        "function-name": false,
+        "import-name": false,
+        "interface-name": false,
         "max-classes-per-file": [
-            false, // changed
+            false,
             3
         ],
-        "max-file-line-count": true,
-        "max-func-body-length": [
-            true,
-            100,
-            {
-                "ignore-parameters-to-function-regex": "describe"
-            }
-        ],
         "max-line-length": [
-            false, // changed
+            false,
             140
         ],
-        "member-access": true,
         "member-ordering": [
-            false, // changed
+            false,
             {
                 "order": "fields-first"
             }
         ],
-        "missing-jsdoc": false, // changed
-        "mocha-unneeded-done": true,
-        "new-parens": true,
-        "no-construct": true,
-        "no-default-export": false, // changed
-        "no-empty-interface": true,
-        "no-for-in": true,
-        "no-function-expression": true,
-        "no-inferrable-types": false,
-        "no-multiline-string": false, // changed
+        "no-default-export": false,
         "no-null-keyword": false,
-        "no-parameter-properties": false, // changed
-        "no-relative-imports": false, // changed
-        "no-require-imports": false, // changed
-        "no-shadowed-variable": true,
-        // TODO: "no-suspicious-comment": true,
-        "no-typeof-undefined": true,
-        "no-unnecessary-field-initialization": true,
-        "no-unnecessary-local-variable": false, //changed
-        "no-unnecessary-qualifier": true,
-        "no-unsupported-browser-code": true,
-        "no-useless-files": true,
-        "no-var-keyword": true,
-        "no-var-requires": true,
-        "no-this-assignment": true,
+        "no-parameter-properties": false,
+        "no-relative-imports": false,
+        "no-require-imports": false,
+        "no-suspicious-comment": false, // TODO
+        "no-unnecessary-local-variable": false,
         "no-void-expression": [
-            false, // changed
-            "ignore-arrow-function-shorthand" // changed
+            false,
+            "ignore-arrow-function-shorthand"
         ],
-        "object-literal-sort-keys": false,
-        "one-variable-per-declaration": false, // changed
-        "only-arrow-functions": false,
-        "ordered-imports": true,
-        "prefer-array-literal": true,
-        "prefer-const": false, // changed
-        "prefer-for-of": true,
-        "prefer-method-signature": true,
-        "prefer-template": false, // changed
-        "return-undefined": false,
+        "one-variable-per-declaration": false,
+        "prefer-const": false,
+        "prefer-template": false,
         "typedef": [
             true,
             "call-signature",
@@ -193,96 +72,34 @@
             // "variable-declaration", changed
             "member-variable-declaration"
         ],
-        "underscore-consistent-invocation": true,
-        "unified-signatures": true,
         "variable-name": [
             true,
             "allow-leading-underscore",
             "ban-keywords"
         ],
-        "react-a11y-anchors": true,
-        "react-a11y-aria-unsupported-elements": true,
-        "react-a11y-event-has-role": true,
-        "react-a11y-image-button-has-alt": true,
-        "react-a11y-img-has-alt": true,
-        "react-a11y-lang": true,
-        "react-a11y-meta": true,
-        "react-a11y-props": true,
-        "react-a11y-proptypes": true,
-        "react-a11y-role": true,
-        "react-a11y-role-has-required-aria-props": true,
-        "react-a11y-role-supports-aria-props": true,
-        "react-a11y-tabindex-no-positive": true,
-        "react-a11y-titles": true,
-        "align": [
-            true,
-            "parameters",
-            "arguments",
-            "statements"
-        ],
-        "curly": true,
-        "eofline": false, // changed
-        "import-spacing": true,
-        "indent": [
-            true,
-            "spaces"
-        ],
-        "linebreak-style": false, //changed
-        "newline-before-return": false, // changed
-        "no-consecutive-blank-lines": true, // changed
-        "no-empty-line-after-opening-brace": false,
-        "no-single-line-block-comment": false, // changed
-        "no-trailing-whitespace": true,
-        "no-unnecessary-semicolons": true,
+        "eofline": false,
+        "linebreak-style": false,
+        "newline-before-return": false,
+        "no-single-line-block-comment": false,
         "object-literal-key-quotes": [
-            false, // changed
+            false,
             "as-needed"
         ],
-        "one-line": [
-            true,
-            "check-open-brace",
-            "check-catch",
-            "check-else",
-            "check-whitespace"
-        ],
         "quotemark": [
-            false, // changed
+            false,
             "single"
         ],
-        "react-tsx-curly-spacing": true,
         "semicolon": [
-            false, // changed
+            false,
             "always"
         ],
         "trailing-comma": [
-            false, // changed
+            false,
             {
                 "singleline": "never",
                 "multiline": "never"
             }
         ],
-        "typedef-whitespace": false,
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ],
-        "ban": false,
-        "ban-types": true,
-        "cyclomatic-complexity": true,
-        "file-header": false,
-        "import-blacklist": false,
-        "interface-over-type-literal": false,
-        "no-angle-bracket-type-assertion": false,
-        "no-inferred-empty-object-type": false,
-        "no-internal-module": false,
-        "no-magic-numbers": false,
-        "no-mergeable-namespace": false,
-        "no-namespace": false,
-        "no-reference": true,
         "no-unexternalized-strings": [
             false,
             {
@@ -294,17 +111,24 @@
                 "messageIndex": 1
             }
         ],
-        "object-literal-shorthand": false,
-        "prefer-type-cast": false, // changed
-        "space-before-function-paren": false,
-        "missing-optional-annotation": false,
-        "no-duplicate-parameter-names": false,
-        "no-empty-interfaces": false,
-        "no-missing-visibility-modifiers": false,
-        "no-multiple-var-decl": false,
-        "no-switch-case-fall-through": false
+        "prefer-type-cast": false,
+        "no-implicit-dependencies": [
+            true,
+            [
+                "vscode"
+            ]
+        ],
+        "newline-per-chained-call": false,
+        "no-submodule-imports": false,
+        "type-literal-delimiter": false,
+        "prefer-readonly": false,
+        "no-return-await": false,
+        "no-parameter-reassignment": false,
+        "no-object-literal-type-assertion": false,
+        "no-duplicate-imports": false,
+        "no-backbone-get-set-outside-model": false,
+        "binary-expression-operand-order": false
     },
-    "rulesDirectory": "node_modules/tslint-microsoft-contrib/",
     "linterOptions": {
         "exclude": [
             "test/**"

--- a/utils/azureUtilityManager.ts
+++ b/utils/azureUtilityManager.ts
@@ -39,7 +39,7 @@ export class AzureUtilityManager {
                 let azureAccountExtension = vscode.extensions.getExtension<AzureAccount>('ms-vscode.azure-account');
                 this.properties.found = azureAccountExtension ? 'true' : 'false';
                 if (azureAccountExtension) {
-                    azureAccount = <AzureAccount>await azureAccountExtension.activate();
+                    azureAccount = await azureAccountExtension.activate();
                 }
 
                 vscode.commands.executeCommand('setContext', 'isAzureAccountInstalled', !!azureAccount);

--- a/utils/keytar.ts
+++ b/utils/keytar.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// tslint:disable-next-line:no-implicit-dependencies
 import * as keytarType from 'keytar';
 import { getCoreNodeModule } from './getCoreNodeModule';
 


### PR DESCRIPTION
- Remove pom-parser due to `npm audit` issues. I'm using the exact same `xml2js` options that pom-parser was using: https://github.com/intuit/node-pom-parser/blob/d59c365fb15a9993b0db19d87da407dccf8f744d/lib/index.js#L11
- Leverage the `no-implicit-dependencies` tslint rule to make sure every dep that we use is listed in package.json (and not just as a dev dependency)
- Clean up tslint.json to use the `extends` property rather than hard-coding every rule ourselves. I disabled all "new" rules that had failures except for these which I fixed:
    ```
    no-unnecessary-type-assertion
    space-within-parens
    no-implicit-dependencies
    ```