### PR TITLE
Upgrade language server version to 0.0.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-docker",
-  "version": "0.5.1",
+  "version": "0.5.2-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2190,23 +2190,49 @@
       }
     },
     "dockerfile-language-server-nodejs": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.19.tgz",
-      "integrity": "sha512-aQ58gy6zrqHBzapBE1EjxZlq8XROezs6y0fnUbSRJd5Uxqy2WU7ExLnmiYLnEXBdmI8E1vtlFB9411mg8Nwdvg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.20.tgz",
+      "integrity": "sha512-dLCP3E+MooojNG97qgunjAYFL1Gu1pA46HXiXYiHJ6AQnfyBM06F5kkTAGf4B68rXRde1oCG5zItTuA2Mtwlgg==",
       "requires": {
-        "dockerfile-language-service": "0.0.6",
+        "dockerfile-language-service": "0.0.7",
         "dockerfile-utils": "0.0.11",
-        "vscode-languageserver": "^4.4.0"
+        "vscode-languageserver": "^5.1.0"
       }
     },
     "dockerfile-language-service": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.6.tgz",
-      "integrity": "sha512-15r1kUsxiBaDjba+7bCqUMtfztihgcSljuYvTfDQG5eEG3PTttR4fRLMDwTauKm2/Z2KG3QKxpcYNabYTLexqg==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.7.tgz",
+      "integrity": "sha512-891Esxo/3pX7IcvR6VCBq2jVWd7jKUSWswTSURVwGD3hN9SsObR2Btd3DEYp1Glspuf+eQIvf2DO1IDJ9kyovQ==",
       "requires": {
         "dockerfile-ast": "0.0.11",
-        "dockerfile-utils": "0.0.11",
+        "dockerfile-utils": "0.0.12",
         "vscode-languageserver-types": "^3.10.0"
+      },
+      "dependencies": {
+        "dockerfile-utils": {
+          "version": "0.0.12",
+          "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.12.tgz",
+          "integrity": "sha512-xH7h27/eJiL+zRaZ9PR8jKSNDSiP60q6aK9XJPZi3l9XbprqV+2T/U11uPsGFWZkf/otciNNzqE8Lq5d/qE8HA==",
+          "requires": {
+            "dockerfile-ast": "0.0.12",
+            "vscode-languageserver-types": "3.6.0"
+          },
+          "dependencies": {
+            "dockerfile-ast": {
+              "version": "0.0.12",
+              "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.12.tgz",
+              "integrity": "sha512-cIV8oXkAxpIuN5XgG0TGg07nLDgrj4olkfrdT77OTA3VypscsYHBUg/FjHxW9K3oA+CyH4Th/qtoMgTVpzSobw==",
+              "requires": {
+                "vscode-languageserver-types": "^3.5.0"
+              }
+            },
+            "vscode-languageserver-types": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.0.tgz",
+              "integrity": "sha512-GSgQtGmtza4PoNH0+iHWylWg/1sw2DODezqYWRxbN910dPchI3CQaSJN76csKcQGv55wsWgX82T6n74q8mFSpw=="
+            }
+          }
+        }
       }
     },
     "dockerfile-utils": {
@@ -2228,7 +2254,7 @@
         },
         "vscode-languageserver-types": {
           "version": "3.6.0",
-          "resolved": "http://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.0.tgz",
           "integrity": "sha512-GSgQtGmtza4PoNH0+iHWylWg/1sw2DODezqYWRxbN910dPchI3CQaSJN76csKcQGv55wsWgX82T6n74q8mFSpw=="
         }
       }
@@ -3079,7 +3105,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3494,7 +3521,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3550,6 +3578,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3593,12 +3622,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9669,12 +9700,28 @@
       }
     },
     "vscode-languageserver": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.4.2.tgz",
-      "integrity": "sha512-61y8Raevi9EigDgg9NelvT9cUAohiEbUl1LOwQQgOCAaNX62yKny/ddi0uC+FUTm4CzsjhBu+06R+vYgfCYReA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz",
+      "integrity": "sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==",
       "requires": {
-        "vscode-languageserver-protocol": "^3.10.3",
-        "vscode-uri": "^1.0.5"
+        "vscode-languageserver-protocol": "3.14.1",
+        "vscode-uri": "^1.0.6"
+      },
+      "dependencies": {
+        "vscode-languageserver-protocol": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
+          "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+          "requires": {
+            "vscode-jsonrpc": "^4.0.0",
+            "vscode-languageserver-types": "3.14.0"
+          }
+        },
+        "vscode-languageserver-types": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
+          "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+        }
       }
     },
     "vscode-languageserver-protocol": {

--- a/package.json
+++ b/package.json
@@ -1023,7 +1023,7 @@
     "azure-storage": "^2.8.1",
     "clipboardy": "^1.2.3",
     "deep-equal": "^1.0.1",
-    "dockerfile-language-server-nodejs": "^0.0.19",
+    "dockerfile-language-server-nodejs": "^0.0.20",
     "dockerode": "^2.5.1",
     "fs-extra": "^6.0.1",
     "glob": "7.1.2",


### PR DESCRIPTION
This new update to version 0.0.20 of the language server includes a few bug fixes in addition to the ability of folding instructions that span multiple lines.

Please use the following Dockerfile to try out the new changes.

```Dockerfile
FROM node
# the variable should no longer be flagged as an error
COPY a bunch of files ${DESTINATION_DIR}

# you can now fold multiline instructions like this one
RUN echo && \
    echo && \
    echo && \
    echo && \
    echo && \
    echo && \
    echo && \
    echo && \
    echo && \
    echo

FROM node as setup

# click inside 'sETUp' and open its definition (F12)
# this should now open something as build stages are case-insensitive
COPY --from=sETUp . .

# click inside 'sETUp' and see what it highlights
# this should now highlight everything as build stages are case-insensitive
COPY --from=seTUp . .

# click inside 'sETUp' and rename it (F2)
# this should now rename all four instances as build stages are case-insensitive
COPY --from=sETup . .
```