### PR TITLE
Improve display of images with no RepoTags

### DIFF
--- a/src/tree/images/ImagesTreeItem.ts
+++ b/src/tree/images/ImagesTreeItem.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ImageInfo } from "dockerode";
 import { ext } from "../../extensionVariables";
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { CommonGroupBy, groupByNoneProperty } from "../settings/CommonProperties";
@@ -50,7 +51,7 @@ export class ImagesTreeItem extends LocalRootTreeItemBase<ILocalImageInfo, Image
         let result: ILocalImageInfo[] = [];
         for (const image of images) {
             if (!image.RepoTags) {
-                result.push(new LocalImageInfo(image, '<none>:<none>'));
+                result.push(new LocalImageInfo(image, getFullTagFromDigest(image)));
             } else {
                 for (let fullTag of image.RepoTags) {
                     result.push(new LocalImageInfo(image, fullTag));
@@ -64,4 +65,19 @@ export class ImagesTreeItem extends LocalRootTreeItemBase<ILocalImageInfo, Image
     public getPropertyValue(item: ILocalImageInfo, property: ImageProperty): string {
         return getImagePropertyValue(item, property);
     }
+}
+
+function getFullTagFromDigest(image: ImageInfo): string {
+    let repo = '<none>';
+    let tag = '<none>';
+
+    const digest = image.RepoDigests[0];
+    if (digest) {
+        const index = digest.indexOf('@');
+        if (index > 0) {
+            repo = digest.substring(0, index);
+        }
+    }
+
+    return `${repo}:${tag}`;
 }


### PR DESCRIPTION
Before:
<img width="240" alt="Screen Shot 2019-06-21 at 3 18 44 PM" src="https://user-images.githubusercontent.com/11282622/59949167-f2417900-9437-11e9-8dc1-b16fccc905dd.png">

After:
<img width="227" alt="Screen Shot 2019-06-21 at 3 19 04 PM" src="https://user-images.githubusercontent.com/11282622/59949171-f7062d00-9437-11e9-99ef-82bd6aca1914.png">

Fixes https://github.com/microsoft/vscode-docker/issues/1003
Fixes https://github.com/microsoft/vscode-docker/issues/209