### PR TITLE
[.NET Core Debugging] Add support for Alpine images

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The exact folder to use for certificatePaths on Linux will depend on the distrib
 
 ## Debugging .NET Core (Preview)
 
-> Note that Windows containers are **not** currently supported, only Linux containers.
+> Note that Windows containers are **not** currently supported, only Linux containers. However, both standard and Alpine .NET Core runtime base images are supported.
 
 ### Prerequisites
 

--- a/debugging/coreclr/debuggerClient.ts
+++ b/debugging/coreclr/debuggerClient.ts
@@ -3,8 +3,8 @@
  *--------------------------------------------------------*/
 
 import { PlatformOS } from '../../utils/platform';
-import { VsDbgClient } from './vsdbgClient';
 import { DockerClient } from './dockerClient';
+import { VsDbgClient } from './vsdbgClient';
 
 export interface DebuggerClient {
     getDebugger(os: PlatformOS, containerId: string): Promise<string>;
@@ -40,7 +40,7 @@ export class DefaultDebuggerClient {
         }
     }
 
-    public getDebuggerFolder(): Promise<string> {
-        return this.vsdbgClient.getVsDbgFolder();
+    public async getDebuggerFolder(): Promise<string> {
+        return await this.vsdbgClient.getVsDbgFolder();
     }
 }

