### PR TITLE
Turn on noUnusedLocals

### DIFF
--- a/commands/azureCommands/acr-logs.ts
+++ b/commands/azureCommands/acr-logs.ts
@@ -60,7 +60,10 @@ export async function viewACRLogs(context: AzureRegistryNode | AzureImageTagNode
         if (context instanceof TaskNode) {
             webViewTitle += '/' + context.label;
         }
-        const webview = new LogTableWebview(webViewTitle, logData);
+
+        // grandfathered in - should ideally be refactored so that calling a constructor does not have side effects
+        // tslint:disable-next-line: no-unused-expression
+        new LogTableWebview(webViewTitle, logData);
     }
 }
 

--- a/commands/azureCommands/pull-from-azure.ts
+++ b/commands/azureCommands/pull-from-azure.ts
@@ -6,11 +6,7 @@
 import * as assert from 'assert';
 import { Registry } from "azure-arm-containerregistry/lib/models";
 import { exec } from 'child_process';
-import * as fse from 'fs-extra';
-import os = require('os');
-import * as path from "path";
 import vscode = require('vscode');
-import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { AzureImageTagNode, AzureRepositoryNode } from '../../explorer/models/azureRegistryNodes';
 import { ext } from '../../extensionVariables';
 import * as acrTools from '../../utils/Azure/acrTools';
@@ -90,19 +86,4 @@ async function pullImage(loginServer: string, imageRequest: string, username: st
     terminal.show();
 
     terminal.sendText(`docker pull ${loginServer}/${imageRequest}`);
-}
-
-async function isLoggedIntoDocker(loginServer: string): Promise<{ configPath: string, loggedIn: boolean }> {
-    const home = os.homedir();
-    let configPath: string = path.join(home, '.docker', 'config.json');
-    let buffer: Buffer;
-
-    await callWithTelemetryAndErrorHandling('findDockerConfig', async function (this: IActionContext): Promise<void> {
-        this.suppressTelemetry = true;
-        buffer = fse.readFileSync(configPath);
-    });
-
-    let index = buffer.indexOf(loginServer);
-    let loggedIn = index >= 0; // Returns -1 if user is not logged into Docker
-    return { configPath, loggedIn }; // Returns object with configuration path and boolean indicating if user was logged in or not
 }

--- a/commands/remove-container.ts
+++ b/commands/remove-container.ts
@@ -11,8 +11,6 @@ import { ext } from '../extensionVariables';
 import { AllStatusFilter, docker, ListContainerDescOptions } from './utils/docker-endpoint';
 import { quickPickContainerOrAll } from './utils/quick-pick-container';
 
-const teleCmdId: string = 'vscode-docker.container.remove';
-
 export async function removeContainer(actionContext: IActionContext, context: RootNode | ContainerNode | undefined): Promise<void> {
 
     let containersToRemove: Docker.ContainerDesc[];

--- a/commands/showlogs-container.ts
+++ b/commands/showlogs-container.ts
@@ -3,14 +3,12 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerDesc } from 'dockerode';
-import vscode = require('vscode');
 import { IActionContext } from 'vscode-azureextensionui';
 import { ContainerNode } from '../explorer/models/containerNode';
 import { RootNode } from '../explorer/models/rootNode';
 import { ext } from '../extensionVariables';
 import { AllStatusFilter, ListContainerDescOptions } from './utils/docker-endpoint';
-import { ContainerItem, quickPickContainer } from './utils/quick-pick-container';
+import { quickPickContainer } from './utils/quick-pick-container';
 
 export async function showLogsContainer(actionContext: IActionContext, context: RootNode | ContainerNode | undefined): Promise<void> {
 

--- a/configureWorkspace/config-utils.ts
+++ b/configureWorkspace/config-utils.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isNumber } from 'util';
 import vscode = require('vscode');
