### PR TITLE
Improvements to ASP.NET Core SSL support

### DIFF
--- a/src/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/src/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -305,6 +305,26 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
             return debugConfiguration.configureAspNetCoreSsl;
         }
 
+        const launchSettingsPath = path.join(path.dirname(projectFile), 'Properties', 'launchSettings.json');
+
+        if (await this.fsProvider.fileExists(launchSettingsPath)) {
+            let launchSettingsString = await this.fsProvider.readFile(launchSettingsPath);
+            if (launchSettingsString.charCodeAt(0) === 0xFEFF) {
+                launchSettingsString = launchSettingsString.slice(1);
+            }
+            const launchSettings = JSON.parse(launchSettingsString);
+
+            //tslint:disable:no-unsafe-any no-any
+            if (launchSettings && launchSettings.profiles) {
+                const projectProfile = Object.values<any>(launchSettings.profiles).find(p => p.commandName === 'Project');
+
+                if (projectProfile && projectProfile.applicationUrl && /https:\/\//i.test(projectProfile.applicationUrl)) {
+                    return true;
+                }
+            }
+            //tslint:enable:no-unsafe-any no-any
+        }
+
         return false;
     }
 

--- a/src/debugging/coreclr/dockerDebugConfigurationProvider.ts
+++ b/src/debugging/coreclr/dockerDebugConfigurationProvider.ts
@@ -310,12 +310,14 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         if (await this.fsProvider.fileExists(launchSettingsPath)) {
             let launchSettingsString = await this.fsProvider.readFile(launchSettingsPath);
             if (launchSettingsString.charCodeAt(0) === 0xFEFF) {
+                // Remove byte order mark if needed
                 launchSettingsString = launchSettingsString.slice(1);
             }
             const launchSettings = JSON.parse(launchSettingsString);
 
             //tslint:disable:no-unsafe-any no-any
             if (launchSettings && launchSettings.profiles) {
+                // launchSettings.profiles is a dictionary instead of an array, so need to get the values and look for one that has commandName: 'Project'
                 const projectProfile = Object.values<any>(launchSettings.profiles).find(p => p.commandName === 'Project');
 
                 if (projectProfile && projectProfile.applicationUrl && /https:\/\//i.test(projectProfile.applicationUrl)) {


### PR DESCRIPTION
* Add <UserSecretsId> property when < 3.0 dotnet CLI is present
* Pass in ASPNETCORE_HTTPS_PORT env var to enable automatic redirection to SSL page
* Automatically infer if the app is SSL-enabled

#1144 