### PR TITLE
Prepare for v0.5.2 hotfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.2 - 30 January 2019
+
+### Fixed
+
+* Extension fails to initialize in VS Code Insiders 1.31 [#733](https://github.com/Microsoft/vscode-docker/issues/733)
+
 ## 0.5.1 - 8 January 2019
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-docker",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "publisher": "PeterJausovec",
   "displayName": "Docker",
   "description": "Adds syntax highlighting, commands, hover tips, and linting for Dockerfile and docker-compose files.",

--- a/utils/getTrustedCertificates.ts
+++ b/utils/getTrustedCertificates.ts
@@ -117,7 +117,9 @@ function getCertificatesFromSystem(): (string | Buffer)[] {
 
         try {
             if (isWindows()) {
-                require('win-ca');
+                // Use win-ca fallback logic since nAPI isn't currently compatible with Electron
+                // (https://github.com/ukoloff/win-ca/issues/12, https://www.npmjs.com/package/win-ca#availability)
+                require('win-ca/fallback');
             } else if (isMac()) {
                 require('mac-ca');
             } else if (isLinux()) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,6 +78,8 @@ const config = {
             // util/getCoreNodeModule.js uses a dynamic require which can't be webpacked
             './getCoreNodeModule': 'commonjs getCoreNodeModule',
 
+            'win-ca/fallback': 'commonjs win-ca/fallback',
+
             // Pull the rest automatically from externalModulesClosure
             ...getExternalsEntries()
         }


### PR DESCRIPTION
Port bug fix "Use win-ca fallback logic since nAPI isn't currently compatible with …  …"
and
Prepare for v0.5.2 hotfix release