### PR TITLE
Allow more customization of docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,22 @@ Example run customization:
                 "labels": {
                     "label1": "value1",
                     "label2": "value2"
-                }
+                },
+                "ports": [
+                    "80:80",
+                    "443:443"
+                ],
+                "externalHosts": [
+                    "some-hostname:some-ip",
+                    "some-other-hostname:some-other-ip"
+                ],
+                "volumes": [
+                    {
+                        "localPath": "path-on-host-machine",
+                        "containerPath": "path-inside-container",
+                        "permissions": "ro|rw"
+                    }
+                ]
             }
         }
     ]

--- a/README.md
+++ b/README.md
@@ -228,6 +228,23 @@ Customize the Docker container run process by adding properties under the `docke
 | `env` | Environment variables applied to the container. | None |
 | `envFiles` | Files of environment variables read in and applied to the container. Environment variables are specified one per line, in `<name>=<value>` format. | None |
 | `labels` | The set of labels added to the container. | `com.microsoft.created-by` = `visual-studio-code` |
+| `ports` | Ports that are going to be mapped on the host. | All ports exposed in the Dockerfile will get binded to a random port on the host machine |
+| `extraHosts` | Hosts to be added on the container `hosts` file for dns resolution. | None |
+| `volumes` | Volumes that are going to be mapped to the container. | None |
+
+# ports
+| Property | Description | Required |
+| --- | --- | --- |
+| `hostPort` | Port number to be binded on the host. | No |
+| `containerPort` | Port number of the container to be binded. | Yes |
+| `protocol` | Specific protocol for the binding (`tcp | udp`). If no protocol is specified it will bind both. | No |
+
+# volumes
+| Property | Description | Default |
+| --- | --- | --- |
+| `localPath` | Path on local machine that would be mapped. If the folder does not exist it will be created.  | None |
+| `containerPath` | Path where the volume will be mapped on the container. If the folder does not exist it will be created. | None |
+| `permissions` | Permissions for the container for the volume mapped (`rw | ro`). | `rw` |
 
 Example run customization:
 
@@ -253,12 +270,36 @@ Example run customization:
                     "label2": "value2"
                 },
                 "ports": [
-                    "80:80",
-                    "443:443"
+                    {
+                        "hostPort": 80,
+                        "containerPort": 80
+                    },
+                    {
+                        "containerPort": 443
+                    },
+                    {
+                        "containerPort": 6029,
+                        "protocol": "udp"
+                    },
+                    {
+                        "containerPort": 6029,
+                        "protocol": "tcp"
+                    },
+                    {
+                        "hostPort": 4562,
+                        "containerPort": 5837,
+                        "protocol": "tcp"
+                    }
                 ],
-                "externalHosts": [
-                    "some-hostname:some-ip",
-                    "some-other-hostname:some-other-ip"
+                "extraHosts": [
+                    {
+                        "hostname": "some-hostname",
+                        "ip": "some-ip"
+                    },
+                    {
+                        "hostname": "some-other-hostname",
+                        "ip": "some-other-ip"
+                    }
                 ],
                 "volumes": [
                     {

--- a/README.md
+++ b/README.md
@@ -228,23 +228,23 @@ Customize the Docker container run process by adding properties under the `docke
 | `env` | Environment variables applied to the container. | None |
 | `envFiles` | Files of environment variables read in and applied to the container. Environment variables are specified one per line, in `<name>=<value>` format. | None |
 | `labels` | The set of labels added to the container. | `com.microsoft.created-by` = `visual-studio-code` |
-| `ports` | Ports that are going to be mapped on the host. | All ports exposed in the Dockerfile will get binded to a random port on the host machine |
-| `extraHosts` | Hosts to be added on the container `hosts` file for dns resolution. | None |
+| `ports` | Ports that are going to be mapped on the host. | All ports exposed by the Dockerfile will be bound to a random port on the host machine |
+| `extraHosts` | Hosts to be added to the container's `hosts` file for DNS resolution. | None |
 | `volumes` | Volumes that are going to be mapped to the container. | None |
 
 # ports
-| Property | Description | Required |
-| --- | --- | --- |
-| `hostPort` | Port number to be binded on the host. | No |
-| `containerPort` | Port number of the container to be binded. | Yes |
-| `protocol` | Specific protocol for the binding (`tcp | udp`). If no protocol is specified it will bind both. | No |
+| Property | Description | Required | Default |
+| --- | --- | --- | --- |
+| `hostPort` | Port number to be bound on the host. | No | None |
+| `containerPort` | Port number of the container to be bound. | Yes | None |
+| `protocol` | Specific protocol for the binding (`tcp | udp`). If no protocol is specified it will bind both. | No | None |
 
 # volumes
