### PR TITLE
Add prerequisite check for missing Dockerfile

### DIFF
--- a/debugging/coreclr/prereqManager.ts
+++ b/debugging/coreclr/prereqManager.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { BrowserClient } from './browserClient';
 import { DockerClient } from './dockerClient';
-import { MacNuGetPackageFallbackFolderPath, LaunchOptions } from './dockerManager';
+import { LaunchOptions, MacNuGetPackageFallbackFolderPath } from './dockerManager';
 import { DotNetClient } from './dotNetClient';
 import { FileSystemProvider } from './fsProvider';
 import { OSProvider } from './osProvider';

--- a/debugging/coreclr/registerDebugger.ts
+++ b/debugging/coreclr/registerDebugger.ts
@@ -15,7 +15,7 @@ import { LocalFileSystemProvider } from './fsProvider';
 import { MsBuildNetCoreProjectProvider } from './netCoreProjectProvider';
 import LocalOSProvider from './osProvider';
 import { DefaultOutputManager } from './outputManager';
-import { AggregatePrerequisite, DockerDaemonIsLinuxPrerequisite, DotNetExtensionInstalledPrerequisite, DotNetSdkInstalledPrerequisite, LinuxUserInDockerGroupPrerequisite, MacNuGetFallbackFolderSharedPrerequisite, DockerfileExistsPrerequisite } from './prereqManager';
+import { AggregatePrerequisite, DockerDaemonIsLinuxPrerequisite, DockerfileExistsPrerequisite, DotNetExtensionInstalledPrerequisite, DotNetSdkInstalledPrerequisite, LinuxUserInDockerGroupPrerequisite, MacNuGetFallbackFolderSharedPrerequisite } from './prereqManager';
 import ChildProcessProvider from './processProvider';
 import { OSTempFileProvider } from './tempFileProvider';
 import { RemoteVsDbgClient } from './vsdbgClient';

--- a/debugging/coreclr/registerDebugger.ts
+++ b/debugging/coreclr/registerDebugger.ts
@@ -15,7 +15,7 @@ import { LocalFileSystemProvider } from './fsProvider';
 import { MsBuildNetCoreProjectProvider } from './netCoreProjectProvider';
 import LocalOSProvider from './osProvider';
 import { DefaultOutputManager } from './outputManager';
-import { AggregatePrerequisite, DockerDaemonIsLinuxPrerequisite, DotNetExtensionInstalledPrerequisite, DotNetSdkInstalledPrerequisite, LinuxUserInDockerGroupPrerequisite, MacNuGetFallbackFolderSharedPrerequisite } from './prereqManager';
+import { AggregatePrerequisite, DockerDaemonIsLinuxPrerequisite, DotNetExtensionInstalledPrerequisite, DotNetSdkInstalledPrerequisite, LinuxUserInDockerGroupPrerequisite, MacNuGetFallbackFolderSharedPrerequisite, DockerfileExistsPrerequisite } from './prereqManager';
 import ChildProcessProvider from './processProvider';
 import { OSTempFileProvider } from './tempFileProvider';
 import { RemoteVsDbgClient } from './vsdbgClient';
@@ -90,6 +90,10 @@ export function registerDebugConfigurationProvider(ctx: vscode.ExtensionContext)
                     new LinuxUserInDockerGroupPrerequisite(
                         osProvider,
                         processProvider,
-                        vscode.window.showErrorMessage)
+                        vscode.window.showErrorMessage),
+                    new DockerfileExistsPrerequisite(
+                        fileSystemProvider,
+                        vscode.window.showErrorMessage,
+                        vscode.commands.executeCommand)
                 ))));
 }

--- a/extension.ts
+++ b/extension.ts
@@ -27,10 +27,11 @@ export { isWindows10RS3OrNewer, isWindows10RS4OrNewer } from "./helpers/osVersio
 export { LineSplitter } from './debugging/coreclr/lineSplitter';
 export { CommandLineBuilder } from './debugging/coreclr/commandLineBuilder';
 export { DockerClient } from './debugging/coreclr/dockerClient';
+export { LaunchOptions } from './debugging/coreclr/dockerManager';
 export { DotNetClient } from './debugging/coreclr/dotNetClient';
 export { FileSystemProvider } from './debugging/coreclr/fsProvider';
 export { OSProvider } from './debugging/coreclr/osProvider';
-export { DockerDaemonIsLinuxPrerequisite, DotNetSdkInstalledPrerequisite, LinuxUserInDockerGroupPrerequisite, MacNuGetFallbackFolderSharedPrerequisite } from './debugging/coreclr/prereqManager';
+export { DockerDaemonIsLinuxPrerequisite, DockerfileExistsPrerequisite, DotNetSdkInstalledPrerequisite, LinuxUserInDockerGroupPrerequisite, MacNuGetFallbackFolderSharedPrerequisite } from './debugging/coreclr/prereqManager';
 export { ProcessProvider } from './debugging/coreclr/processProvider';
 export { PlatformOS, Platform } from './utils/platform';
 export { DockerBuildImageOptions } from "./debugging/coreclr/dockerClient";


### PR DESCRIPTION
Adds a prerequisite check that verifies the existence of the `Dockerfile` inferred or specified by the user.  If the `Dockerfile` does not exist, the error message prompts the user to run the scaffolding task.

Resolves #681.