### PR TITLE
Add debugging and dockerfile creation for fsharp dotnet core projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ When possible, the location and output of the application will be inferred from 
 | Property | Description | Default |
 | --- | --- | --- |
 | `appFolder` | The root folder of the application | The workspace folder |
-| `appProject` | The path to the project file | The first `.csproj` found in the application folder |
+| `appProject` | The path to the project file | The first `.csproj` or `.fsproj` found in the application folder |
 | `appOutput` | The application folder relative path to the output assembly | The `TargetPath` MS Build property |
 
 > You can specify either `appFolder` or `appProject` but should not specify *both*.

--- a/configureWorkspace/configure.ts
+++ b/configureWorkspace/configure.ts
@@ -364,17 +364,19 @@ async function configureCore(actionContext: IActionContext, options: ConfigureAp
     }
 
     let targetFramework: string;
+    let projFile: string;
     let serviceNameAndPathRelativeToOutput: string;
     {
         // Scope serviceNameAndPathRelativeToRoot only to this block of code
         let serviceNameAndPathRelativeToRoot: string;
         if (platformType.toLowerCase().includes('.net')) {
             let projFilePath = await findCSProjOrFSProjFile(rootFolderPath);
-            serviceNameAndPathRelativeToRoot = projFilePath;
+            serviceNameAndPathRelativeToRoot = projFilePath.slice(0, -(path.extname(projFilePath).length));
             let projFileContents = (await fse.readFile(path.join(rootFolderPath, projFilePath))).toString();
 
             // Extract TargetFramework for version
             [targetFramework] = extractRegExGroups(projFileContents, /<TargetFramework>(.+)<\/TargetFramework/, ['']);
+            projFile = projFilePath;
 
             properties.packageFileType = projFilePath.endsWith('.csproj') ? '.csproj' : '.fsproj';
             properties.packageFileSubfolderDepth = getSubfolderDepth(serviceNameAndPathRelativeToRoot);
@@ -406,6 +408,7 @@ async function configureCore(actionContext: IActionContext, options: ConfigureAp
 
     if (targetFramework) {
         packageInfo.version = targetFramework;
+        packageInfo.artifactName = projFile;
     }
 
     let filesWritten: string[] = [];

--- a/configureWorkspace/configure.ts
+++ b/configureWorkspace/configure.ts
@@ -51,7 +51,7 @@ interface PomXmlContents {
 export type ConfigureTelemetryProperties = {
     configurePlatform?: Platform;
     configureOs?: PlatformOS;
-    packageFileType?: string; // 'build.gradle', 'pom.xml', 'package.json', '.csproj'
+    packageFileType?: string; // 'build.gradle', 'pom.xml', 'package.json', '.csproj', '.fsproj'
     packageFileSubfolderDepth?: string; // 0 = project/etc file in root folder, 1 = in subfolder, 2 = in subfolder of subfolder, etc.
 };
 
@@ -238,17 +238,17 @@ async function readPomOrGradle(folderPath: string): Promise<{ foundPath?: string
 }
 
 // Returns the relative path of the project file without the extension
-async function findCSProjFile(folderPath: string): Promise<string> {
+async function findCSProjOrFSProjFile(folderPath: string): Promise<string> {
     const opt: vscode.QuickPickOptions = {
         matchOnDescription: true,
         matchOnDetail: true,
         placeHolder: 'Select Project'
     }
 
-    const projectFiles: string[] = await globAsync('**/*.csproj', { cwd: folderPath });
+    const projectFiles: string[] = await globAsync('**/*.@(c|f)sproj', { cwd: folderPath });
 
     if (!projectFiles || !projectFiles.length) {
-        throw new Error("No .csproj file could be found. You need a C# project file in the workspace to generate Docker files for the selected platform.");
+        throw new Error("No .csproj or .fsproj file could be found. You need a C# or F# project file in the workspace to generate Docker files for the selected platform.");
     }
 
     if (projectFiles.length > 1) {
@@ -369,14 +369,14 @@ async function configureCore(actionContext: IActionContext, options: ConfigureAp
         // Scope serviceNameAndPathRelativeToRoot only to this block of code
         let serviceNameAndPathRelativeToRoot: string;
         if (platformType.toLowerCase().includes('.net')) {
-            let csProjFilePath = await findCSProjFile(rootFolderPath);
-            serviceNameAndPathRelativeToRoot = csProjFilePath.slice(0, -'.csproj'.length);
-            let csProjFileContents = (await fse.readFile(path.join(rootFolderPath, csProjFilePath))).toString();
+            let projFilePath = await findCSProjOrFSProjFile(rootFolderPath);
+            serviceNameAndPathRelativeToRoot = projFilePath;
+            let projFileContents = (await fse.readFile(path.join(rootFolderPath, projFilePath))).toString();
 
             // Extract TargetFramework for version
-            [targetFramework] = extractRegExGroups(csProjFileContents, /<TargetFramework>(.+)<\/TargetFramework/, ['']);
+            [targetFramework] = extractRegExGroups(projFileContents, /<TargetFramework>(.+)<\/TargetFramework/, ['']);
 
-            properties.packageFileType = '.csproj';
+            properties.packageFileType = projFilePath.endsWith('.csproj') ? '.csproj' : '.fsproj';
             properties.packageFileSubfolderDepth = getSubfolderDepth(serviceNameAndPathRelativeToRoot);
         } else {
             serviceNameAndPathRelativeToRoot = path.basename(rootFolderPath).toLowerCase();

--- a/configureWorkspace/configure_dotnetcore.ts
+++ b/configureWorkspace/configure_dotnetcore.ts
@@ -155,20 +155,21 @@ ENTRYPOINT ["dotnet", "$assembly_name$.dll"]
 
 //#endregion
 
-function genDockerFile(projectFileAndRelativePath: string, platform: Platform, os: PlatformOS | undefined, port: string, { version }: Partial<PackageInfo>): string {
+function genDockerFile(serviceNameAndRelativePath: string, platform: Platform, os: PlatformOS | undefined, port: string, { version, artifactName }: Partial<PackageInfo>): string {
     // VS version of this function is in ResolveImageNames (src/Docker/Microsoft.VisualStudio.Docker.DotNetCore/DockerDotNetCoreScaffoldingProvider.cs)
 
     if (os !== 'Windows' && os !== 'Linux') {
         throw new Error(`Unexpected OS "${os}"`);
     }
-    let parsedProjectFileAndRelativePath = path.parse(projectFileAndRelativePath);
-    let projectDirectory = parsedProjectFileAndRelativePath.dir;
-    let projectFileName = parsedProjectFileAndRelativePath.base;
+
+    let serviceName = path.basename(serviceNameAndRelativePath);
+    let projectDirectory = path.dirname(serviceNameAndRelativePath);
+    let projectFileName = path.basename(artifactName);
 
     // We don't want the project folder in $assembly_name$ because the assembly is in /app and WORKDIR has been set to that
-    let assemblyNameNoExtension = parsedProjectFileAndRelativePath.name;
+    let assemblyNameNoExtension = serviceName;
     // example: COPY Core2.0ConsoleAppWindows/Core2.0ConsoleAppWindows.csproj Core2.0ConsoleAppWindows/
-    let copyProjectCommands = `COPY ["${projectFileAndRelativePath}", "${projectDirectory}/"]`
+    let copyProjectCommands = `COPY ["${artifactName}", "${projectDirectory}/"]`
     let exposeStatements = getExposeStatements(port);
 
     // Parse version from TargetFramework

--- a/configureWorkspace/configure_dotnetcore.ts
+++ b/configureWorkspace/configure_dotnetcore.ts
@@ -155,20 +155,20 @@ ENTRYPOINT ["dotnet", "$assembly_name$.dll"]
 
 //#endregion
 
-function genDockerFile(serviceNameAndRelativePath: string, platform: Platform, os: PlatformOS | undefined, port: string, { version }: Partial<PackageInfo>): string {
+function genDockerFile(projectFileAndRelativePath: string, platform: Platform, os: PlatformOS | undefined, port: string, { version }: Partial<PackageInfo>): string {
     // VS version of this function is in ResolveImageNames (src/Docker/Microsoft.VisualStudio.Docker.DotNetCore/DockerDotNetCoreScaffoldingProvider.cs)
 
     if (os !== 'Windows' && os !== 'Linux') {
         throw new Error(`Unexpected OS "${os}"`);
     }
+    let parsedProjectFileAndRelativePath = path.parse(projectFileAndRelativePath);
+    let projectDirectory = parsedProjectFileAndRelativePath.dir;
+    let projectFileName = parsedProjectFileAndRelativePath.base;
 
-    let serviceName = path.basename(serviceNameAndRelativePath);
-    let projectDirectory = path.dirname(serviceNameAndRelativePath);
-    let projectFileName = `${serviceName}.csproj`;
     // We don't want the project folder in $assembly_name$ because the assembly is in /app and WORKDIR has been set to that
-    let assemblyNameNoExtension = serviceName;
+    let assemblyNameNoExtension = parsedProjectFileAndRelativePath.name;
     // example: COPY Core2.0ConsoleAppWindows/Core2.0ConsoleAppWindows.csproj Core2.0ConsoleAppWindows/
-    let copyProjectCommands = `COPY ["${serviceNameAndRelativePath}.csproj", "${projectDirectory}/"]`
+    let copyProjectCommands = `COPY ["${projectFileAndRelativePath}", "${projectDirectory}/"]`
     let exposeStatements = getExposeStatements(port);
 
     // Parse version from TargetFramework

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -101,7 +101,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         const { appProject, resolvedAppProject } = await this.inferAppProject(folder, debugConfiguration, resolvedAppFolder);
 
-        const appName = path.basename(resolvedAppProject, '.csproj');
+        const appName = path.parse(resolvedAppProject).name;
 
         const os = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.os
             ? debugConfiguration.dockerRun.os
@@ -195,8 +195,8 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
     private static inferVolumes(folder: WorkspaceFolder, debugConfiguration: DockerDebugConfiguration): DockerContainerVolume[] {
         return debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.volumes
-        ? debugConfiguration.dockerRun.volumes.map(volume => ({ ...volume, localPath: DockerDebugConfigurationProvider.resolveFolderPath(volume.localPath, folder) }))
-        : [];
+            ? debugConfiguration.dockerRun.volumes.map(volume => ({ ...volume, localPath: DockerDebugConfigurationProvider.resolveFolderPath(volume.localPath, folder) }))
+            : [];
     }
 
     private async inferAppFolder(folder: WorkspaceFolder, configuration: DockerDebugConfiguration): Promise<{ appFolder: string, resolvedAppFolder: string }> {
@@ -247,7 +247,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         if (appProject === undefined) {
             const files = await this.fsProvider.readDir(resolvedAppFolder);
 
-            const projectFile = files.find(file => path.extname(file) === '.csproj');
+            const projectFile = files.find(file => ['.csproj', '.fsproj'].includes(path.extname(file)));
 
             if (projectFile) {
                 appProject = path.join(resolvedAppFolder, projectFile);

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -570,13 +570,13 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     },
                     ['Windows']
                 ),
-                { message: "No .csproj file could be found. You need a C# project file in the workspace to generate Docker files for the selected platform." }
+                { message: "No .csproj or .fsproj file could be found. You need a C# or F# project file in the workspace to generate Docker files for the selected platform." }
             );
         });
 
         testInEmptyFolder("ASP.NET Core no project file", async () => {
             await assertEx.throwsOrRejectsAsync(async () => testConfigureDocker('ASP.NET Core', {}, ['Windows', '1234']),
-                { message: "No .csproj file could be found. You need a C# project file in the workspace to generate Docker files for the selected platform." }
+                { message: "No .csproj or .fsproj file could be found. You need a C# or F# project file in the workspace to generate Docker files for the selected platform." }
             );
         });
 


### PR DESCRIPTION
**Tested only on Windows 10 machine with Docker for Windows** using template generated fsharp app and generated dockerfile.

~~After refreshing my branch with master the debugging feature stopped working for my setup and the changes in commit e6cc443 are workarounds for those problems:~~
1. ~~Before changing the  single quotes to double quotes in platform checking docker exec call it resulted in `Syntax error: Unterminated quoted string`  error.~~
2. ~~The call to ` this.debuggerClient.getDebugger` was returning path with backslashes. This also caused error. Please confirm that this is the right place to do the normalization if you decide to merge this.~~