### PR TITLE
Always Add host and port to `compose.debug.yml`

### DIFF
--- a/src/configureWorkspace/configureNode.ts
+++ b/src/configureWorkspace/configureNode.ts
@@ -44,7 +44,7 @@ function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: str
     cmdArray.splice(1, 0, inspectConfig);
     cmd = `command: ${cmdArray.join(' ')}`;
   } else {
-    cmd = `## set your startup file here\n    command: node ${inspectConfig} index.js';
+    cmd = `## set your startup file here\n    command: node ${inspectConfig} index.js`;
   }
 
   return `version: '2.1'

--- a/src/configureWorkspace/configureNode.ts
+++ b/src/configureWorkspace/configureNode.ts
@@ -38,13 +38,13 @@ ${getComposePorts(ports)}`;
 }
 
 function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { fullCommand: cmd }: Partial<PackageInfo>): string {
-
+  const inspectConfig = '--inspect=0.0.0.0:9229'
   const cmdArray: string[] = cmd.split(' ');
   if (cmdArray[0].toLowerCase() === 'node') {
-    cmdArray.splice(1, 0, '--inspect=0.0.0.0:9229');
+    cmdArray.splice(1, 0, inspectConfig);
     cmd = `command: ${cmdArray.join(' ')}`;
   } else {
-    cmd = '## set your startup file here\n    command: node --inspect index.js';
+    cmd = `## set your startup file here\n    command: node ${inspectConfig} index.js';
   }
 
   return `version: '2.1'

--- a/src/configureWorkspace/configureNode.ts
+++ b/src/configureWorkspace/configureNode.ts
@@ -38,7 +38,7 @@ ${getComposePorts(ports)}`;
 }
 
 function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { fullCommand: cmd }: Partial<PackageInfo>): string {
-  const inspectConfig = '--inspect=0.0.0.0:9229'
+  const inspectConfig = '--inspect=0.0.0.0:9229';
   const cmdArray: string[] = cmd.split(' ');
   if (cmdArray[0].toLowerCase() === 'node') {
     cmdArray.splice(1, 0, inspectConfig);

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -462,13 +462,13 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('docker-compose.debug.yml', '9229:9229');
             assertFileContains('docker-compose.debug.yml', 'image: testoutput');
             assertFileContains('docker-compose.debug.yml', 'NODE_ENV: development');
-            assertFileContains('docker-compose.debug.yml', 'command: node --inspect index.js');
+            assertFileContains('docker-compose.debug.yml', 'command: node --inspect:0.0.0.0:9229 index.js');
 
             assertFileContains('docker-compose.yml', '1234:1234');
             assertNotFileContains('docker-compose.yml', '9229:9229');
             assertFileContains('docker-compose.yml', 'image: testoutput');
             assertFileContains('docker-compose.yml', 'NODE_ENV: production');
-            assertNotFileContains('docker-compose.yml', 'command: node --inspect index.js');
+            assertNotFileContains('docker-compose.yml', 'command: node --inspect:0.0.0.0:9229 index.js');
 
             assertFileContains('.dockerignore', '.vscode');
         });
@@ -510,13 +510,13 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('docker-compose.debug.yml', '9229:9229');
             assertFileContains('docker-compose.debug.yml', 'image: testoutput');
             assertFileContains('docker-compose.debug.yml', 'NODE_ENV: development');
-            assertFileContains('docker-compose.debug.yml', 'command: node --inspect index.js');
+            assertFileContains('docker-compose.debug.yml', 'command: node --inspect:0.0.0.0:9229 index.js');
 
             assertFileContains('docker-compose.yml', '4321:4321');
             assertNotFileContains('docker-compose.yml', '9229:9229');
             assertFileContains('docker-compose.yml', 'image: testoutput');
             assertFileContains('docker-compose.yml', 'NODE_ENV: production');
-            assertNotFileContains('docker-compose.yml', 'command: node --inspect index.js');
+            assertNotFileContains('docker-compose.yml', 'command: node --inspect:0.0.0.0:9229 index.js');
 
             assertFileContains('.dockerignore', '.vscode');
         });

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -462,13 +462,13 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('docker-compose.debug.yml', '9229:9229');
             assertFileContains('docker-compose.debug.yml', 'image: testoutput');
             assertFileContains('docker-compose.debug.yml', 'NODE_ENV: development');
-            assertFileContains('docker-compose.debug.yml', 'command: node --inspect:0.0.0.0:9229 index.js');
+            assertFileContains('docker-compose.debug.yml', 'command: node --inspect=0.0.0.0:9229 index.js');
 
             assertFileContains('docker-compose.yml', '1234:1234');
             assertNotFileContains('docker-compose.yml', '9229:9229');
             assertFileContains('docker-compose.yml', 'image: testoutput');
             assertFileContains('docker-compose.yml', 'NODE_ENV: production');
-            assertNotFileContains('docker-compose.yml', 'command: node --inspect:0.0.0.0:9229 index.js');
+            assertNotFileContains('docker-compose.yml', 'command: node --inspect=0.0.0.0:9229 index.js');
 
             assertFileContains('.dockerignore', '.vscode');
         });
@@ -510,13 +510,13 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('docker-compose.debug.yml', '9229:9229');
             assertFileContains('docker-compose.debug.yml', 'image: testoutput');
             assertFileContains('docker-compose.debug.yml', 'NODE_ENV: development');
-            assertFileContains('docker-compose.debug.yml', 'command: node --inspect:0.0.0.0:9229 index.js');
+            assertFileContains('docker-compose.debug.yml', 'command: node --inspect=0.0.0.0:9229 index.js');
 
             assertFileContains('docker-compose.yml', '4321:4321');
             assertNotFileContains('docker-compose.yml', '9229:9229');
             assertFileContains('docker-compose.yml', 'image: testoutput');
             assertFileContains('docker-compose.yml', 'NODE_ENV: production');
-            assertNotFileContains('docker-compose.yml', 'command: node --inspect:0.0.0.0:9229 index.js');
+            assertNotFileContains('docker-compose.yml', 'command: node --inspect=0.0.0.0:9229 index.js');
 
             assertFileContains('.dockerignore', '.vscode');
         });


### PR DESCRIPTION
It appears that we are looking for an `npm` script which directly references `node` in order to generate the proper debug configuration (--inspect=0.0.0.0:9229). But directly referencing `node` isn't required for an `npm start` script. For instance, the following is valid...

```
"scripts": {
  "start": "./server.js"
}
```

I had this configuration and it took me quite a while to figure out why the debugger wouldn't attach.

It seems to me that we should always generate the proper host:port configuration for the `debug.yml`. What is the use case for not doing that if we don't find "node" as a command in the `package.json` scripts section? If the user has already selected "node", then node is explicit.