### PR TITLE
Resolve local volume paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Customize the Docker container run process by adding properties under the `docke
 # volumes
 | Property | Description | Required | Default |
 | --- | --- | --- | --- |
-| `localPath` | Path on local machine that will be mapped. The folder will be created if it does not exist. | Yes | None |
+| `localPath` | Path on local machine that will be mapped. The folder will be created if it does not exist. Path may use the `${workspaceFolder}` variable when needed. | Yes | None |
 | `containerPath` | Path where the volume will be mapped within the container. The folder will be created if it does not exist. | Yes | None |
 | `permissions` | Permissions for the container for the mapped volume, `rw` for read-write or `ro` for read-only. | Yes | `rw` |
 

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -186,8 +186,11 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         const network = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.network;
         const ports = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.ports;
-        const volumes = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.volumes;
         const extraHosts = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.extraHosts;
+
+        const volumes = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.volumes
+            ? debugConfiguration.dockerRun.volumes.map(volume => ({ ...volume, localPath: DockerDebugConfigurationProvider.resolveFolderPath(volume.localPath, folder) }))
+            : [];
 
         return {
             containerName,

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -186,11 +186,8 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         const network = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.network;
         const ports = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.ports;
+        const volumes = DockerDebugConfigurationProvider.inferVolumes(folder, debugConfiguration);
         const extraHosts = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.extraHosts;
-
-        const volumes = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.volumes
-            ? debugConfiguration.dockerRun.volumes.map(volume => ({ ...volume, localPath: DockerDebugConfigurationProvider.resolveFolderPath(volume.localPath, folder) }))
-            : [];
 
         return {
             containerName,
@@ -203,6 +200,12 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
             ports,
             volumes
         };
+    }
+
+    private static inferVolumes(folder: WorkspaceFolder, debugConfiguration: DockerDebugConfiguration): DockerContainerVolume[] {
+        return debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.volumes
+            ? debugConfiguration.dockerRun.volumes.map(volume => ({ ...volume, localPath: DockerDebugConfigurationProvider.resolveFolderPath(volume.localPath, folder) }))
+            : [];
     }
 
     private inferAppFolder(folder: WorkspaceFolder, configuration: DockerDebugConfiguration): string {


### PR DESCRIPTION
Resolves the `localPath` debug configuration of volumes to allow the use of the `${workspaceFolder}` variable.  This allows users to specify workspace-relative volumes rather than absolute volumes, which helps users share launch configurations.

Resolves #785.