### PR TITLE
Add `network` option to Docker run configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,10 @@ Customize the Docker container run process by adding properties under the `docke
 | `containerName` | The name of the container. | `<Application Name>-dev` |
 | `env` | Environment variables applied to the container. | None |
 | `envFiles` | Files of environment variables read in and applied to the container. Environment variables are specified one per line, in `<name>=<value>` format. | None |
-| `labels` | The set of labels added to the container. | `com.microsoft.created-by` = `visual-studio-code` |
-| `ports` | Ports that are going to be mapped on the host. | All ports exposed by the Dockerfile will be bound to a random port on the host machine |
 | `extraHosts` | Hosts to be added to the container's `hosts` file for DNS resolution. | None |
+| `labels` | The set of labels added to the container. | `com.microsoft.created-by` = `visual-studio-code` |
+| `network` | The network to which the container will be connected. Use values as described in the [Docker run documentation](https://docs.docker.com/engine/reference/run/#network-settings). | `bridge` |
+| `ports` | Ports that are going to be mapped on the host. | All ports exposed by the Dockerfile will be bound to a random port on the host machine |
 | `volumes` | Volumes that are going to be mapped to the container. | None |
 
 # ports
@@ -269,6 +270,7 @@ Example run customization:
                     "label1": "value1",
                     "label2": "value2"
                 },
+                "network": "host",
                 "ports": [
                     {
                         "hostPort": 80,

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -50,10 +50,11 @@ export type DockerRunContainerOptions = {
     entrypoint?: string;
     env?: { [key: string]: string };
     envFiles?: string[];
-    labels?: { [key: string]: string };
-    volumes?: DockerContainerVolume[];
-    ports?: DockerContainerPort[];
     extraHosts?: DockerContainerExtraHost[];
+    labels?: { [key: string]: string };
+    network?: string;
+    ports?: DockerContainerPort[];
+    volumes?: DockerContainerVolume[];
 };
 
 export type DockerVersionOptions = {
@@ -203,6 +204,7 @@ export class CliDockerClient implements DockerClient {
             .create('docker', 'run', '-dt')
             .withFlagArg('-P', options.ports === undefined || options.ports.length < 1)
             .withNamedArg('--name', options.containerName)
+            .withNamedArg('--network', options.network)
             .withKeyValueArgs('-e', options.env)
             .withArrayArgs('--env-file', options.envFiles)
             .withKeyValueArgs('--label', options.labels)

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -27,11 +27,12 @@ interface DockerDebugRunOptions {
     containerName?: string;
     env?: { [key: string]: string };
     envFiles?: string[];
+    extraHosts?: DockerContainerExtraHost[];
     labels?: { [key: string]: string };
+    network?: string;
     os?: PlatformOS;
     ports?: DockerContainerPort[];
     volumes?: DockerContainerVolume[];
-    extraHosts?: DockerContainerExtraHost[];
 }
 
 interface DebugConfigurationBrowserBaseOptions {
@@ -183,6 +184,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         const labels = (debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.labels)
             || DockerDebugConfigurationProvider.defaultLabels;
 
+        const network = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.network;
         const ports = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.ports;
         const volumes = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.volumes;
         const extraHosts = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.extraHosts;
@@ -193,6 +195,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
             envFiles,
             extraHosts,
             labels,
+            network,
             os,
             ports,
             volumes

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -219,7 +219,7 @@ export class DefaultDockerManager implements DockerManager {
                         extraHosts: options.extraHosts,
                         labels: options.labels,
                         ports: options.ports,
-                        volumes: [...volumes, ...options.volumes]
+                        volumes: [...(volumes || []), ...(options.volumes || [])]
                     });
             },
             id => `Container ${this.dockerClient.trimId(id)} started.`,

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -218,6 +218,7 @@ export class DefaultDockerManager implements DockerManager {
                         envFiles: options.envFiles,
                         extraHosts: options.extraHosts,
                         labels: options.labels,
+                        network: options.network,
                         ports: options.ports,
                         volumes: [...(volumes || []), ...(options.volumes || [])]
                     });

--- a/package.json
+++ b/package.json
@@ -408,6 +408,10 @@
                       "type": "string"
                     }
                   },
+                  "network": {
+                    "type": "string",
+                    "description": "The network to which the container will be connected."
+                  },
                   "ports": {
                     "type": "array",
                     "description": "Ports that are going to be mapped on the host.",


### PR DESCRIPTION
Adds a `network` option to the Docker run section of the Docker debug configuration.  This option corresponds to the  `--network` option of the `docker run` command.

Also resolves an issue introduced with #690 which causes debugging to fail if the `volumes` configuration option is not specified (i.e. is `undefined`).  (In that case, the workaround until this fix is committed and released is to set it to an empty array.)