### PR TITLE
Support all `DOCKER_*` environment variables as VS Code settings

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -15,6 +15,7 @@ const env = process.env;
 function test(): cp.ChildProcess {
     env.DEBUGTELEMETRY = '1';
     env.CODE_TESTS_WORKSPACE = path.join(__dirname, 'test/test.code-workspace');
+    env.MOCHA_timeout = String(10 * 1000);
     env.CODE_TESTS_PATH = path.join(__dirname, 'dist/test');
     return spawn('node', ['./node_modules/vscode/bin/test'], { stdio: 'inherit', env });
 }

--- a/package.json
+++ b/package.json
@@ -988,7 +988,22 @@
                 "docker.host": {
                     "type": "string",
                     "default": "",
-                    "description": "Full host address to connect to (with protocol). Equivalent to setting the DOCKER_HOST environment variable"
+                    "description": "Equivalent to setting the DOCKER_HOST environment variable."
+                },
+                "docker.certPath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Equivalent to setting the DOCKER_CERT_PATH environment variable."
+                },
+                "docker.tlsVerify": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Equivalent to setting the DOCKER_TLS_VERIFY environment variable."
+                },
+                "docker.machineName": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Equivalent to setting the DOCKER_MACHINE_NAME environment variable."
                 },
                 "docker.importCertificates": {
                     "oneOf": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -279,11 +279,11 @@ function refreshDockerode(): void {
     try {
         process.env = { ...process.env }; // make a clone before we change anything
         addDockerSettingsToEnv(process.env, oldEnv);
-        ext.dockerodeError = undefined;
+        ext.dockerodeInitError = undefined;
         ext.dockerode = new Dockerode();
     } catch (error) {
         // This will be displayed in the tree
-        ext.dockerodeError = error;
+        ext.dockerodeInitError = error;
     } finally {
         process.env = oldEnv;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -278,7 +278,7 @@ function refreshDockerode(): void {
     const oldEnv = process.env;
     try {
         process.env = { ...process.env }; // make a clone before we change anything
-        addDockerSettingsToEnv(process.env);
+        addDockerSettingsToEnv(process.env, oldEnv);
         ext.dockerodeError = undefined;
         ext.dockerode = new Dockerode();
     } catch (error) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { DockerComposeParser } from './dockerCompose/dockerComposeParser';
 import { DockerfileCompletionItemProvider } from './dockerfileCompletionItemProvider';
 import { ext } from './extensionVariables';
 import { registerTrees } from './tree/registerTrees';
+import { addDockerSettingsToEnv } from './utils/addDockerSettingsToEnv';
 import { addUserAgent } from './utils/addUserAgent';
 import { getTrustedCertificates } from './utils/getTrustedCertificates';
 import { Keytar } from './utils/keytar';
@@ -269,32 +270,21 @@ function activateLanguageClient(): void {
     });
 }
 
+/**
+ * Dockerode parses and handles the well-known `DOCKER_*` environment variables, but it doesn't let us pass those values as-is to the constructor
+ * Thus we will temporarily update `process.env` and pass nothing to the constructor
+ */
 function refreshDockerode(): void {
-    const value: string = vscode.workspace.getConfiguration("docker").get("host", "");
-    if (value) {
-        let newHost: string = '';
-        let newPort: number = 2375;
-        let sep: number = -1;
-
-        sep = value.lastIndexOf(':');
-
-        const errorMessage = 'The docker.host configuration setting must be entered as <host>:<port>, e.g. dockerhost:2375';
-        if (sep < 0) {
-            vscode.window.showErrorMessage(errorMessage);
-        } else {
-            newHost = value.slice(0, sep);
-            newPort = Number(value.slice(sep + 1));
-            if (isNaN(newPort)) {
-                vscode.window.showErrorMessage(errorMessage);
-            } else {
-                ext.dockerode = new Dockerode({ host: newHost, port: newPort });
-            }
-        }
-    }
-
-    if (!ext.dockerode || !value) {
-        // Pass no options so that the defaultOpts of docker-modem will be used if the endpoint wasn't created
-        // or the user went from configured setting to empty settign
+    const oldEnv = process.env;
+    try {
+        process.env = { ...process.env }; // make a clone before we change anything
+        addDockerSettingsToEnv(process.env);
+        ext.dockerodeError = undefined;
         ext.dockerode = new Dockerode();
+    } catch (error) {
+        // This will be displayed in the tree
+        ext.dockerodeError = error;
+    } finally {
+        process.env = oldEnv;
     }
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -31,6 +31,7 @@ export namespace ext {
     export let terminalProvider: ITerminalProvider;
     export let keytar: IKeytar | undefined;
     export let dockerode: Dockerode;
+    export let dockerodeError: unknown;
 
     export let imagesTree: AzExtTreeDataProvider;
     export let imagesTreeView: TreeView<AzExtTreeItem>;

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -31,7 +31,7 @@ export namespace ext {
     export let terminalProvider: ITerminalProvider;
     export let keytar: IKeytar | undefined;
     export let dockerode: Dockerode;
-    export let dockerodeError: unknown;
+    export let dockerodeInitError: unknown;
 
     export let imagesTree: AzExtTreeDataProvider;
     export let imagesTreeView: TreeView<AzExtTreeItem>;

--- a/src/tree/LocalRootTreeItemBase.ts
+++ b/src/tree/LocalRootTreeItemBase.ts
@@ -6,6 +6,7 @@
 import { ConfigurationChangeEvent, ConfigurationTarget, TreeView, TreeViewVisibilityChangeEvent, workspace, WorkspaceConfiguration } from "vscode";
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, GenericTreeItem, IActionContext, InvalidTreeItem, registerEvent } from "vscode-azureextensionui";
 import { configPrefix } from "../constants";
+import { ext } from "../extensionVariables";
 import { nonNullProp } from "../utils/nonNull";
 import { isLinux } from "../utils/osUtils";
 import { getThemedIconPath } from "./IconPath";
@@ -293,8 +294,12 @@ export abstract class LocalRootTreeItemBase<TItem extends ILocalItem, TProperty 
     }
 
     private async getSortedItems(): Promise<TItem[]> {
-        const items: TItem[] = await this.getItems() || [];
-        return items.sort((a, b) => a.treeId.localeCompare(b.treeId));
+        if (ext.dockerodeError === undefined) {
+            const items: TItem[] = await this.getItems() || [];
+            return items.sort((a, b) => a.treeId.localeCompare(b.treeId));
+        } else {
+            throw ext.dockerodeError;
+        }
     }
 
     private async hasChanged(): Promise<boolean> {

--- a/src/tree/LocalRootTreeItemBase.ts
+++ b/src/tree/LocalRootTreeItemBase.ts
@@ -294,11 +294,11 @@ export abstract class LocalRootTreeItemBase<TItem extends ILocalItem, TProperty 
     }
 
     private async getSortedItems(): Promise<TItem[]> {
-        if (ext.dockerodeError === undefined) {
+        if (ext.dockerodeInitError === undefined) {
             const items: TItem[] = await this.getItems() || [];
             return items.sort((a, b) => a.treeId.localeCompare(b.treeId));
         } else {
-            throw ext.dockerodeError;
+            throw ext.dockerodeInitError;
         }
     }
 

--- a/src/utils/TerminalProvider.ts
+++ b/src/utils/TerminalProvider.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import { Terminal } from 'vscode';
+import { addDockerSettingsToEnv } from './addDockerSettingsToEnv';
 
 export interface ITerminalProvider {
   createTerminal(name: string): Terminal;
@@ -14,12 +15,8 @@ export class DefaultTerminalProvider {
   public createTerminal(name: string): Terminal {
     let terminalOptions: vscode.TerminalOptions = {};
     terminalOptions.name = name;
-    const value: string = vscode.workspace.getConfiguration("docker").get("host", "");
-    if (value) {
-      terminalOptions.env = {
-        DOCKER_HOST: value
-      };
-    }
+    terminalOptions.env = {};
+    addDockerSettingsToEnv(terminalOptions.env);
     return vscode.window.createTerminal(terminalOptions);
   }
 }

--- a/src/utils/TerminalProvider.ts
+++ b/src/utils/TerminalProvider.ts
@@ -16,7 +16,7 @@ export class DefaultTerminalProvider {
     let terminalOptions: vscode.TerminalOptions = {};
     terminalOptions.name = name;
     terminalOptions.env = {};
-    addDockerSettingsToEnv(terminalOptions.env);
+    addDockerSettingsToEnv(terminalOptions.env, process.env);
     return vscode.window.createTerminal(terminalOptions);
   }
 }

--- a/src/utils/addDockerSettingsToEnv.ts
+++ b/src/utils/addDockerSettingsToEnv.ts
@@ -1,0 +1,28 @@
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { workspace } from 'vscode';
+import { configPrefix } from '../constants';
+import { ext } from '../extensionVariables';
+
+export function addDockerSettingsToEnv(env: {}): void {
+    addDockerSettingToEnv("host", 'DOCKER_HOST', env);
+    addDockerSettingToEnv("certPath", 'DOCKER_CERT_PATH', env);
+    addDockerSettingToEnv("tlsVerify", 'DOCKER_TLS_VERIFY', env);
+    addDockerSettingToEnv("machineName", 'DOCKER_MACHINE_NAME', env);
+}
+
+function addDockerSettingToEnv(settingKey: string, envVar: string, env: {}): void {
+    const value = workspace.getConfiguration(configPrefix).get<string>(settingKey, '');
+
+    const expectedType = "string";
+    const actualType = typeof value;
+    if (expectedType !== actualType) {
+        ext.outputChannel.appendLine(`WARNING: Ignoring setting "${configPrefix}.${settingKey}" because type "${actualType}" does not match expected type "${expectedType}".`);
+    } else if (value) {
+        env[envVar] = value;
+    }
+}

--- a/src/utils/addDockerSettingsToEnv.ts
+++ b/src/utils/addDockerSettingsToEnv.ts
@@ -8,14 +8,14 @@ import { workspace } from 'vscode';
 import { configPrefix } from '../constants';
 import { ext } from '../extensionVariables';
 
-export function addDockerSettingsToEnv(env: {}): void {
-    addDockerSettingToEnv("host", 'DOCKER_HOST', env);
-    addDockerSettingToEnv("certPath", 'DOCKER_CERT_PATH', env);
-    addDockerSettingToEnv("tlsVerify", 'DOCKER_TLS_VERIFY', env);
-    addDockerSettingToEnv("machineName", 'DOCKER_MACHINE_NAME', env);
+export function addDockerSettingsToEnv(env: {}, oldEnv: {}): void {
+    addDockerSettingToEnv("host", 'DOCKER_HOST', env, oldEnv);
+    addDockerSettingToEnv("certPath", 'DOCKER_CERT_PATH', env, oldEnv);
+    addDockerSettingToEnv("tlsVerify", 'DOCKER_TLS_VERIFY', env, oldEnv);
+    addDockerSettingToEnv("machineName", 'DOCKER_MACHINE_NAME', env, oldEnv);
 }
 
-function addDockerSettingToEnv(settingKey: string, envVar: string, env: {}): void {
+function addDockerSettingToEnv(settingKey: string, envVar: string, env: {}, oldEnv: {}): void {
     const value = workspace.getConfiguration(configPrefix).get<string>(settingKey, '');
 
     const expectedType = "string";
@@ -23,6 +23,10 @@ function addDockerSettingToEnv(settingKey: string, envVar: string, env: {}): voi
     if (expectedType !== actualType) {
         ext.outputChannel.appendLine(`WARNING: Ignoring setting "${configPrefix}.${settingKey}" because type "${actualType}" does not match expected type "${expectedType}".`);
     } else if (value) {
+        if (oldEnv[envVar] && oldEnv[envVar] !== value) {
+            ext.outputChannel.appendLine(`WARNING: Overwriting environment variable "${envVar}" with VS Code setting "${configPrefix}.${settingKey}".`);
+        }
+
         env[envVar] = value;
     }
 }


### PR DESCRIPTION
Previously we only supported "docker.host" (aka "DOCKER_HOST") as a VS Code setting. I added support for the 4 main environment variables used in [docker machine](https://docs.docker.com/machine/get-started/). Users want these as VS Code settings so that they can have per-workspace setups and so that they can modify a setting without reloading VS Code or changing their environment variables.

Also we were parsing "docker.host" ourselves in the past, which led to a lot of problems because our parsing logic was _very_ simplistic. Instead, I will let docker_modem (a dependency of Dockerode) do all the parsing for us. See [here](https://github.com/apocas/docker-modem/blob/master/lib/modem.js#L26) for more info.

Fixes https://github.com/microsoft/vscode-docker/issues/962
Fixes https://github.com/microsoft/vscode-docker/issues/914
Fixes https://github.com/microsoft/vscode-docker/issues/649
Fixes https://github.com/microsoft/vscode-docker/issues/580
Fixes https://github.com/microsoft/vscode-docker/issues/216

Related to https://github.com/microsoft/vscode-docker/issues/646