### PR TITLE
Updating netcore Dockerfile to use separate directory for publish

### DIFF
--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -80,7 +80,7 @@ $copy_project_commands$
 RUN dotnet restore "$container_project_directory$/$project_file_name$"
 COPY . .
 WORKDIR "/src/$container_project_directory$"
-RUN dotnet build "$project_file_name$" -c Release -o /app
+RUN dotnet build "$project_file_name$" -c Release -o /app/build
 
 FROM build AS publish
 RUN dotnet publish "$project_file_name$" -c Release -o /app/publish
@@ -102,7 +102,7 @@ $copy_project_commands$
 RUN dotnet restore "$container_project_directory$/$project_file_name$"
 COPY . .
 WORKDIR "/src/$container_project_directory$"
-RUN dotnet build "$project_file_name$" -c Release -o /app
+RUN dotnet build "$project_file_name$" -c Release -o /app/build
 
 FROM build AS publish
 RUN dotnet publish "$project_file_name$" -c Release -o /app/publish
@@ -131,7 +131,7 @@ $copy_project_commands$
 RUN dotnet restore "$container_project_directory$/$project_file_name$"
 COPY . .
 WORKDIR "/src/$container_project_directory$"
-RUN dotnet build "$project_file_name$" -c Release -o /app
+RUN dotnet build "$project_file_name$" -c Release -o /app/build
 
 FROM build AS publish
 RUN dotnet publish "$project_file_name$" -c Release -o /app/publish
@@ -153,7 +153,7 @@ $copy_project_commands$
 RUN dotnet restore "$container_project_directory$/$project_file_name$"
 COPY . .
 WORKDIR "/src/$container_project_directory$"
-RUN dotnet build "$project_file_name$" -c Release -o /app
+RUN dotnet build "$project_file_name$" -c Release -o /app/build
 
 FROM build AS publish
 RUN dotnet publish "$project_file_name$" -c Release -o /app/publish

--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -83,11 +83,11 @@ WORKDIR "/src/$container_project_directory$"
 RUN dotnet build "$project_file_name$" -c Release -o /app
 
 FROM build AS publish
-RUN dotnet publish "$project_file_name$" -c Release -o /app
+RUN dotnet publish "$project_file_name$" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app
-COPY --from=publish /app .
+COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "$assembly_name$.dll"]
 `;
 
@@ -105,11 +105,11 @@ WORKDIR "/src/$container_project_directory$"
 RUN dotnet build "$project_file_name$" -c Release -o /app
 
 FROM build AS publish
-RUN dotnet publish "$project_file_name$" -c Release -o /app
+RUN dotnet publish "$project_file_name$" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app
-COPY --from=publish /app .
+COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "$assembly_name$.dll"]
 `;
 
@@ -134,11 +134,11 @@ WORKDIR "/src/$container_project_directory$"
 RUN dotnet build "$project_file_name$" -c Release -o /app
 
 FROM build AS publish
-RUN dotnet publish "$project_file_name$" -c Release -o /app
+RUN dotnet publish "$project_file_name$" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app
-COPY --from=publish /app .
+COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "$assembly_name$.dll"]
 `;
 
@@ -156,11 +156,11 @@ WORKDIR "/src/$container_project_directory$"
 RUN dotnet build "$project_file_name$" -c Release -o /app
 
 FROM build AS publish
-RUN dotnet publish "$project_file_name$" -c Release -o /app
+RUN dotnet publish "$project_file_name$" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app
-COPY --from=publish /app .
+COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "$assembly_name$.dll"]
 `;
 

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -627,11 +627,11 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app
 
                     FROM build AS publish
-                    RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app
+                    RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app/publish
 
                     FROM base AS final
                     WORKDIR /app
-                    COPY --from=publish /app .
+                    COPY --from=publish /app/publish .
                     ENTRYPOINT ["dotnet", "ConsoleApp1.dll"]
                 `));
 
@@ -659,11 +659,11 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app
 
                     FROM build AS publish
-                    RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app
+                    RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app/publish
 
                     FROM base AS final
                     WORKDIR /app
-                    COPY --from=publish /app .
+                    COPY --from=publish /app/publish .
                     ENTRYPOINT ["dotnet", "ConsoleApp1.dll"]
                 `));
 
