### PR TITLE
Add `networkAlias` option to Docker run configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Customize the Docker container run process by adding properties under the `docke
 | `extraHosts` | Hosts to be added to the container's `hosts` file for DNS resolution. | None |
 | `labels` | The set of labels added to the container. | `com.microsoft.created-by` = `visual-studio-code` |
 | `network` | The network to which the container will be connected. Use values as described in the [Docker run documentation](https://docs.docker.com/engine/reference/run/#network-settings). | `bridge` |
+| `networkAlias` | The network-scoped alias to assign to the container. | None |
 | `ports` | Ports that are going to be mapped on the host. | All ports exposed by the Dockerfile will be bound to a random port on the host machine |
 | `volumes` | Volumes that are going to be mapped to the container. | None |
 
@@ -271,6 +272,7 @@ Example run customization:
                     "label2": "value2"
                 },
                 "network": "host",
+                "networkAlias": "mycontainer",
                 "ports": [
                     {
                         "hostPort": 80,

--- a/debugging/coreclr/dockerClient.ts
+++ b/debugging/coreclr/dockerClient.ts
@@ -53,6 +53,7 @@ export type DockerRunContainerOptions = {
     extraHosts?: DockerContainerExtraHost[];
     labels?: { [key: string]: string };
     network?: string;
+    networkAlias?: string;
     ports?: DockerContainerPort[];
     volumes?: DockerContainerVolume[];
 };
@@ -211,6 +212,7 @@ export class CliDockerClient implements DockerClient {
             .withFlagArg('-P', options.ports === undefined || options.ports.length < 1)
             .withNamedArg('--name', options.containerName)
             .withNamedArg('--network', options.network)
+            .withNamedArg('--network-alias', options.networkAlias)
             .withKeyValueArgs('-e', options.env)
             .withArrayArgs('--env-file', options.envFiles)
             .withKeyValueArgs('--label', options.labels)

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -30,6 +30,7 @@ interface DockerDebugRunOptions {
     extraHosts?: DockerContainerExtraHost[];
     labels?: { [key: string]: string };
     network?: string;
+    networkAlias?: string;
     os?: PlatformOS;
     ports?: DockerContainerPort[];
     volumes?: DockerContainerVolume[];
@@ -176,6 +177,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
             || DockerDebugConfigurationProvider.defaultLabels;
 
         const network = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.network;
+        const networkAlias = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.networkAlias;
         const ports = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.ports;
         const volumes = DockerDebugConfigurationProvider.inferVolumes(folder, debugConfiguration);
         const extraHosts = debugConfiguration && debugConfiguration.dockerRun && debugConfiguration.dockerRun.extraHosts;
@@ -187,6 +189,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
             extraHosts,
             labels,
             network,
+            networkAlias,
             os,
             ports,
             volumes

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -220,6 +220,7 @@ export class DefaultDockerManager implements DockerManager {
                         extraHosts: options.extraHosts,
                         labels: options.labels,
                         network: options.network,
+                        networkAlias: options.networkAlias,
                         ports: options.ports,
                         volumes: [...(volumes || []), ...(options.volumes || [])]
                     });

--- a/package.json
+++ b/package.json
@@ -452,6 +452,10 @@
                     "type": "string",
                     "description": "The network to which the container will be connected."
                   },
+                  "networkAlias": {
+                    "type": "string",
+                    "description": "The network-scoped alias to assign to the container."
+                  },
                   "ports": {
                     "type": "array",
                     "description": "Ports that are going to be mapped on the host.",


### PR DESCRIPTION
Adds the `networkAlias` option to the Docker .NET Core debugging run configuration. This option corresponds to the `--network-alias` option of the `docker run` command.  This resolves #884.