### PR TITLE
Revert "Create requirements.txt if it doesn't exist (#647)"

### DIFF
--- a/configureWorkspace/configure_python.ts
+++ b/configureWorkspace/configure_python.ts
@@ -32,7 +32,6 @@ WORKDIR /app
 ADD . /app
 
 # Using pip:
-RUN if [ ! -f requirements.txt ]; then pip3 freeze > requirements.txt; fi
 RUN python3 -m pip install -r requirements.txt
 CMD ["python3", "-m", "${serviceNameAndRelativePath}"]
 


### PR DESCRIPTION
This reverts commit d4c1b3e8bf7783beb2a8683394510672fded9a73.

There is currently some question as to the correct fix.  Reverting until resolved.  Created issue #693 to track.