-import { IAzureQuickPickItem, IAzureUserInput } from 'vscode-azureextensionui';
+import { IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { ext } from "../extensionVariables";
 import { Platform, PlatformOS } from '../utils/platform';
 

--- a/configureWorkspace/configure_cpp.ts
+++ b/configureWorkspace/configure_cpp.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getExposeStatements, IPlatformGeneratorInfo, PackageInfo } from './configure';
+import { IPlatformGeneratorInfo, PackageInfo } from './configure';
 
 export let configureCpp: IPlatformGeneratorInfo = {
   genDockerFile,
@@ -13,8 +13,6 @@ export let configureCpp: IPlatformGeneratorInfo = {
 };
 
 function genDockerFile(serviceNameAndRelativePath: string, platform: string, os: string | undefined, port: string, { cmd, author, version, artifactName }: Partial<PackageInfo>): string {
-  let exposeStatements = getExposeStatements(port);
-
   return `# GCC support can be specified at major, minor, or micro version
 # (e.g. 8, 8.2 or 8.2.0).
 # See https://hub.docker.com/r/library/gcc/ for all supported GCC

--- a/configureWorkspace/configure_dotnetcore.ts
+++ b/configureWorkspace/configure_dotnetcore.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as nodeOs from 'os';
 import * as path from 'path';
 import * as semver from 'semver';
 import { extractRegExGroups } from '../helpers/extractRegExGroups';

--- a/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -100,7 +100,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
         const { appFolder, resolvedAppFolder } = await this.inferAppFolder(folder, debugConfiguration);
 
-        const { appProject, resolvedAppProject } = await this.inferAppProject(folder, debugConfiguration, resolvedAppFolder);
+        const { resolvedAppProject } = await this.inferAppProject(folder, debugConfiguration, resolvedAppFolder);
 
         const appName = path.parse(resolvedAppProject).name;
 

--- a/debugging/coreclr/dockerManager.ts
+++ b/debugging/coreclr/dockerManager.ts
@@ -60,11 +60,6 @@ type LastImageBuildMetadata = {
     options: DockerBuildImageOptions;
 };
 
-type LastContainerRunMetadata = {
-    containerId: string;
-    options: DockerRunContainerOptions;
-}
-
 export interface DockerManager {
     buildImage(options: DockerManagerBuildImageOptions): Promise<string>;
     runContainer(imageTagOrId: string, options: DockerManagerRunContainerOptions): Promise<string>;

--- a/debugging/coreclr/netCoreProjectProvider.ts
+++ b/debugging/coreclr/netCoreProjectProvider.ts
@@ -2,13 +2,12 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import * as path from 'path';
 import { DotNetClient } from "./dotNetClient";
 import { FileSystemProvider } from "./fsProvider";
 import { TempFileProvider } from './tempFileProvider';
 
 const getTargetPathProjectFileContent =
-`<Project>
+    `<Project>
     <Target Name="GetTargetPath">
         <MSBuild
             Projects="$(ProjectFilename)"

--- a/dockerCompose/dockerComposeCompletionItemProvider.ts
+++ b/dockerCompose/dockerComposeCompletionItemProvider.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { CancellationToken, CompletionItem, CompletionItemKind, CompletionItemProvider, Position, TextDocument, Uri } from 'vscode';
+import { CancellationToken, CompletionItem, CompletionItemKind, CompletionItemProvider, Position, TextDocument } from 'vscode';
 import { KeyInfo } from '../extension';
 import helper = require('../helpers/suggestSupportHelper');
 import composeVersions from './dockerComposeKeyInfo';

--- a/dockerHubSearch.ts
+++ b/dockerHubSearch.ts
@@ -6,7 +6,6 @@
 'use strict';
 
 import https = require('https');
-import vscode = require('vscode');
 import { httpsRequest } from './utils/httpRequest';
 
 export function tagsForImage(image: IHubSearchResponseResult): string {

--- a/explorer/deploy/azureAccountWrapper.ts
+++ b/explorer/deploy/azureAccountWrapper.ts
@@ -5,13 +5,11 @@
 
 import { SubscriptionClient, SubscriptionModels } from 'azure-arm-resource';
 import { ServiceClientCredentials } from 'ms-rest';
-import { AzureEnvironment } from 'ms-rest-azure';
-import { Disposable, Extension, ExtensionContext, extensions } from 'vscode';
+import { Disposable, ExtensionContext } from 'vscode';
 import { AzureAccount, AzureLoginStatus, AzureSession } from '../../typings/azure-account.api';
 
 import { Subscription } from 'azure-arm-resource/lib/subscription/models';
-import { getSubscriptionId, getTenantId, nonNullValue } from '../../utils/nonNull';
-import * as util from './util';
+import { getSubscriptionId, getTenantId } from '../../utils/nonNull';
 
 export class NotSignedInError extends Error { }
 
@@ -34,7 +32,7 @@ export class AzureAccountWrapper {
 
     public getCredentialByTenantId(tenantIdOrSubscription: string | Subscription): ServiceClientCredentials {
         let tenantId = typeof tenantIdOrSubscription === 'string' ? tenantIdOrSubscription : getTenantId(tenantIdOrSubscription);
-        const session = this.getAzureSessions().find((s, i, array) => s.tenantId.toLowerCase() === tenantId.toLowerCase());
+        const session = this.getAzureSessions().find((s) => s.tenantId.toLowerCase() === tenantId.toLowerCase());
 
         if (session) {
             return session.credentials;

--- a/explorer/deploy/util.ts
+++ b/explorer/deploy/util.ts
@@ -6,9 +6,7 @@
 import { SubscriptionModels } from 'azure-arm-resource';
 import WebSiteManagementClient = require('azure-arm-website');
 import * as WebSiteModels from 'azure-arm-website/lib/models';
-import { ServiceClientCredentials } from 'ms-rest';
-import * as vscode from 'vscode';
-import { getSubscriptionId, getTenantId, nonNullProp, nonNullValue } from '../../utils/nonNull';
+import { getSubscriptionId, nonNullProp } from '../../utils/nonNull';
 import { AzureAccountWrapper } from './azureAccountWrapper';
 
 export interface PartialList<T> extends Array<T> {

--- a/explorer/models/azureRegistryNodes.ts
+++ b/explorer/models/azureRegistryNodes.ts
@@ -99,8 +99,6 @@ export class AzureRepositoryNode extends NodeBase {
     }
 
     public async getChildren(element: AzureRepositoryNode): Promise<AzureImageTagNode[]> {
-        // tslint:disable-next-line:no-this-assignment
-        let me = this;
         return await callWithTelemetryAndErrorHandling('getChildren', async function (this: IActionContext): Promise<AzureImageTagNode[]> {
             this.suppressTelemetry = true;
             this.properties.source = 'azureRepositoryNode';

--- a/explorer/models/customRegistryNodes.ts
+++ b/explorer/models/customRegistryNodes.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { callWithTelemetryAndErrorHandling, IActionContext, parseError } from 'vscode-azureextensionui';
 import { treeUtils } from '../../utils/treeUtils';

--- a/explorer/models/dockerHubNodes.ts
+++ b/explorer/models/dockerHubNodes.ts
@@ -42,8 +42,6 @@ export class DockerHubOrgNode extends NodeBase {
     }
 
     public async getChildren(element: DockerHubOrgNode): Promise<DockerHubRepositoryNode[]> {
-        // tslint:disable-next-line:no-this-assignment
-        let me = this;
         return await callWithTelemetryAndErrorHandling('getChildren', async function (this: IActionContext): Promise<DockerHubRepositoryNode[]> {
             this.suppressTelemetry = true;
             this.properties.source = 'dockerHubOrgNode';
@@ -98,8 +96,6 @@ export class DockerHubRepositoryNode extends NodeBase {
     }
 
     public async getChildren(element: DockerHubRepositoryNode): Promise<DockerHubImageTagNode[]> {
-        // tslint:disable-next-line:no-this-assignment
-        let me = this;
         return await callWithTelemetryAndErrorHandling('getChildren', async function (this: IActionContext): Promise<DockerHubImageTagNode[]> {
             this.suppressTelemetry = true;
             this.properties.source = 'dockerHubRepositoryNode';

--- a/explorer/models/getImageLabel.ts
+++ b/explorer/models/getImageLabel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { ContainerDesc, ImageDesc } from 'dockerode';
+import { ImageDesc } from 'dockerode';
 import * as moment from 'moment';
 import * as vscode from 'vscode';
 import { extractRegExGroups } from '../../helpers/extractRegExGroups';

--- a/explorer/models/rootNode.ts
+++ b/explorer/models/rootNode.ts
@@ -70,10 +70,6 @@ export class RootNode extends NodeBase {
         return this.contextValue === "containersRootNode";
     }
 
-    private get isRegistries(): boolean {
-        return this.contextValue === "registriesRootNode";
-    }
-
     public autoRefreshImages(): void {
         const configOptions: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('docker');
         const refreshInterval: number = configOptions.get<number>('explorerRefreshInterval', 1000);

--- a/explorer/utils/dockerHubUtils.ts
+++ b/explorer/utils/dockerHubUtils.ts
@@ -153,8 +153,6 @@ export function setDockerHubToken(token: string): void {
 }
 
 async function login(username: string, password: string): Promise<Token> {
-    let t: Token;
-
     let options = {
         method: 'POST',
         uri: 'https://hub.docker.com/v2/users/login',

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -143,6 +143,8 @@ async function testConfigureDocker(platform: Platform, expectedTelemetryProperti
             }
         }
     }
+
+    verifyTelemetryProperties(actionContext, expectedTelemetryProperties);
 }
 
 //#region .NET Core Console projects
@@ -394,7 +396,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     configurePlatform: '.NET Core Console',
                     configureOs: os,
                     packageFileType: '.csproj',
-                    packageFileSubfolderDepth: '1'
+                    packageFileSubfolderDepth: projectFolder.includes('/') ? '2' : '1'
                 },
                 [os /* it doesn't ask for a port, so we don't specify one here */],
                 ['Dockerfile', '.dockerignore', `${projectFolder}/Program.cs`, `${projectFolder}/${projectFileName}`]
@@ -1186,6 +1188,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('Dockerfile', 'WORKDIR /usr/src/myapp');
             assertFileContains('Dockerfile', 'RUN g++ -o myapp main.cpp');
             assertFileContains('Dockerfile', 'CMD ["./myapp"]');
+            assertNotFileContains('Dockerfile', 'EXPOSE');
         });
     });
 
@@ -1212,8 +1215,8 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                 {
                     configurePlatform: 'Other',
                     configureOs: undefined,
-                    packageFileType: undefined,
-                    packageFileSubfolderDepth: undefined
+                    packageFileType: 'package.json',
+                    packageFileSubfolderDepth: '0'
                 },
                 [TestInput.UseDefaultValue /*port*/],
                 ['Dockerfile', 'docker-compose.debug.yml', 'docker-compose.yml', '.dockerignore', 'package.json']);

--- a/test/customRegistries.test.ts
+++ b/test/customRegistries.test.ts
@@ -6,11 +6,10 @@
 import * as assertEx from './assertEx';
 import { commands, OutputChannel, window } from 'vscode';
 import { ext } from '../extension.bundle';
-import { Suite, Test, Context } from 'mocha';
+import { Suite, Context } from 'mocha';
 import { TestTerminalProvider } from './TestTerminalProvider';
 import { TestUserInput } from 'vscode-azureextensionui';
 import { shouldSkipDockerTest } from './dockerInfo';
-import { debug } from 'util';
 
 const registryContainerName = 'test-registry';
 

--- a/test/nonNull.test.ts
+++ b/test/nonNull.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { Suite, Test, Context } from 'mocha';
+import { Suite } from 'mocha';
 import { nonNullProp } from '../extension.bundle';
 
 suite("nonNull", async function (this: Suite): Promise<void> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
         "noImplicitAny": false, // TODO
         "noImplicitReturns": false, // TODO
         "noImplicitThis": true,
-        "noUnusedLocals": false, // TODO
+        "noUnusedLocals": true,
         "noUnusedParameters": false, // TODO
         "strictNullChecks": false, // TODO
         "strict": true

--- a/utils/httpRequest.ts
+++ b/utils/httpRequest.ts
@@ -5,7 +5,6 @@
 
 import * as https from 'https';
 import url = require('url');
-import { Uri } from 'vscode';
 import { addUserAgent } from './addUserAgent';
 
 function convertToOptions(options: https.RequestOptions | string): https.RequestOptions {


### PR DESCRIPTION
A few notes:
1. `verifyTelemetryProperties` wasn't used in the configure tests, but seems somewhat useful so I added it and fixed the failing tests
1. the cpp generation was ignoring `exposeStatements`, but I assume that's fine since it says `// We don't open a port for Cpp` a few lines above. Updated the cpp test to reflect this