### PR TITLE
Ensure debugger directory exists

### DIFF
--- a/debugging/coreclr/appStorage.ts
+++ b/debugging/coreclr/appStorage.ts
@@ -38,9 +38,7 @@ export class DefaultAppStorage implements MementoAsync {
         if (item) {
             const itemDir = path.dirname(itemPath);
 
-            if (!await this.fileSystemProvider.dirExists(itemDir)) {
-                await this.fileSystemProvider.makeDir(itemDir);
-            }
+            await this.fileSystemProvider.ensureDir(itemDir);
 
             await this.fileSystemProvider.writeFile(itemPath, JSON.stringify(item));
         } else {

--- a/debugging/coreclr/fsProvider.ts
+++ b/debugging/coreclr/fsProvider.ts
@@ -7,9 +7,9 @@ import * as fse from 'fs-extra';
 
 export interface FileSystemProvider {
     dirExists(path: string): Promise<boolean>;
+    ensureDir(path: string): Promise<void>;
     fileExists(path: string): Promise<boolean>;
     hashFile(path: string): Promise<string>;
-    makeDir(path: string): Promise<void>;
     readDir(path: string): Promise<string[]>;
     readFile(filename: string, encoding?: string): Promise<string>;
     unlinkFile(filename: string): Promise<void>;
@@ -31,6 +31,10 @@ export class LocalFileSystemProvider implements FileSystemProvider {
 
             throw err;
         }
+    }
+
+    public async ensureDir(path: string): Promise<void> {
+        return await fse.ensureDir(path);
     }
 
     public async fileExists(path: string): Promise<boolean> {
@@ -56,10 +60,6 @@ export class LocalFileSystemProvider implements FileSystemProvider {
         hash.update(contents);
 
         return hash.digest('hex');
-    }
-
-    public async makeDir(path: string): Promise<void> {
-        return await fse.mkdir(path);
     }
 
     public async readDir(path: string): Promise<string[]> {

--- a/debugging/coreclr/vsdbgClient.ts
+++ b/debugging/coreclr/vsdbgClient.ts
@@ -98,11 +98,7 @@ export class RemoteVsDbgClient implements VsDbgClient {
     }
 
     private async ensureVsDbgFolderExists(): Promise<void> {
-        const directoryExists = await this.fileSystemProvider.dirExists(this.vsdbgPath);
-
-        if (!directoryExists) {
-            await this.fileSystemProvider.makeDir(this.vsdbgPath);
-        }
+        await this.fileSystemProvider.ensureDir(this.vsdbgPath);
     }
 
     private async getVsDbgAcquisitionScript(): Promise<void> {

--- a/debugging/coreclr/vsdbgClient.ts
+++ b/debugging/coreclr/vsdbgClient.ts
@@ -59,6 +59,11 @@ export class RemoteVsDbgClient implements VsDbgClient {
     }
 
     public async getVsDbgFolder(): Promise<string> {
+        // NOTE: If non-existant, other processes (e.g. Docker when volume mounting) may attempt to create this folder.
+        //       This can lead to "access denied" if those processes run elevated compared to VS Code.
+        //       Therefore, ensure it's created before they're ever given the folder name.
+        await this.ensureVsDbgFolderExists();
+
         return this.vsdbgPath;
     }
 
@@ -92,6 +97,14 @@ export class RemoteVsDbgClient implements VsDbgClient {
             'Unable to acquire the .NET Core debugger.');
     }
 
+    private async ensureVsDbgFolderExists(): Promise<void> {
+        const directoryExists = await this.fileSystemProvider.dirExists(this.vsdbgPath);
+
+        if (!directoryExists) {
+            await this.fileSystemProvider.makeDir(this.vsdbgPath);
+        }
+    }
+
     private async getVsDbgAcquisitionScript(): Promise<void> {
         const vsdbgAcquisitionScriptPath = path.join(this.vsdbgPath, this.options.name);
         const acquisitionScriptExists = await this.fileSystemProvider.fileExists(vsdbgAcquisitionScriptPath);
@@ -101,11 +114,7 @@ export class RemoteVsDbgClient implements VsDbgClient {
             return;
         }
 
-        const directoryExists = await this.fileSystemProvider.dirExists(this.vsdbgPath);
-
-        if (!directoryExists) {
-            await this.fileSystemProvider.makeDir(this.vsdbgPath);
-        }
+        await this.ensureVsDbgFolderExists();
 
         const script = await ext.request(this.options.url);
 


### PR DESCRIPTION
Ensure the debugger directory exists prior to starting the container (or, rather, before any possible use of the directory), to prevent it potentially being created with permissions different than those used by VS Code (to actually acquire the debugger).

This resolves #897.