### PR TITLE
Add back support for "Attach Visual Studio Code" command

### DIFF
--- a/src/tree/containers/ContainerTreeItem.ts
+++ b/src/tree/containers/ContainerTreeItem.ts
@@ -47,6 +47,15 @@ export class ContainerTreeItem extends AzExtTreeItem {
         return this._item.state + 'Container';
     }
 
+    /**
+     * @deprecated This is only kept for backwards compatability with the "Remote Containers" extension
+     * They add a context menu item "Attach Visual Studio Code" to our container nodes that relies on containerDesc
+     * https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+     */
+    public get containerDesc(): {} {
+        return this._item.data;
+    }
+
     public get iconPath(): IconPath {
         if (this._item.status.includes('(unhealthy)')) {
             return getThemedIconPath('statusWarning');

--- a/test/tree/containersTree.test.ts
+++ b/test/tree/containersTree.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as assert from 'assert';
 import { ContainerInfo } from 'dockerode';
 import { ext } from '../../extension.bundle';
 import { generateCreatedTimeInSec, ITestTreeItem, IValidateTreeOptions, validateTree } from './validateTree';
@@ -378,6 +379,36 @@ suite('Containers Tree', async () => {
                     ]
                 }
             ]);
+    });
+
+    /**
+     * This test verifies we maintain support for the "Attach Visual Studio Code" context menu item that the "Remote Containers" extension adds to our tree (specifically running containers)
+     * https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+     */
+    test('Remote Containers - Attach Visual Studio Code', async () => {
+        const containers = [
+            {
+                Id: "faeb6f02af06df748a0040476ba7c335fb8aaefd76f6ea14a76800faf0fa3910",
+                Names: ["/elegant_knuth"],
+                Image: "registry:latest",
+                ImageID: "sha256:f32a97de94e13d29835a19851acd6cbc7979d1d50f703725541e44bb89a1ce91",
+                Created: generateCreatedTimeInSec(2),
+                Ports: [
+                    { "IP": "0.0.0.0", "PrivatePort": 5000, "PublicPort": 5000, "Type": "tcp" }
+                ],
+                State: "running",
+                Status: "Up 6 minutes",
+            },
+        ];
+
+        const expectedNodes = [
+            { label: "registry:latest", description: "elegant_knuth - Up 6 minutes" },
+        ];
+
+        const actualNodes = await validateTree(ext.containersRoot, 'containers', {}, { containers: containers }, expectedNodes);
+
+        assert.equal(actualNodes[0].contextValue, 'runningContainer', 'Must have context value "runningContainer"');
+        assert.equal((<any>actualNodes[0]).containerDesc.Id, 'faeb6f02af06df748a0040476ba7c335fb8aaefd76f6ea14a76800faf0fa3910', 'Must have property "containerDesc"');
     });
 });
 

--- a/test/tree/validateTree.ts
+++ b/test/tree/validateTree.ts
@@ -31,7 +31,8 @@ export interface ITestTreeItem {
     children?: ITestTreeItem[];
 }
 
-export async function validateTree(rootTreeItem: AzExtParentTreeItem, treePrefix: string, treeOptions: IValidateTreeOptions, dockerodeOptions: ITestDockerodeOptions, expectedNodes: ITestTreeItem[]): Promise<void> {
+export async function validateTree(rootTreeItem: AzExtParentTreeItem, treePrefix: string, treeOptions: IValidateTreeOptions, dockerodeOptions: ITestDockerodeOptions, expectedNodes: ITestTreeItem[]): Promise<AzExtTreeItem[]> {
+    let actualNodes: AzExtTreeItem[] = [];
     await runWithSetting(`${treePrefix}.sortBy`, treeOptions.sortBy, async () => {
         await runWithSetting(`${treePrefix}.groupBy`, treeOptions.groupBy, async () => {
             await runWithSetting(`${treePrefix}.label`, treeOptions.label, async () => {
@@ -41,7 +42,7 @@ export async function validateTree(rootTreeItem: AzExtParentTreeItem, treePrefix
 
                         const context: IActionContext = { telemetry: { properties: {}, measurements: {} }, errorHandling: {} };
 
-                        const actualNodes = await rootTreeItem.getCachedChildren(context);
+                        actualNodes = await rootTreeItem.getCachedChildren(context);
 
                         const actual = await Promise.all(actualNodes.map(async node => {
                             const actualNode: ITestTreeItem = convertToTestTreeItem(node);
@@ -58,6 +59,7 @@ export async function validateTree(rootTreeItem: AzExtParentTreeItem, treePrefix
             });
         });
     });
+    return actualNodes;
 }
 
 interface ITestDockerodeOptions {


### PR DESCRIPTION
The "Attach Visual Studio Code" command is contributed by the [remote containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension and it doesn't work with the new explorer as-is. Fixed that and added a test to make sure we don't break this in the future.