### PR TITLE
Use Log In/Out consistently for Docker Hub

### DIFF
--- a/explorer/models/registryRootNode.ts
+++ b/explorer/models/registryRootNode.ts
@@ -185,7 +185,7 @@ export class RegistryRootNode extends NodeBase {
 
 export class DockerHubNotSignedInNode extends NodeBase {
     constructor() {
-        super('Sign in to Docker Hub...');
+        super('Log In to Docker Hub...');
     }
 
     public readonly contextValue: string = 'dockerHubNotSignedInNode';


### PR DESCRIPTION
Don't ask why Azure uses Sign In and Docker Hub uses Log In, but I kept our terminology consistent with those.

Fixes #829 