### PR TITLE
Add support for Redstone 5

### DIFF
--- a/configureWorkspace/configure_dotnetcore.ts
+++ b/configureWorkspace/configure_dotnetcore.ts
@@ -8,7 +8,7 @@ import * as nodeOs from 'os';
 import * as path from 'path';
 import * as semver from 'semver';
 import { extractRegExGroups } from '../helpers/extractRegExGroups';
-import { isWindows, isWindows10RS3OrNewer, isWindows10RS4OrNewer } from '../helpers/osVersion';
+import { isWindows, isWindows10RS3OrNewer, isWindows10RS4OrNewer, isWindows10RS5OrNewer } from '../helpers/osVersion';
 import { Platform, PlatformOS } from '../utils/platform';
 import { getExposeStatements, IPlatformGeneratorInfo, PackageInfo } from './configure';
 
@@ -36,8 +36,10 @@ const DotNetCoreSdkImageFormat = "microsoft/dotnet:{0}.{1}-sdk{2}";
 
 function GetWindowsImageTag(): string {
     // The host OS version needs to match the version of .NET core images being created
-    if (!isWindows() || isWindows10RS4OrNewer()) {
+    if (!isWindows() || isWindows10RS5OrNewer()) {
         // If we're not on Windows (and therefore can't detect the version), assume a Windows RS4 host
+        return "-nanoserver-1809";
+    } else if (isWindows10RS4OrNewer()) {
         return "-nanoserver-1803";
     } else if (isWindows10RS3OrNewer()) {
         return "-nanoserver-1709";

--- a/configureWorkspace/configure_dotnetcore.ts
+++ b/configureWorkspace/configure_dotnetcore.ts
@@ -37,7 +37,7 @@ const DotNetCoreSdkImageFormat = "microsoft/dotnet:{0}.{1}-sdk{2}";
 function GetWindowsImageTag(): string {
     // The host OS version needs to match the version of .NET core images being created
     if (!isWindows() || isWindows10RS5OrNewer()) {
-        // If we're not on Windows (and therefore can't detect the version), assume a Windows RS4 host
+        // If we're not on Windows (and therefore can't detect the version), assume a Windows RS5 host
         return "-nanoserver-1809";
     } else if (isWindows10RS4OrNewer()) {
         return "-nanoserver-1803";

--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -25,7 +25,7 @@ export { IKeytar } from './utils/keytar';
 export { throwDockerConnectionError, internal } from './explorer/utils/dockerConnectionError';
 export { getImageOrContainerDisplayName } from './explorer/models/getImageOrContainerDisplayName';
 export { trimWithElipsis } from './explorer/utils/utils';
-export { isWindows10RS3OrNewer, isWindows10RS4OrNewer } from "./helpers/osVersion";
+export { isWindows10RS3OrNewer, isWindows10RS4OrNewer, isWindows10RS5OrNewer } from "./helpers/osVersion";
 export { LineSplitter } from './debugging/coreclr/lineSplitter';
 export { CommandLineBuilder } from './debugging/coreclr/commandLineBuilder';
 export { DockerClient } from './debugging/coreclr/dockerClient';

--- a/helpers/osVersion.ts
+++ b/helpers/osVersion.ts
@@ -12,8 +12,19 @@ const windows10RS3MinVersion = '10.0.16299';
 // Minimum Windows RS4 version number
 const windows10RS4MinVersion = '10.0.17134';
 
+// Minimum Windows RS5 version number
+const windows10RS5MinVersion = "10.0.17763";
+
 export function isWindows(): boolean {
     return ext.os.platform === 'win32';
+}
+
+export function isWindows10RS5OrNewer(): boolean {
+  if (!isWindows()) {
+    return false;
+  }
+
+  return semver.gte(ext.os.release, windows10RS5MinVersion);
 }
 
 export function isWindows10RS4OrNewer(): boolean {

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -939,8 +939,8 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                 'project1.csproj',
                 aspNet_22_ProjectFileContents);
 
-            assertFileContains('Dockerfile', 'FROM microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1803 AS base');
-            assertFileContains('Dockerfile', 'FROM microsoft/dotnet:2.2-sdk-nanoserver-1803 AS build');
+            assertFileContains('Dockerfile', 'FROM microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1809 AS base');
+            assertFileContains('Dockerfile', 'FROM microsoft/dotnet:2.2-sdk-nanoserver-1809 AS build');
         });
     });
 

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -19,6 +19,7 @@ const outputAllGeneratedFileContents = false;
 const windowsServer2016 = '10.0.14393';
 const windows10RS3 = '10.0.16299';
 const windows10RS4 = '10.0.17134';
+const windows10RS5 = '10.0.17763';
 
 let testRootFolder: string = getTestRootFolder();
 
@@ -607,7 +608,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             await testDotNetCoreConsole(
                 'Windows',
                 'Windows',
-                windows10RS4,
+                windows10RS5,
                 'ConsoleApp1Folder',
                 'ConsoleApp1.csproj',
                 dotNetCoreConsole_21_ProjectFileContents,
@@ -615,10 +616,10 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     #Depending on the operating system of the host machines(s) that will build or run the containers, the image specified in the FROM statement may need to be changed.
                     #For more information, please see https://aka.ms/containercompat
 
-                    FROM microsoft/dotnet:2.1-runtime-nanoserver-1803 AS base
+                    FROM microsoft/dotnet:2.1-runtime-nanoserver-1809 AS base
                     WORKDIR /app
 
-                    FROM microsoft/dotnet:2.1-sdk-nanoserver-1803 AS build
+                    FROM microsoft/dotnet:2.1-sdk-nanoserver-1809 AS build
                     WORKDIR /src
                     COPY ["ConsoleApp1Folder/ConsoleApp1.csproj", "ConsoleApp1Folder/"]
                     RUN dotnet restore "ConsoleApp1Folder/ConsoleApp1.csproj"
@@ -676,7 +677,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             await testDotNetCoreConsole(
                 'Windows',
                 'Windows',
-                windows10RS4,
+                windows10RS5,
                 'subfolder/projectFolder',
                 'ConsoleApp1.csproj',
                 dotNetCoreConsole_20_ProjectFileContents,
@@ -684,10 +685,10 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     #Depending on the operating system of the host machines(s) that will build or run the containers, the image specified in the FROM statement may need to be changed.
                     #For more information, please see https://aka.ms/containercompat
 
-                    FROM microsoft/dotnet:2.0-runtime-nanoserver-1803 AS base
+                    FROM microsoft/dotnet:2.0-runtime-nanoserver-1809 AS base
                     WORKDIR /app
 
-                    FROM microsoft/dotnet:2.0-sdk-nanoserver-1803 AS build
+                    FROM microsoft/dotnet:2.0-sdk-nanoserver-1809 AS build
                     WORKDIR /src
                     COPY ["subfolder/projectFolder/ConsoleApp1.csproj", "subfolder/projectFolder/"]
                     RUN dotnet restore "subfolder/projectFolder/ConsoleApp1.csproj"
@@ -745,7 +746,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             await testDotNetCoreConsole(
                 'Windows',
                 'Windows',
-                windows10RS4,
+                windows10RS5,
                 'subfolder/projectFolder',
                 'ConsoleApp1.csproj',
                 dotNetCoreConsole_11_ProjectFileContents);
@@ -775,14 +776,14 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             await testDotNetCoreConsole(
                 'Windows',
                 'Windows',
-                windows10RS4,
+                windows10RS5,
                 'subfolder/projectFolder',
                 'ConsoleApp1.csproj',
                 dotNetCoreConsole_22_ProjectFileContents);
 
             assertNotFileContains('Dockerfile', 'EXPOSE');
-            assertFileContains('Dockerfile', 'FROM microsoft/dotnet:2.2-runtime-nanoserver-1803 AS base');
-            assertFileContains('Dockerfile', 'FROM microsoft/dotnet:2.2-sdk-nanoserver-1803 AS build');
+            assertFileContains('Dockerfile', 'FROM microsoft/dotnet:2.2-runtime-nanoserver-1809 AS base');
+            assertFileContains('Dockerfile', 'FROM microsoft/dotnet:2.2-sdk-nanoserver-1809 AS build');
         });
 
         testInEmptyFolder("Linux", async () => {
@@ -825,11 +826,11 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertNotFileContains('Dockerfile', 'EXPOSE');
         });
 
-        testInEmptyFolder("Windows 10 RS4", async () => {
+        testInEmptyFolder("Windows 10 RS5", async () => {
             await testAspNetCore(
                 'Windows',
                 'Windows',
-                windows10RS4,
+                windows10RS5,
                 'AspNetApp1',
                 'project1.csproj',
                 aspNet_22_ProjectFileContents,
@@ -837,11 +838,11 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     #Depending on the operating system of the host machines(s) that will build or run the containers, the image specified in the FROM statement may need to be changed.
                     #For more information, please see https://aka.ms/containercompat
 
-                    FROM microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1803 AS base
+                    FROM microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1809 AS base
                     WORKDIR /app
                     EXPOSE 1234
 
-                    FROM microsoft/dotnet:2.2-sdk-nanoserver-1803 AS build
+                    FROM microsoft/dotnet:2.2-sdk-nanoserver-1809 AS build
                     WORKDIR /src
                     COPY ["AspNetApp1/project1.csproj", "AspNetApp1/"]
                     RUN dotnet restore "AspNetApp1/project1.csproj"
@@ -890,6 +891,19 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                 `));
         });
 
+        testInEmptyFolder("Windows 10 RS4", async () => {
+            await testAspNetCore(
+                'Windows',
+                'Windows',
+                windows10RS4,
+                'AspNetApp1',
+                'project1.csproj',
+                aspNet_22_ProjectFileContents);
+
+            assertFileContains('Dockerfile', 'FROM microsoft/dotnet:2.2-aspnetcore-runtime-nanoserver-1803 AS base');
+            assertFileContains('Dockerfile', 'FROM microsoft/dotnet:2.2-sdk-nanoserver-1803 AS build');
+        });
+
         testInEmptyFolder("Windows 10 RS3", async () => {
             await testAspNetCore(
                 'Windows',
@@ -935,7 +949,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             await testAspNetCore(
                 'Windows',
                 'Windows',
-                windows10RS4,
+                windows10RS5,
                 'AspNetApp1',
                 'project1.csproj',
                 aspNet_10_ProjectFileContents);


### PR DESCRIPTION
Add support for Redstone 5 which should generate Dockerfiles referencing -1809 images

Fixes #805 