-| Property | Description | Default |
-| --- | --- | --- |
-| `localPath` | Path on local machine that would be mapped. If the folder does not exist it will be created.  | None |
-| `containerPath` | Path where the volume will be mapped on the container. If the folder does not exist it will be created. | None |
-| `permissions` | Permissions for the container for the volume mapped (`rw | ro`). | `rw` |
+| Property | Description | Required | Default |
+| --- | --- | --- | --- |
+| `localPath` | Path on local machine that will be mapped. The folder will be created if it does not exist. | Yes | None |
+| `containerPath` | Path where the volume will be mapped within the container. The folder will be created if it does not exist. | Yes | None |
+| `permissions` | Permissions for the container for the mapped volume, `rw` for read-write or `ro` for read-only. | Yes | `rw` |
 
 Example run customization:
 

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -41,6 +41,8 @@ export type DockerRunContainerOptions = {
     envFiles?: string[];
     labels?: { [key: string]: string };
     volumes?: DockerContainerVolume[];
+    ports?: string[];
+    externalHosts?: string[];
 };
 
 export type DockerVersionOptions = {
@@ -193,6 +195,8 @@ export class CliDockerClient implements DockerClient {
             .withArrayArgs('--env-file', options.envFiles)
             .withKeyValueArgs('--label', options.labels)
             .withArrayArgs('-v', options.volumes, volume => `${volume.localPath}:${volume.containerPath}${volume.permissions ? ':' + volume.permissions : ''}`)
+            .withArrayArgs('-p', options.ports)
+            .withArrayArgs('--add-host', options.externalHosts)
             .withNamedArg('--entrypoint', options.entrypoint)
             .withQuotedArg(imageTagOrId)
             .withArg(options.command)

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -200,7 +200,8 @@ export class CliDockerClient implements DockerClient {
         options = options || {};
 
         const command = CommandLineBuilder
-            .create('docker', 'run', '-dt', options.ports ? '-P' : '')
+            .create('docker', 'run', '-dt')
+            .withFlagArg('-P', options.ports === undefined || options.ports.length < 1)
             .withNamedArg('--name', options.containerName)
             .withKeyValueArgs('-e', options.env)
             .withArrayArgs('--env-file', options.envFiles)

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -27,6 +27,17 @@ export type DockerContainerRemoveOptions = {
     force?: boolean;
 };
 
+export type DockerContainerPort = {
+    hostPort?: string;
+    containerPort: string;
+    protocol?: 'tcp' | 'udp';
+}
+
+export type DockerContainerExtraHost = {
+    hostname: string;
+    ip: string;
+}
+
 export type DockerContainerVolume = {
     localPath: string;
     containerPath: string;
@@ -41,8 +52,8 @@ export type DockerRunContainerOptions = {
     envFiles?: string[];
     labels?: { [key: string]: string };
     volumes?: DockerContainerVolume[];
-    ports?: string[];
-    externalHosts?: string[];
+    ports?: DockerContainerPort[];
+    extraHosts?: DockerContainerExtraHost[];
 };
 
 export type DockerVersionOptions = {
@@ -189,14 +200,14 @@ export class CliDockerClient implements DockerClient {
         options = options || {};
 
         const command = CommandLineBuilder
-            .create('docker', 'run', '-dt', '-P')
+            .create('docker', 'run', '-dt', options.ports ? '-P' : '')
             .withNamedArg('--name', options.containerName)
             .withKeyValueArgs('-e', options.env)
             .withArrayArgs('--env-file', options.envFiles)
             .withKeyValueArgs('--label', options.labels)
             .withArrayArgs('-v', options.volumes, volume => `${volume.localPath}:${volume.containerPath}${volume.permissions ? ':' + volume.permissions : ''}`)
-            .withArrayArgs('-p', options.ports)
-            .withArrayArgs('--add-host', options.externalHosts)
+            .withArrayArgs('-p', options.ports, port => `${port.hostPort ? port.hostPort + ':' : ''}${port.containerPort}${port.protocol ? '/' + port.protocol : ''}`)
+            .withArrayArgs('--add-host', options.extraHosts, extraHost => `${extraHost.hostname}:${extraHost.ip}`)
             .withNamedArg('--entrypoint', options.entrypoint)
             .withQuotedArg(imageTagOrId)
             .withArg(options.command)

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -7,7 +7,7 @@ import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, Prov
 import { callWithTelemetryAndErrorHandling } from 'vscode-azureextensionui';
 import { PlatformOS } from '../../utils/platform';
 import { DebugSessionManager } from './debugSessionManager';
-import { DockerContainerVolume } from './dockerClient';
+import { DockerContainerExtraHost, DockerContainerPort, DockerContainerVolume } from './dockerClient';
 import { DockerManager, LaunchBuildOptions, LaunchResult, LaunchRunOptions } from './dockerManager';
 import { FileSystemProvider } from './fsProvider';
 import { NetCoreProjectProvider } from './netCoreProjectProvider';
@@ -29,9 +29,9 @@ interface DockerDebugRunOptions {
     envFiles?: string[];
     labels?: { [key: string]: string };
     os?: PlatformOS;
-    ports?: string[];
+    ports?: DockerContainerPort[];
     volumes?: DockerContainerVolume[];
-    externalHosts?: string[];
+    extraHosts?: DockerContainerExtraHost[];
 }
 
 interface DebugConfigurationBrowserBaseOptions {
@@ -185,13 +185,13 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         const ports = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.ports;
         const volumes = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.volumes;
-        const externalHosts = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.externalHosts;
+        const extraHosts = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.extraHosts;
 
         return {
             containerName,
             env,
             envFiles,
-            externalHosts,
+            extraHosts,
             labels,
             os,
             ports,

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -7,12 +7,12 @@ import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, Prov
 import { callWithTelemetryAndErrorHandling } from 'vscode-azureextensionui';
 import { PlatformOS } from '../../utils/platform';
 import { DebugSessionManager } from './debugSessionManager';
+import { DockerContainerVolume } from './dockerClient';
 import { DockerManager, LaunchBuildOptions, LaunchResult, LaunchRunOptions } from './dockerManager';
 import { FileSystemProvider } from './fsProvider';
 import { NetCoreProjectProvider } from './netCoreProjectProvider';
 import { OSProvider } from './osProvider';
 import { Prerequisite } from './prereqManager';
-import { DockerContainerVolume } from './dockerClient';
 
 interface DockerDebugBuildOptions {
     args?: { [key: string]: string };
@@ -183,19 +183,19 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         const labels = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.labels)
             || DockerDebugConfigurationProvider.defaultLabels;
 
-        const ports = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.ports) || [];
-        const volumes = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.volumes) || undefined;
-        const externalHosts = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.externalHosts) || [];
+        const ports = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.ports;
+        const volumes = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.volumes;
+        const externalHosts = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.externalHosts;
 
         return {
             containerName,
             env,
             envFiles,
+            externalHosts,
             labels,
             os,
             ports,
-            volumes,
-            externalHosts
+            volumes
         };
     }
 

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -12,6 +12,7 @@ import { FileSystemProvider } from './fsProvider';
 import { NetCoreProjectProvider } from './netCoreProjectProvider';
 import { OSProvider } from './osProvider';
 import { Prerequisite } from './prereqManager';
+import { DockerContainerVolume } from './dockerClient';
 
 interface DockerDebugBuildOptions {
     args?: { [key: string]: string };
@@ -28,6 +29,9 @@ interface DockerDebugRunOptions {
     envFiles?: string[];
     labels?: { [key: string]: string };
     os?: PlatformOS;
+    ports?: string[];
+    volumes?: DockerContainerVolume[];
+    externalHosts?: string[];
 }
 
 interface DebugConfigurationBrowserBaseOptions {
@@ -179,12 +183,19 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         const labels = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.labels)
             || DockerDebugConfigurationProvider.defaultLabels;
 
+        const ports = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.ports) || [];
+        const volumes = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.volumes) || undefined;
+        const externalHosts = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.externalHosts) || [];
+
         return {
             containerName,
             env,
             envFiles,
             labels,
             os,
+            ports,
+            volumes,
+            externalHosts
         };
     }
 

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -216,7 +216,9 @@ export class DefaultDockerManager implements DockerManager {
                         entrypoint,
                         env: options.env,
                         envFiles: options.envFiles,
+                        extraHosts: options.extraHosts,
                         labels: options.labels,
+                        ports: options.ports,
                         volumes: [...volumes, ...options.volumes]
                     });
             },

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -217,7 +217,7 @@ export class DefaultDockerManager implements DockerManager {
                         env: options.env,
                         envFiles: options.envFiles,
                         labels: options.labels,
-                        volumes
+                        volumes: [...volumes, ...options.volumes]
                     });
             },
             id => `Container ${this.dockerClient.trimId(id)} started.`,

