### PR TITLE
Include "Connect Registry..." in command palette

### DIFF
--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -43,6 +43,7 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
                 label: 'Connect Registry...',
                 contextValue: 'connectRegistry',
                 iconPath: getThemedIconPath('connect'),
+                includeInTreeItemPicker: true,
                 commandId: 'vscode-docker.registries.connectRegistry'
             })];
         } else {


### PR DESCRIPTION
I've seen some cases of "No resources found" in telemetry, which implies people are trying to run commands without connecting anything yet