### PR TITLE
Make disconnect registry more robust to errors

### DIFF
--- a/src/commands/registries/disconnectRegistry.ts
+++ b/src/commands/registries/disconnectRegistry.ts
@@ -6,12 +6,7 @@
 import { AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { IRegistryProviderTreeItem } from "../../tree/registries/IRegistryProviderTreeItem";
-import { registryExpectedContextValues } from "../../tree/registries/registryContextValues";
 
 export async function disconnectRegistry(context: IActionContext, node?: IRegistryProviderTreeItem & AzExtTreeItem): Promise<void> {
-    if (!node) {
-        node = await ext.registriesTree.showTreeItemPicker<IRegistryProviderTreeItem & AzExtTreeItem>(registryExpectedContextValues.all.registryProvider, context);
-    }
-
-    await ext.registriesRoot.disconnectRegistry(context, node);
+    await ext.registriesRoot.disconnectRegistry(context, node && node.cachedProvider);
 }

--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -140,13 +140,35 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
         await this.saveCachedProviders();
     }
 
-    public async disconnectRegistry(context: IActionContext, node: IRegistryProviderTreeItem): Promise<void> {
-        context.telemetry.properties.providerId = node.cachedProvider.id;
-        context.telemetry.properties.providerApi = node.cachedProvider.api;
+    public async disconnectRegistry(context: IActionContext, cachedProvider: ICachedRegistryProvider | undefined): Promise<void> {
+        if (!cachedProvider) {
+            const picks = this._cachedProviders.map(crp => {
+                const provider = getRegistryProviders().find(rp => rp.id === crp.id);
+                let label: string = (provider && provider.label) || crp.id;
+                let descriptions: string[] = [];
+                if (crp.username) {
+                    descriptions.push(`Username: "${crp.username}"`)
+                }
+                if (crp.url) {
+                    descriptions.push(`URL: "${crp.url}"`)
+                }
+                return {
+                    label,
+                    description: descriptions[0],
+                    detail: descriptions[1],
+                    data: crp
+                }
+            });
+            const placeHolder: string = 'Select the registry to disconnect';
+            cachedProvider = (await ext.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true })).data;
+        }
 
-        await deleteRegistryPassword(node.cachedProvider);
+        context.telemetry.properties.providerId = cachedProvider.id;
+        context.telemetry.properties.providerApi = cachedProvider.api;
 
-        const index = this._cachedProviders.findIndex(n => n === node.cachedProvider);
+        await deleteRegistryPassword(cachedProvider);
+
+        const index = this._cachedProviders.findIndex(n => n === cachedProvider);
         if (index !== -1) {
             this._cachedProviders.splice(index, 1);
         }


### PR DESCRIPTION
A user was able to connect a registry with an empty URL and get in a situation where they couldn't disconnect it because `ext.registriesTree.showTreeItemPicker` would throw an error. Instead, I will circumvent the tree and use the registry cache more directly to show the quick pick.

Related to https://github.com/microsoft/vscode-docker/issues/1155 (emphasis on _related to_. There's still other aspects of that bug that I want to address, like preventing users from entering empty urls, etc.)

Example screenshot:
![Screen Shot 2019-07-25 at 11 48 07 AM](https://user-images.githubusercontent.com/11282622/61900847-5215be80-aed3-11e9-9b1e-014965a68ed5.png)