### PR TITLE
Upgrade language server version to 0.0.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2434,50 +2434,42 @@
       }
     },
     "dockerfile-ast": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.11.tgz",
-      "integrity": "sha512-biCqz6yJ6xlRD/jPCI9bFFDBFVawAuYZc/7HqrdQBHdtOx+JbnqP0UgVGpzJrcdGCivfq5l3Dga1pISOL8F4Iw==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.16.tgz",
+      "integrity": "sha512-+HZToHjjiLPl46TqBrok5dMrg5oCkZFPSROMQjRmvin0zG4FxK0DJXTpV/CUPYY2zpmEvVza55XLwSHFx/xZMw==",
       "requires": {
         "vscode-languageserver-types": "^3.5.0"
       }
     },
     "dockerfile-language-server-nodejs": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.20.tgz",
-      "integrity": "sha512-dLCP3E+MooojNG97qgunjAYFL1Gu1pA46HXiXYiHJ6AQnfyBM06F5kkTAGf4B68rXRde1oCG5zItTuA2Mtwlgg==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.21.tgz",
+      "integrity": "sha512-lZ7VFAlS4vTm5MvxmwpREcYMARB3RQaGX0OZdcY8oSytsu4i5mMGVa6mi9/pZ9soqcUC08uxEA8EcqIeL3lyAA==",
       "requires": {
-        "dockerfile-language-service": "0.0.7",
+        "dockerfile-language-service": "0.0.8",
         "dockerfile-utils": "0.0.11",
         "vscode-languageserver": "^5.1.0"
       }
     },
     "dockerfile-language-service": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.7.tgz",
-      "integrity": "sha512-891Esxo/3pX7IcvR6VCBq2jVWd7jKUSWswTSURVwGD3hN9SsObR2Btd3DEYp1Glspuf+eQIvf2DO1IDJ9kyovQ==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.8.tgz",
+      "integrity": "sha512-peko1rQtZ81e3QK3VLZgkCKkCMnuoSqZxCQuudyEbtYqqAe6jJ4r0bwOnWD9hyH/FMg7jMvI5uLsoo7/dHLNYw==",
       "requires": {
-        "dockerfile-ast": "0.0.11",
-        "dockerfile-utils": "0.0.12",
+        "dockerfile-ast": "0.0.16",
+        "dockerfile-utils": "0.0.13",
         "vscode-languageserver-types": "^3.10.0"
       },
       "dependencies": {
         "dockerfile-utils": {
-          "version": "0.0.12",
-          "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.12.tgz",
-          "integrity": "sha512-xH7h27/eJiL+zRaZ9PR8jKSNDSiP60q6aK9XJPZi3l9XbprqV+2T/U11uPsGFWZkf/otciNNzqE8Lq5d/qE8HA==",
+          "version": "0.0.13",
+          "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.13.tgz",
+          "integrity": "sha512-+MAmhEnQ16B7+3C2UDWpmIS1D8EiKvpl4LDRjrMv94bOusaeRcLagRR0AvgV6NWT+oiRxDMLDyay6yjm6LESsw==",
           "requires": {
-            "dockerfile-ast": "0.0.12",
+            "dockerfile-ast": "0.0.16",
             "vscode-languageserver-types": "3.6.0"
           },
           "dependencies": {
-            "dockerfile-ast": {
-              "version": "0.0.12",
-              "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.12.tgz",
-              "integrity": "sha512-cIV8oXkAxpIuN5XgG0TGg07nLDgrj4olkfrdT77OTA3VypscsYHBUg/FjHxW9K3oA+CyH4Th/qtoMgTVpzSobw==",
-              "requires": {
-                "vscode-languageserver-types": "^3.5.0"
-              }
-            },
             "vscode-languageserver-types": {
               "version": "3.6.0",
               "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.0.tgz",
@@ -3374,12 +3366,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3399,7 +3393,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -3547,6 +3542,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9968,9 +9964,9 @@
       }
     },
     "vscode-uri": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
-      "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.8.tgz",
+      "integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ=="
     },
     "vso-node-api": {
       "version": "6.1.2-preview",

--- a/package.json
+++ b/package.json
@@ -1627,7 +1627,7 @@
         "azure-arm-website": "^5.3.0",
         "azure-storage": "^2.8.1",
         "deep-equal": "^1.0.1",
-        "dockerfile-language-server-nodejs": "^0.0.20",
+        "dockerfile-language-server-nodejs": "^0.0.21",
         "dockerode": "^2.5.8",
         "fs-extra": "^6.0.1",
         "glob": "7.1.2",


### PR DESCRIPTION
This new update is mainly focused around improvements to the validation to correct some false positives (fixes #952) in addition to a fix to how variables were being resolved. Now the language server only considers alphanumeric and underscore characters as part of a variable's name.

As always, please use the following Dockerfile before and after the pull request to verify the changes:
```Dockerfile
# VOLUME fixes -------------------------------------------------
FROM node
# hover over VOLUME, there is a typo "specifid" that is now fixed
VOLUME [ "/data" ]
# invoke Intellisense here, the documentation has the same typo "specifid" that is now fixed
VOL

# RUN instruction linting fixes --------------------------------
FROM scratch
# there was an error on the question mark, this is now fixed
RUN echo ${bbb:?}

# there was an error on the "T", this is now fixed
# see https://github.com/microsoft/vscode-docker/issues/952
RUN echo ${Env:Temp}

# FROM linting fixes -------------------------------------------
# there was no error before, now this will be properly flagged as being an invalid base image
FROM $image

# variable resolution linting fixes ----------------------------
FROM scratch
ARG ARG_VAR=1234
ENV ENV_VAR $ARG_VAR
# "$ENV_VAR" was incorrectly highlighted as an error, now it's okay
EXPOSE "$ENV_VAR"

FROM scratch
ARG ARG_VAR=1234
# "$ARG_VAR" was incorrectly highlighted as an error, now it's okay
EXPOSE "$ARG_VAR"

# variable resolution fixes ------------------------------------
FROM alpine
ENV var value
# put your cursor in $var, the whole $var:test gets highlighted
# now it only highlights $var
RUN echo $var:test

FROM alpine
ENV var value
# put your cursor in $var, hit F2 to rename, it used to
# show var:test, now it only shows var
RUN echo $var:test

FROM alpine
ENV var value
# put your cursor in $var, hit F2 to rename, rename the variable,
# only the RUN gets modified, the ENV declaration should get modified also
RUN echo $var:test

FROM alpine
ENV var value
# put your cursor in $var, hit F12 to open the definition,
# nothing happens, now it will jump to the variable declaration
RUN echo $var:test

FROM alpine
ENV var value
# hover your cursor over $var, nothing is shown, now it resolve correctly
# and show "value"
RUN echo $var:test
```