### PR TITLE
Use tag icon if label is set to "Tag"

### DIFF
--- a/src/tree/images/ImageTreeItem.ts
+++ b/src/tree/images/ImageTreeItem.ts
@@ -44,7 +44,15 @@ export class ImageTreeItem extends AzExtTreeItem {
     }
 
     public get iconPath(): IconPath {
-        return getThemedIconPath('application');
+        let icon: string;
+        switch (ext.imagesRoot.labelSetting) {
+            case 'Tag':
+                icon = 'tag';
+                break;
+            default:
+                icon = 'application';
+        }
+        return getThemedIconPath(icon);
     }
 
     public getImage(): Image {


### PR DESCRIPTION
<img width="231" alt="Screen Shot 2019-06-21 at 3 23 47 PM" src="https://user-images.githubusercontent.com/11282622/59950087-93313380-943a-11e9-9da9-720832fb2f9e.png">

In all other cases I think it still makes sense to use the "application" icon. For example:
<img width="230" alt="Screen Shot 2019-06-21 at 3 38 45 PM" src="https://user-images.githubusercontent.com/11282622/59950192-ca9fe000-943a-11e9-84c9-4e2a3eb870f5.png">
<img width="280" alt="Screen Shot 2019-06-21 at 3 39 01 PM" src="https://user-images.githubusercontent.com/11282622/59950193-ca9fe000-943a-11e9-972f-b313c7951649.png">

Fixes https://github.com/microsoft/vscode-docker/issues/1076