### PR TITLE
Use win-ca fallback logic since nAPI isn't currently compatible with Electron

### DIFF
--- a/utils/getTrustedCertificates.ts
+++ b/utils/getTrustedCertificates.ts
@@ -119,6 +119,7 @@ function getCertificatesFromSystem(): (string | Buffer)[] {
 
         try {
             if (isWindows()) {
+                // Use win-ca fallback logic since nAPI isn't currently compatible with Electron (https://github.com/ukoloff/win-ca/issues/12)
                 require('win-ca/fallback');
             } else if (isMac()) {
                 require('mac-ca');

--- a/utils/getTrustedCertificates.ts
+++ b/utils/getTrustedCertificates.ts
@@ -119,7 +119,8 @@ function getCertificatesFromSystem(): (string | Buffer)[] {
 
         try {
             if (isWindows()) {
-                // Use win-ca fallback logic since nAPI isn't currently compatible with Electron (https://github.com/ukoloff/win-ca/issues/12)
+                // Use win-ca fallback logic since nAPI isn't currently compatible with Electron
+                // (https://github.com/ukoloff/win-ca/issues/12, https://www.npmjs.com/package/win-ca#availability)
                 require('win-ca/fallback');
             } else if (isMac()) {
                 require('mac-ca');

--- a/utils/getTrustedCertificates.ts
+++ b/utils/getTrustedCertificates.ts
@@ -119,7 +119,7 @@ function getCertificatesFromSystem(): (string | Buffer)[] {
 
         try {
             if (isWindows()) {
-                require('win-ca');
+                require('win-ca/fallback');
             } else if (isMac()) {
                 require('mac-ca');
             } else if (isLinux()) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,6 +79,8 @@ const config = {
             // util/getCoreNodeModule.js uses a dynamic require which can't be webpacked
             './getCoreNodeModule': 'commonjs getCoreNodeModule',
 
+            'win-ca/fallback': 'commonjs win-ca/fallback',
+
             // Pull the rest automatically from externalModulesClosure
             ...getExternalsEntries()
         }


### PR DESCRIPTION
Not positive if this is the correct fix (it might be), or just a work-around, but it does fix the issue, and we need a fix before vscode ships next week.

#733 

Note that mac-ca works differently (spawns a mac exe) so does not have this same problem.