@@ -696,11 +696,11 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app
 
                     FROM build AS publish
-                    RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app
+                    RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app/publish
 
                     FROM base AS final
                     WORKDIR /app
-                    COPY --from=publish /app .
+                    COPY --from=publish /app/publish .
                     ENTRYPOINT ["dotnet", "ConsoleApp1.dll"]
                 `));
 
@@ -728,11 +728,11 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app
 
                     FROM build AS publish
-                    RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app
+                    RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app/publish
 
                     FROM base AS final
                     WORKDIR /app
-                    COPY --from=publish /app .
+                    COPY --from=publish /app/publish .
                     ENTRYPOINT ["dotnet", "ConsoleApp1.dll"]
                 `));
 
@@ -850,11 +850,11 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet build "project1.csproj" -c Release -o /app
 
                     FROM build AS publish
-                    RUN dotnet publish "project1.csproj" -c Release -o /app
+                    RUN dotnet publish "project1.csproj" -c Release -o /app/publish
 
                     FROM base AS final
                     WORKDIR /app
-                    COPY --from=publish /app .
+                    COPY --from=publish /app/publish .
                     ENTRYPOINT ["dotnet", "project1.dll"]
                 `));
         });
@@ -881,11 +881,11 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet build "project2.csproj" -c Release -o /app
 
                     FROM build AS publish
-                    RUN dotnet publish "project2.csproj" -c Release -o /app
+                    RUN dotnet publish "project2.csproj" -c Release -o /app/publish
 
                     FROM base AS final
                     WORKDIR /app
-                    COPY --from=publish /app .
+                    COPY --from=publish /app/publish .
                     ENTRYPOINT ["dotnet", "project2.dll"]
                 `));
         });

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -624,7 +624,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet restore "ConsoleApp1Folder/ConsoleApp1.csproj"
                     COPY . .
                     WORKDIR "/src/ConsoleApp1Folder"
-                    RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app
+                    RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app/build
 
                     FROM build AS publish
                     RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app/publish
@@ -656,7 +656,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet restore "ConsoleApp1Folder/ConsoleApp1.csproj"
                     COPY . .
                     WORKDIR "/src/ConsoleApp1Folder"
-                    RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app
+                    RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app/build
 
                     FROM build AS publish
                     RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app/publish
@@ -693,7 +693,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet restore "subfolder/projectFolder/ConsoleApp1.csproj"
                     COPY . .
                     WORKDIR "/src/subfolder/projectFolder"
-                    RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app
+                    RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app/build
 
                     FROM build AS publish
                     RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app/publish
@@ -725,7 +725,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet restore "subfolder/projectFolder/ConsoleApp1.csproj"
                     COPY . .
                     WORKDIR "/src/subfolder/projectFolder"
-                    RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app
+                    RUN dotnet build "ConsoleApp1.csproj" -c Release -o /app/build
 
                     FROM build AS publish
                     RUN dotnet publish "ConsoleApp1.csproj" -c Release -o /app/publish
@@ -847,7 +847,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet restore "AspNetApp1/project1.csproj"
                     COPY . .
                     WORKDIR "/src/AspNetApp1"
-                    RUN dotnet build "project1.csproj" -c Release -o /app
+                    RUN dotnet build "project1.csproj" -c Release -o /app/build
 
                     FROM build AS publish
                     RUN dotnet publish "project1.csproj" -c Release -o /app/publish
@@ -878,7 +878,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     RUN dotnet restore "project2/project2.csproj"
                     COPY . .
                     WORKDIR "/src/project2"
-                    RUN dotnet build "project2.csproj" -c Release -o /app
+                    RUN dotnet build "project2.csproj" -c Release -o /app/build
 
                     FROM build AS publish
                     RUN dotnet publish "project2.csproj" -c Release -o /app/publish


### PR DESCRIPTION
The Dockerfile we scaffold calls build and publish with the same target directory. In .NET Core 3 this causes a problem because some build artifacts are left over in the publish output. See: https://github.com/aspnet/AspNetCore/issues/11609