--- a/package.json
+++ b/package.json
@@ -407,6 +407,50 @@
                     "additionalProperties": {
                       "type": "string"
                     }
+                  },
+                  "ports": {
+                    "type": "array",
+                    "description": "Ports that are going to be mapped on the host.",
+                    "hostPort": {
+                      "type": "string",
+                      "description": "Port number to be binded on the host."
+                    },
+                    "containerPort": {
+                      "type": "string",
+                      "description": "Port number of the container to be binded."
+                    },
+                    "protocol": {
+                      "type": "string",
+                      "description": "Specific protocol for the binding (`tcp | udp`)."
+                    }
+                  },
+                  "extraHosts": {
+                    "type": "array",
+                    "description": "Hosts to be added on the container `hosts` file for dns resolution.",
+                    "hostname": {
+                      "type": "string",
+                      "description": "Hostname for dns resolution."
+                    },
+                    "ip": {
+                      "type": "string",
+                      "description": "IP associated to the hostname."
+                    }
+                  },
+                  "volumes": {
+                    "type": "array",
+                    "description": "Volumes that are going to be mapped to the container.",
+                    "localPath": {
+                      "type": "string",
+                      "description": "Path on local machine that would be mapped. If the folder does not exist it will be created."
+                    },
+                    "containerPath": {
+                      "type": "string",
+                      "description": "Path where the volume will be mapped on the container. If the folder does not exist it will be created."
+                    },
+                    "permissions": {
+                      "type": "string",
+                      "description": "Permissions for the container for the volume mapped (`rw | ro`)."
+                    }
                   }
                 }
               }