--- a/debugging/coreclr/debuggerClient.ts
+++ b/debugging/coreclr/debuggerClient.ts
@@ -26,7 +26,7 @@ export class DefaultDebuggerClient {
         if (os === 'Windows') {
             return await this.vsdbgClient.getVsDbgVersion(DefaultDebuggerClient.debuggerVersion, DefaultDebuggerClient.debuggerWindowsRuntime);
         } else {
-            const result = await this.dockerClient.exec(containerId, '/bin/sh -c \'. /etc/os-release && echo $ID\'', { interactive: true });
+            const result = await this.dockerClient.exec(containerId, '/bin/sh -c \'ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID\'', { interactive: true });
 
             return await this.vsdbgClient.getVsDbgVersion(
                 DefaultDebuggerClient.debuggerVersion,

--- a/debugging/coreclr/debuggerClient.ts
+++ b/debugging/coreclr/debuggerClient.ts
@@ -4,22 +4,39 @@
 
 import { PlatformOS } from '../../utils/platform';
 import { VsDbgClient } from './vsdbgClient';
+import { DockerClient } from './dockerClient';
 
 export interface DebuggerClient {
-    getDebugger(os: PlatformOS): Promise<string>;
+    getDebugger(os: PlatformOS, containerId: string): Promise<string>;
+    getDebuggerFolder(): Promise<string>;
 }
 
 export class DefaultDebuggerClient {
     private static debuggerVersion: string = 'vs2017u5';
-    private static debuggerLinuxRuntime: string = 'debian.8-x64';
+    private static debuggerLinuxAlpineRuntime: string = 'linux-musl-x64';
+    private static debuggerLinuxDefaultRuntime: string = 'linux-x64';
     private static debuggerWindowsRuntime: string = 'win7-x64';
 
-    constructor(private readonly vsdbgClient: VsDbgClient) {
+    constructor(
+        private readonly dockerClient: DockerClient,
+        private readonly vsdbgClient: VsDbgClient) {
     }
 
-    public async getDebugger(os: PlatformOS): Promise<string> {
-        return await this.vsdbgClient.getVsDbgVersion(
-            DefaultDebuggerClient.debuggerVersion,
-            os === 'Windows' ? DefaultDebuggerClient.debuggerWindowsRuntime : DefaultDebuggerClient.debuggerLinuxRuntime);
+    public async getDebugger(os: PlatformOS, containerId: string): Promise<string> {
+        if (os === 'Windows') {
+            return await this.vsdbgClient.getVsDbgVersion(DefaultDebuggerClient.debuggerVersion, DefaultDebuggerClient.debuggerWindowsRuntime);
+        } else {
+            const result = await this.dockerClient.exec(containerId, '/bin/sh -c \'. /etc/os-release && echo $ID\'', { interactive: true });
+
+            return await this.vsdbgClient.getVsDbgVersion(
+                DefaultDebuggerClient.debuggerVersion,
+                result.trim() === 'alpine'
+                    ? DefaultDebuggerClient.debuggerLinuxAlpineRuntime
+                    : DefaultDebuggerClient.debuggerLinuxDefaultRuntime);
+        }
+    }
+
+    public getDebuggerFolder(): Promise<string> {
+        return this.vsdbgClient.getVsDbgFolder();
     }
 }

--- a/debugging/coreclr/debuggerClient.ts
+++ b/debugging/coreclr/debuggerClient.ts
@@ -17,6 +17,10 @@ export class DefaultDebuggerClient {
     private static debuggerLinuxDefaultRuntime: string = 'linux-x64';
     private static debuggerWindowsRuntime: string = 'win7-x64';
 
+    // This script determines the "type" of Linux release (e.g. 'alpine', 'debian', etc.).
+    // NOTE: The result may contain line endings.
+    private static debuggerLinuxReleaseIdScript: string = '/bin/sh -c \'ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID\'';
+
     constructor(
         private readonly dockerClient: DockerClient,
         private readonly vsdbgClient: VsDbgClient) {
@@ -26,7 +30,7 @@ export class DefaultDebuggerClient {
         if (os === 'Windows') {
             return await this.vsdbgClient.getVsDbgVersion(DefaultDebuggerClient.debuggerVersion, DefaultDebuggerClient.debuggerWindowsRuntime);
         } else {
-            const result = await this.dockerClient.exec(containerId, '/bin/sh -c \'ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID\'', { interactive: true });
+            const result = await this.dockerClient.exec(containerId, DefaultDebuggerClient.debuggerLinuxReleaseIdScript, { interactive: true });
 
             return await this.vsdbgClient.getVsDbgVersion(
                 DefaultDebuggerClient.debuggerVersion,

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -75,7 +75,7 @@ export interface DockerClient {
     removeContainer(containerNameOrId: string, options?: DockerContainerRemoveOptions): Promise<void>;
     runContainer(imageTagOrId: string, options?: DockerRunContainerOptions): Promise<string>;
     trimId(id: string): string;
-    exec(containerNameOrId: string, command: string, options?:DockerExecOptions): Promise<string>;
+    exec(containerNameOrId: string, command: string, options?: DockerExecOptions): Promise<string>;
 }
 
 export class CliDockerClient implements DockerClient {
@@ -248,7 +248,7 @@ export class CliDockerClient implements DockerClient {
         return id.substring(0, 12);
     }
 
-    public async exec(containerNameOrId: string, args: string, options?:DockerExecOptions): Promise<string> {
+    public async exec(containerNameOrId: string, args: string, options?: DockerExecOptions): Promise<string> {
         options = options || {};
 
         const command = CommandLineBuilder

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -61,6 +61,11 @@ export type DockerVersionOptions = {
     format?: string;
 }
 
+export type DockerExecOptions = {
+    interactive?: boolean;
+    tty?: boolean;
+}
+
 export interface DockerClient {
     buildImage(options: DockerBuildImageOptions, progress?: (content: string) => void): Promise<string>;
     getVersion(options?: DockerVersionOptions): Promise<string>;
@@ -70,6 +75,7 @@ export interface DockerClient {
     removeContainer(containerNameOrId: string, options?: DockerContainerRemoveOptions): Promise<void>;
     runContainer(imageTagOrId: string, options?: DockerRunContainerOptions): Promise<string>;
     trimId(id: string): string;
+    exec(containerNameOrId: string, command: string, options?:DockerExecOptions): Promise<string>;
 }
 
 export class CliDockerClient implements DockerClient {
@@ -240,6 +246,22 @@ export class CliDockerClient implements DockerClient {
         }
 
         return id.substring(0, 12);
+    }
+
+    public async exec(containerNameOrId: string, args: string, options?:DockerExecOptions): Promise<string> {
+        options = options || {};
+
+        const command = CommandLineBuilder
+            .create('docker', 'exec')
+            .withFlagArg('-i', options.interactive)
+            .withFlagArg('-t', options.tty)
+            .withQuotedArg(containerNameOrId)
+            .withArg(args)
+            .build();
+
+        const result = await this.processProvider.exec(command, {});
+
+        return result.stdout;
     }
 }
 

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -187,7 +187,7 @@ export class DefaultDockerManager implements DockerManager {
 
         const containerName = options.containerName;
 
-        const debuggerFolder = await this.debuggerClient.getDebugger(options.os);
+        const debuggerFolder = await this.debuggerClient.getDebuggerFolder();
 
         const command = options.os === 'Windows'
             ? '-t localhost'
@@ -236,6 +236,8 @@ export class DefaultDockerManager implements DockerManager {
 
         await this.addToDebugContainers(containerId);
 
+        const debuggerPath = await this.debuggerClient.getDebugger(options.run.os, containerId);
+
         const browserUrl = await this.getContainerWebEndpoint(containerId);
 
         const additionalProbingPaths = options.run.os === 'Windows'
@@ -255,7 +257,7 @@ export class DefaultDockerManager implements DockerManager {
 
         return {
             browserUrl,
-            debuggerPath: options.run.os === 'Windows' ? 'C:\\remote_debugger\\vsdbg' : '/remote_debugger/vsdbg',
+            debuggerPath: this.osProvider.pathJoin(options.run.os, options.run.os === 'Windows' ? 'C:\\remote_debugger' : '/remote_debugger', debuggerPath, 'vsdbg'),
             // tslint:disable-next-line:no-invalid-template-strings
             pipeArgs: ['exec', '-i', containerId, '${debuggerCommand}'],
             // tslint:disable-next-line:no-invalid-template-strings

--- a/debugging/coreclr/registerDebugger.ts
+++ b/debugging/coreclr/registerDebugger.ts
@@ -38,6 +38,7 @@ export function registerDebugConfigurationProvider(ctx: vscode.ExtensionContext)
         new DefaultDockerManager(
             new DefaultAppStorageProvider(fileSystemProvider),
             new DefaultDebuggerClient(
+                dockerClient,
                 new RemoteVsDbgClient(
                     dockerOutputManager,
                     fileSystemProvider,

--- a/debugging/coreclr/vsdbgClient.ts
+++ b/debugging/coreclr/vsdbgClient.ts
@@ -12,6 +12,7 @@ import { OutputManager } from './outputManager';
 import { ProcessProvider } from './processProvider';
 
 export interface VsDbgClient {
+    getVsDbgFolder(): Promise<string>;
     getVsDbgVersion(version: string, runtime: string): Promise<string>;
 }
 
@@ -57,13 +58,18 @@ export class RemoteVsDbgClient implements VsDbgClient {
             };
     }
 
+    public getVsDbgFolder(): Promise<string> {
+        return Promise.resolve(this.vsdbgPath);
+    }
+
     public async getVsDbgVersion(version: string, runtime: string): Promise<string> {
-        const vsdbgVersionPath = path.join(this.vsdbgPath, runtime, version);
+        const vsdbgRelativeVersionPath = path.join(runtime, version);
+        const vsdbgVersionPath = path.join(this.vsdbgPath, vsdbgRelativeVersionPath);
         const vsdbgVersionExists = await this.fileSystemProvider.dirExists(vsdbgVersionPath);
 
         if (vsdbgVersionExists && await this.isUpToDate(this.lastDebuggerAcquisitionKey(version, runtime))) {
             // The debugger is up to date...
-            return vsdbgVersionPath;
+            return vsdbgRelativeVersionPath;
         }
 
         return await this.dockerOutputManager.performOperation(
@@ -80,7 +86,7 @@ export class RemoteVsDbgClient implements VsDbgClient {
 
                 await this.updateDate(this.lastDebuggerAcquisitionKey(version, runtime), new Date());
 
-                return vsdbgVersionPath;
+                return vsdbgRelativeVersionPath;
             },
             'Debugger acquired.',
             'Unable to acquire the .NET Core debugger.');

--- a/debugging/coreclr/vsdbgClient.ts
+++ b/debugging/coreclr/vsdbgClient.ts
@@ -58,8 +58,8 @@ export class RemoteVsDbgClient implements VsDbgClient {
             };
     }
 
-    public getVsDbgFolder(): Promise<string> {
-        return Promise.resolve(this.vsdbgPath);
+    public async getVsDbgFolder(): Promise<string> {
+        return this.vsdbgPath;
     }
 
     public async getVsDbgVersion(version: string, runtime: string): Promise<string> {


### PR DESCRIPTION
Adds support for debugging Linux images based on the "Alpine" set of .NET Core base images.

Alpine images require a different variant of the .NET Core debugger (`vsdbg`) than used for the "standard" images currently supported.  Determining which variant is necessary must be done *after* the container is running, by executing a script on the container which returns the image type.

Currently, the debugging provider volume mounts only the folder of a specific variant of debugger, and has the debugging engine use that variant.  This change updates the debugging provider such that containers volume mount the *root* folder for all cached debugging variants (as that must happen during container creation), then starts the container, then runs the script to determine the needed variant, and *then* has the debugging engine use that variant.  Because the volume mount is the root of the debugger cache, the container can use any of the cached variants as needed.