### PR TITLE
Mark event as activation event

### DIFF
--- a/dockerExtension.ts
+++ b/dockerExtension.ts
@@ -370,8 +370,8 @@ namespace Configuration {
 
 function activateLanguageClient(ctx: vscode.ExtensionContext): void {
   // Don't wait
-  // tslint:disable-next-line:no-function-expression
   callWithTelemetryAndErrorHandling('docker.languageclient.activate', async function (this: IActionContext): Promise<void> {
+    this.properties.isActivationEvent = 'true';
     let serverModule = ctx.asAbsolutePath(
       path.join(
         "dist",


### PR DESCRIPTION
Was going through telemetry and noticed this wasn't properly marked with `isActivationEvent`