### PR TITLE
Fix weird grouping bug

### DIFF
--- a/src/tree/LocalGroupTreeItemBase.ts
+++ b/src/tree/LocalGroupTreeItemBase.ts
@@ -23,7 +23,7 @@ export abstract class LocalGroupTreeItemBase<TItem extends ILocalItem, TProperty
     }
 
     public get id(): string {
-        return this.group;
+        return this.group + '|LocalGroup'; // Add suffix to ensure this id doesn't coincidentally overlap with a non-grouped item
     }
 
     public get maxCreatedTime(): number {


### PR DESCRIPTION
Take this tree item as an example:
![Screen Shot 2019-07-09 at 10 18 50 AM](https://user-images.githubusercontent.com/11282622/60909381-f7256b80-a232-11e9-9a57-0c6764f034d0.png)

An image's id is currently `fullTag + id`. A group's id is the same as the label. This results in the following full ids for the above screenshot:
* `/erijiz2/helloacrtasks`
  * `/erijiz2/helloacrtasks:v1sha256:3700e2efe77f976cb8cc80b3ae3315baaaab4e9068857da491c1e99aaf555059`

However, if you change the grouping to "None" that confuses VS Code resulting in a broken view because the id for the image is still the same (just without a parent). Here are the new full ids:
* `/erijiz2/helloacrtasks|LocalGroup`
  * `/erijiz2/helloacrtasks|LocalGroup/erijiz2/helloacrtasks:v1sha256:3700e2efe77f976cb8cc80b3ae3315baaaab4e9068857da491c1e99aaf555059`