### PR TITLE
Workaround for multiple publishers installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.4 - 19 June 2019
+
+### Changed
+* Mitigate error "command 'vscode-docker.images.selectGroupBy' already exists" [#1008](https://github.com/microsoft/vscode-docker/issues/1008)
+
 ## 0.6.3 - 18 June 2019
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.4 - 19 June 2019
 
-### Changed
+### Fixed
 * Mitigate error "command 'vscode-docker.images.selectGroupBy' already exists" [#1008](https://github.com/microsoft/vscode-docker/issues/1008)
 
 ## 0.6.3 - 18 June 2019

--- a/extension.ts
+++ b/extension.ts
@@ -112,6 +112,15 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
     this.properties.isActivationEvent = 'true';
     this.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
 
+    const extension = vscode.extensions.getExtension('PeterJausovec.vscode-docker');
+    if (extension) {
+      // temporary workaround for https://github.com/microsoft/vscode-docker/issues/1008
+      // We will essentially defer all functionality to the old publisher's extension if we detect both installed
+      vscode.commands.executeCommand('setContext', 'isOldPublisherInstalled', true);
+      this.properties.isOldPublisherInstalled = 'true';
+      return;
+    }
+
     ctx.subscriptions.push(
       vscode.languages.registerCompletionItemProvider(
         DOCUMENT_SELECTOR,

--- a/extension.ts
+++ b/extension.ts
@@ -116,8 +116,8 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
     if (extension) {
       // temporary workaround for https://github.com/microsoft/vscode-docker/issues/1008
       // We will essentially defer all functionality to the old publisher's extension if we detect both installed
-      vscode.commands.executeCommand('setContext', 'isOldPublisherInstalled', true);
-      this.properties.isOldPublisherInstalled = 'true';
+      vscode.commands.executeCommand('setContext', 'isOldDockerPublisherInstalled', true);
+      this.properties.isOldDockerPublisherInstalled = 'true';
       return;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-docker",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -98,228 +98,228 @@
         },
         {
           "command": "vscode-docker.acr.createRegistry",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.deleteImage",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.deleteRegistry",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.deleteRepository",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.pullImage",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.pullRepo",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.quickBuild",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.runTask",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.runTaskFile",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.showTask",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.untagImage",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.acr.viewLogs",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.browseAzurePortal",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.compose.down",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.compose.restart",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.compose.up",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.configure",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.connectCustomRegistry",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.container.open-shell",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.container.remove",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.container.restart",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.container.show-logs",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.container.start",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.container.start.azurecli",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.container.start.interactive",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.container.stop",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.disconnectCustomRegistry",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.dockerHubLogin",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.dockerHubLogout",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.explorer.refresh",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.image.build",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.image.inspect",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.image.push",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.image.remove",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.images.selectGroupBy",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.image.tag",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         },
         {
           "command": "vscode-docker.system.prune",
-          "when": "!isOldPublisherInstalled"
+          "when": "!isOldDockerPublisherInstalled"
         }
       ],
       "editor/context": [
         {
-          "when": "!isOldPublisherInstalled && editorLangId == dockerfile && isAzureAccountInstalled",
+          "when": "!isOldDockerPublisherInstalled && editorLangId == dockerfile && isAzureAccountInstalled",
           "command": "vscode-docker.acr.quickBuild",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && editorLangId == yaml",
+          "when": "!isOldDockerPublisherInstalled && editorLangId == yaml",
           "command": "vscode-docker.acr.runTaskFile",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.yml",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename == docker-compose.yml",
           "command": "vscode-docker.compose.down",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.yml",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename == docker-compose.yml",
           "command": "vscode-docker.compose.restart",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.yml",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename == docker-compose.yml",
           "command": "vscode-docker.compose.up",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.debug.yml",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename == docker-compose.debug.yml",
           "command": "vscode-docker.compose.down",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.debug.yml",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename == docker-compose.debug.yml",
           "command": "vscode-docker.compose.restart",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.debug.yml",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename == docker-compose.debug.yml",
           "command": "vscode-docker.compose.up",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && editorLangId == dockerfile",
+          "when": "!isOldDockerPublisherInstalled && editorLangId == dockerfile",
           "command": "vscode-docker.image.build",
           "group": "docker"
         }
       ],
       "explorer/context": [
         {
-          "when": "!isOldPublisherInstalled && resourceFilename =~ /(^|\\.)dockerfile$/i",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename =~ /(^|\\.)dockerfile$/i",
           "command": "vscode-docker.acr.quickBuild",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename =~ /^(?:(?!^docker-compose\\.ya?ml$).)*\\.ya?ml$/i",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename =~ /^(?:(?!^docker-compose\\.ya?ml$).)*\\.ya?ml$/i",
           "command": "vscode-docker.acr.runTaskFile",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename =~ /docker-compose/i",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename =~ /docker-compose/i",
           "command": "vscode-docker.compose.down",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename =~ /docker-compose/i",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename =~ /docker-compose/i",
           "command": "vscode-docker.compose.restart",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename =~ /docker-compose/i",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename =~ /docker-compose/i",
           "command": "vscode-docker.compose.up",
           "group": "docker"
         },
         {
-          "when": "!isOldPublisherInstalled && resourceFilename =~ /dockerfile/i",
+          "when": "!isOldDockerPublisherInstalled && resourceFilename =~ /dockerfile/i",
           "command": "vscode-docker.image.build",
           "group": "docker"
         }
@@ -327,159 +327,159 @@
       "view/title": [
         {
           "command": "vscode-docker.explorer.refresh",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer",
           "group": "navigation@1"
         },
         {
           "command": "vscode-docker.system.prune",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer",
           "group": "navigation@2"
         }
       ],
       "view/item/context": [
         {
           "command": "vscode-docker.images.selectGroupBy",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^imagesRootNode$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^imagesRootNode$/",
           "group": "inline"
         },
         {
           "command": "vscode-docker.acr.createRegistry",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureRegistryRootNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == azureRegistryRootNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.deleteImage",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureImageTagNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == azureImageTagNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.deleteRegistry",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureRegistryNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == azureRegistryNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.deleteRepository",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureRepositoryNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == azureRepositoryNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.pullImage",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureImageTagNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == azureImageTagNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.pullRepo",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureRepositoryNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == azureRepositoryNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.runTask",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == taskNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == taskNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.showTask",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == taskNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == taskNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.untagImage",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureImageTagNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == azureImageTagNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.viewLogs",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(azureRegistryNode|azureImageTagNode|taskNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(azureRegistryNode|azureImageTagNode|taskNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.browseDockerHub",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(dockerHubImageTagNode|dockerHubRepositoryNode|dockerHubOrgNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(dockerHubImageTagNode|dockerHubRepositoryNode|dockerHubOrgNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.browseAzurePortal",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(azureRegistryNode|azureRepositoryNode|azureImageTagNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(azureRegistryNode|azureRepositoryNode|azureImageTagNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.connectCustomRegistry",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == customRootNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == customRootNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.container.open-shell",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|containersRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|containersRootNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.container.remove",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(stoppedLocalContainerNode|runningLocalContainerNode|containersRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(stoppedLocalContainerNode|runningLocalContainerNode|containersRootNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.container.restart",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|stoppedLocalContainerNode|containersRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|stoppedLocalContainerNode|containersRootNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.container.show-logs",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|stoppedLocalContainerNode|containersRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|stoppedLocalContainerNode|containersRootNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.container.start",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.container.start.interactive",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.container.stop",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|containersRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|containersRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.createWebApp",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(azureImageTagNode|dockerHubImageTagNode|customImageTagNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(azureImageTagNode|dockerHubImageTagNode|customImageTagNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.disconnectCustomRegistry",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(customRegistryNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(customRegistryNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.dockerHubLogout",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == dockerHubRootNode",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem == dockerHubRootNode",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.image.inspect",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.image.push",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.image.remove",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.image.tag",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.setRegistryAsDefault",
-          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(customRegistryNode|azureRegistryNode|dockerHubOrgNode)$/",
+          "when": "!isOldDockerPublisherInstalled && view == dockerExplorer && viewItem =~ /^(customRegistryNode|azureRegistryNode|dockerHubOrgNode)$/",
           "group": "5_default"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-docker",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "preview": true,
   "publisher": "ms-azuretools",
   "displayName": "Docker",
@@ -95,83 +95,231 @@
         {
           "command": "vscode-docker.setRegistryAsDefault",
           "when": "never"
+        },
+        {
+          "command": "vscode-docker.acr.createRegistry",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.deleteImage",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.deleteRegistry",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.deleteRepository",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.pullImage",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.pullRepo",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.quickBuild",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.runTask",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.runTaskFile",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.showTask",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.untagImage",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.acr.viewLogs",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.browseAzurePortal",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.compose.down",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.compose.restart",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.compose.up",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.configure",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.connectCustomRegistry",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.container.open-shell",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.container.remove",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.container.restart",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.container.show-logs",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.container.start",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.container.start.azurecli",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.container.start.interactive",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.container.stop",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.disconnectCustomRegistry",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.dockerHubLogin",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.dockerHubLogout",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.explorer.refresh",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.image.build",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.image.inspect",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.image.push",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.image.remove",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.images.selectGroupBy",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.image.tag",
+          "when": "!isOldPublisherInstalled"
+        },
+        {
+          "command": "vscode-docker.system.prune",
+          "when": "!isOldPublisherInstalled"
         }
       ],
       "editor/context": [
         {
-          "when": "editorLangId == dockerfile && isAzureAccountInstalled",
+          "when": "!isOldPublisherInstalled && editorLangId == dockerfile && isAzureAccountInstalled",
           "command": "vscode-docker.acr.quickBuild",
           "group": "docker"
         },
         {
-          "when": "editorLangId == yaml",
+          "when": "!isOldPublisherInstalled && editorLangId == yaml",
           "command": "vscode-docker.acr.runTaskFile",
           "group": "docker"
         },
         {
-          "when": "resourceFilename == docker-compose.yml",
+          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.yml",
           "command": "vscode-docker.compose.down",
           "group": "docker"
         },
         {
-          "when": "resourceFilename == docker-compose.yml",
+          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.yml",
           "command": "vscode-docker.compose.restart",
           "group": "docker"
         },
         {
-          "when": "resourceFilename == docker-compose.yml",
+          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.yml",
           "command": "vscode-docker.compose.up",
           "group": "docker"
         },
         {
-          "when": "resourceFilename == docker-compose.debug.yml",
+          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.debug.yml",
           "command": "vscode-docker.compose.down",
           "group": "docker"
         },
         {
-          "when": "resourceFilename == docker-compose.debug.yml",
+          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.debug.yml",
           "command": "vscode-docker.compose.restart",
           "group": "docker"
         },
         {
-          "when": "resourceFilename == docker-compose.debug.yml",
+          "when": "!isOldPublisherInstalled && resourceFilename == docker-compose.debug.yml",
           "command": "vscode-docker.compose.up",
           "group": "docker"
         },
         {
-          "when": "editorLangId == dockerfile",
+          "when": "!isOldPublisherInstalled && editorLangId == dockerfile",
           "command": "vscode-docker.image.build",
           "group": "docker"
         }
       ],
       "explorer/context": [
         {
-          "when": "resourceFilename =~ /(^|\\.)dockerfile$/i",
+          "when": "!isOldPublisherInstalled && resourceFilename =~ /(^|\\.)dockerfile$/i",
           "command": "vscode-docker.acr.quickBuild",
           "group": "docker"
         },
         {
-          "when": "resourceFilename =~ /^(?:(?!^docker-compose\\.ya?ml$).)*\\.ya?ml$/i",
+          "when": "!isOldPublisherInstalled && resourceFilename =~ /^(?:(?!^docker-compose\\.ya?ml$).)*\\.ya?ml$/i",
           "command": "vscode-docker.acr.runTaskFile",
           "group": "docker"
         },
         {
-          "when": "resourceFilename =~ /docker-compose/i",
+          "when": "!isOldPublisherInstalled && resourceFilename =~ /docker-compose/i",
           "command": "vscode-docker.compose.down",
           "group": "docker"
         },
         {
-          "when": "resourceFilename =~ /docker-compose/i",
+          "when": "!isOldPublisherInstalled && resourceFilename =~ /docker-compose/i",
           "command": "vscode-docker.compose.restart",
           "group": "docker"
         },
         {
-          "when": "resourceFilename =~ /docker-compose/i",
+          "when": "!isOldPublisherInstalled && resourceFilename =~ /docker-compose/i",
           "command": "vscode-docker.compose.up",
           "group": "docker"
         },
         {
-          "when": "resourceFilename =~ /dockerfile/i",
+          "when": "!isOldPublisherInstalled && resourceFilename =~ /dockerfile/i",
           "command": "vscode-docker.image.build",
           "group": "docker"
         }
@@ -179,159 +327,159 @@
       "view/title": [
         {
           "command": "vscode-docker.explorer.refresh",
-          "when": "view == dockerExplorer",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer",
           "group": "navigation@1"
         },
         {
           "command": "vscode-docker.system.prune",
-          "when": "view == dockerExplorer",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer",
           "group": "navigation@2"
         }
       ],
       "view/item/context": [
         {
           "command": "vscode-docker.images.selectGroupBy",
-          "when": "view == dockerExplorer && viewItem =~ /^imagesRootNode$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^imagesRootNode$/",
           "group": "inline"
         },
         {
           "command": "vscode-docker.acr.createRegistry",
-          "when": "view == dockerExplorer && viewItem == azureRegistryRootNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureRegistryRootNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.deleteImage",
-          "when": "view == dockerExplorer && viewItem == azureImageTagNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureImageTagNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.deleteRegistry",
-          "when": "view == dockerExplorer && viewItem == azureRegistryNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureRegistryNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.deleteRepository",
-          "when": "view == dockerExplorer && viewItem == azureRepositoryNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureRepositoryNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.pullImage",
-          "when": "view == dockerExplorer && viewItem == azureImageTagNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureImageTagNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.pullRepo",
-          "when": "view == dockerExplorer && viewItem == azureRepositoryNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureRepositoryNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.runTask",
-          "when": "view == dockerExplorer && viewItem == taskNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == taskNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.showTask",
-          "when": "view == dockerExplorer && viewItem == taskNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == taskNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.untagImage",
-          "when": "view == dockerExplorer && viewItem == azureImageTagNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == azureImageTagNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.acr.viewLogs",
-          "when": "view == dockerExplorer && viewItem =~ /^(azureRegistryNode|azureImageTagNode|taskNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(azureRegistryNode|azureImageTagNode|taskNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.browseDockerHub",
-          "when": "view == dockerExplorer && viewItem =~ /^(dockerHubImageTagNode|dockerHubRepositoryNode|dockerHubOrgNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(dockerHubImageTagNode|dockerHubRepositoryNode|dockerHubOrgNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.browseAzurePortal",
-          "when": "view == dockerExplorer && viewItem =~ /^(azureRegistryNode|azureRepositoryNode|azureImageTagNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(azureRegistryNode|azureRepositoryNode|azureImageTagNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.connectCustomRegistry",
-          "when": "view == dockerExplorer && viewItem == customRootNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == customRootNode",
           "group": "default"
         },
         {
           "command": "vscode-docker.container.open-shell",
-          "when": "view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|containersRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|containersRootNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.container.remove",
-          "when": "view == dockerExplorer && viewItem =~ /^(stoppedLocalContainerNode|runningLocalContainerNode|containersRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(stoppedLocalContainerNode|runningLocalContainerNode|containersRootNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.container.restart",
-          "when": "view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|stoppedLocalContainerNode|containersRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|stoppedLocalContainerNode|containersRootNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.container.show-logs",
-          "when": "view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|stoppedLocalContainerNode|containersRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|stoppedLocalContainerNode|containersRootNode)$/",
           "group": "default"
         },
         {
           "command": "vscode-docker.container.start",
-          "when": "view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.container.start.interactive",
-          "when": "view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.container.stop",
-          "when": "view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|containersRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(runningLocalContainerNode|containersRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.createWebApp",
-          "when": "view == dockerExplorer && viewItem =~ /^(azureImageTagNode|dockerHubImageTagNode|customImageTagNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(azureImageTagNode|dockerHubImageTagNode|customImageTagNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.disconnectCustomRegistry",
-          "when": "view == dockerExplorer && viewItem =~ /^(customRegistryNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(customRegistryNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.dockerHubLogout",
-          "when": "view == dockerExplorer && viewItem == dockerHubRootNode",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem == dockerHubRootNode",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.image.inspect",
-          "when": "view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.image.push",
-          "when": "view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.image.remove",
-          "when": "view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.image.tag",
-          "when": "view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(localImageNode|imagesRootNode)$/",
           "group": "5_default"
         },
         {
           "command": "vscode-docker.setRegistryAsDefault",
-          "when": "view == dockerExplorer && viewItem =~ /^(customRegistryNode|azureRegistryNode|dockerHubOrgNode)$/",
+          "when": "!isOldPublisherInstalled && view == dockerExplorer && viewItem =~ /^(customRegistryNode|azureRegistryNode|dockerHubOrgNode)$/",
           "group": "5_default"
         }
       ]


### PR DESCRIPTION
Potential temporary workaround for https://github.com/microsoft/vscode-docker/issues/1008

Still testing, but wanted to get eyes on it ASAP. I basically check if both extensions are installed and defer to the old publisher for all functionality.