--- a/package.json
+++ b/package.json
@@ -411,45 +411,79 @@
                   "ports": {
                     "type": "array",
                     "description": "Ports that are going to be mapped on the host.",
-                    "hostPort": {
-                      "type": "string",
-                      "description": "Port number to be binded on the host."
-                    },
-                    "containerPort": {
-                      "type": "string",
-                      "description": "Port number of the container to be binded."
-                    },
-                    "protocol": {
-                      "type": "string",
-                      "description": "Specific protocol for the binding (`tcp | udp`)."
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "hostPort": {
+                          "type": "string",
+                          "description": "Port number to be bound on the host."
+                        },
+                        "containerPort": {
+                          "type": "string",
+                          "description": "Port number of the container to be bound."
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "description": "Specific protocol for the binding (`tcp | udp`).",
+                          "enum": [
+                            "tcp",
+                            "udp"
+                          ]
+                        },
+                        "required": [
+                          "containerPort"
+                        ]
+                      }
                     }
                   },
                   "extraHosts": {
                     "type": "array",
-                    "description": "Hosts to be added on the container `hosts` file for dns resolution.",
-                    "hostname": {
-                      "type": "string",
-                      "description": "Hostname for dns resolution."
-                    },
-                    "ip": {
-                      "type": "string",
-                      "description": "IP associated to the hostname."
+                    "description": "Hosts to be added to the container's `hosts` file for DNS resolution.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "hostname": {
+                          "type": "string",
+                          "description": "Hostname for dns resolution."
+                        },
+                        "ip": {
+                          "type": "string",
+                          "description": "IP associated to the hostname."
+                        }
+                      },
+                      "required": [
+                        "hostname",
+                        "ip"
+                      ]
                     }
                   },
                   "volumes": {
                     "type": "array",
                     "description": "Volumes that are going to be mapped to the container.",
-                    "localPath": {
-                      "type": "string",
-                      "description": "Path on local machine that would be mapped. If the folder does not exist it will be created."
-                    },
-                    "containerPath": {
-                      "type": "string",
-                      "description": "Path where the volume will be mapped on the container. If the folder does not exist it will be created."
-                    },
-                    "permissions": {
-                      "type": "string",
-                      "description": "Permissions for the container for the volume mapped (`rw | ro`)."
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "localPath": {
+                          "type": "string",
+                          "description": "Path on local machine that will be mapped. The folder will be created if it does not exist."
+                        },
+                        "containerPath": {
+                          "type": "string",
+                          "description": "Path where the volume will be mapped within the container. The folder will be created if it does not exist."
+                        },
+                        "permissions": {
+                          "type": "string",
+                          "description": "Permissions for the container for the mapped volume, `rw` for read-write or `ro` for read-only.",
+                          "enum": [
+                            "rw",
+                            "ro"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "localPath",
+                        "containerPath"
+                      ]
                     }
                   }
                 }


### PR DESCRIPTION
## SUMMARY
Extend Docker Run configuration to add more customisations on the containers.

Now the `DockerRun` config on `launch.json` file can accept the following elements:

```json
"dockerRun": {
    "containerName": "my-container",
    "env": {
        "var1": "value1",
        "var2": "value2"
    },
    "envFiles": [
        "${workspaceFolder}/staging.env"
    ],
    "labels": {
        "label1": "value1",
        "label2": "value2"
    },
    "ports": [
        "80:80",
        "443:443"
    ],
    "externalHosts": [
        "some-hostname:some-ip",
        "some-other-hostname:some-other-ip"
    ],
    "volumes": [
        {
            "localPath": "path-on-host-machine",
            "containerPath": "path-inside-container",
            "permissions": "ro|rw"
        }
    ]
}
```