### PR TITLE
Fix nuget fallback volume mount for dotnet debugging

### DIFF
--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -73,6 +73,7 @@ export interface DockerManager {
 }
 
 export const MacNuGetPackageFallbackFolderPath = '/usr/local/share/dotnet/sdk/NuGetFallbackFolder';
+const LinuxNuGetPackageFallbackFolderPath = '/usr/share/dotnet/sdk/NuGetFallbackFolder';
 
 function compareProperty<T, U>(obj1: T | undefined, obj2: T | undefined, getter: (obj: T) => (U | undefined)): boolean {
     const prop1 = obj1 ? getter(obj1) : undefined;
@@ -352,7 +353,8 @@ export class DefaultDockerManager implements DockerManager {
         }
 
         const nugetFallbackVolume: DockerContainerVolume = {
-            localPath: this.osProvider.os === 'Windows' ? path.join(programFilesEnvironmentVariable, 'dotnet', 'sdk', 'NuGetFallbackFolder') : MacNuGetPackageFallbackFolderPath,
+            localPath: this.osProvider.os === 'Windows' ? path.join(programFilesEnvironmentVariable, 'dotnet', 'sdk', 'NuGetFallbackFolder') :
+                (this.osProvider.isMac ? MacNuGetPackageFallbackFolderPath : LinuxNuGetPackageFallbackFolderPath),
             containerPath: options.os === 'Windows' ? 'C:\\.nuget\\fallbackpackages' : '/root/.nuget/fallbackpackages',
             permissions: 'ro'
         };


### PR DESCRIPTION
Previously the NuGetFallbackFolder mounted into the container used for
debugging was hardcoded to /usr/local/share/dotnet/sdk/NuGetFallbackFolder
for all non-windows platforms. However this path is only the valid
default for OSX. On Linux /usr/share/dotnet/sdk/NuGetFallbackFolder is
the default installation location. This patch corrects that behavior.