### PR TITLE
make order of container / image name configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -892,6 +892,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Run docker-compose with the --d (detached) argument, defaults to true"
+                },
+                "docker.imageFirst": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "When displaying containers, show the image first if true, otherwise show the container name first; defaults to true"
                 }
             }
         },

--- a/src/tree/containers/ContainerTreeItem.ts
+++ b/src/tree/containers/ContainerTreeItem.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ContainerInfo } from "dockerode";
+import { workspace } from "vscode";
 import { AzExtParentTreeItem, AzExtTreeItem } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { getThemedIconPath, IconPath } from '../IconPath';
-import { workspace } from 'vscode';
 
 export class ContainerTreeItem extends AzExtTreeItem {
     public static allContextRegExp: RegExp = /Container$/;


### PR DESCRIPTION
If you have multiple containers from the same repo / image, the container list can be difficult to use as you need to make it very wide to be able to distinguish the containers 

![image](https://user-images.githubusercontent.com/15346084/59272346-22c62d80-8c56-11e9-9469-d925a9b51539.png)

As you can see, the first and third container are not distinguishable and for the second the eye also has to travel some way to the right to find the difference. In that case it would be good to have the config setting proposed in my PR which shows the container name first

![image](https://user-images.githubusercontent.com/15346084/59272300-02966e80-8c56-11e9-8b90-07dfdf030cfe.png)


