### PR TITLE
Resolve .NET Core debugging on Windows

### DIFF
--- a/debugging/coreclr/debuggerClient.ts
+++ b/debugging/coreclr/debuggerClient.ts
@@ -21,7 +21,7 @@ export class DefaultDebuggerClient {
     // This script determines the "type" of Linux release (e.g. 'alpine', 'debian', etc.).
     // NOTES:
     //   - The result may contain line endings.
-    //   - Windows seems to insist on double quotes
+    //   - Windows seems to insist on double quotes.
     private static debuggerLinuxReleaseIdScript: string = '/bin/sh -c \'ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID\'';
     private static debuggerLinuxReleaseIdScriptOnWindows: string = '/bin/sh -c \"ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID\"';
 

--- a/debugging/coreclr/registerDebugger.ts
+++ b/debugging/coreclr/registerDebugger.ts
@@ -39,6 +39,7 @@ export function registerDebugConfigurationProvider(ctx: vscode.ExtensionContext)
             new DefaultAppStorageProvider(fileSystemProvider),
             new DefaultDebuggerClient(
                 dockerClient,
+                osProvider,
                 new RemoteVsDbgClient(
                     dockerOutputManager,
                     fileSystemProvider,


### PR DESCRIPTION
gdziadkiewicz had discovered that I broke debugging .NET Core in Docker on Windows with the previous Alpine support commit, and was also kind enough to suggest a workaround in PR #795 (a larger change to support F# project debugging).

For simplicity, I've split that workaround into a separate PR and updated/verified it to work across Mac/Ubuntu/Windows.  The changes are:

 - Use a double-quoted script string to obtain the container debugger type when VS Code is running on Windows.
 - Normalize the relative (host) path returned by the debugging client for the target (i.e. container's) platform.