### PR TITLE
Allow user to disconnect invalid registry from tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -419,6 +419,11 @@
                     "group": "regs_yyy_destructive@1"
                 },
                 {
+                    "command": "vscode-docker.registries.disconnectRegistry",
+                    "when": "view == dockerRegistries && viewItem == invalidRegistryProvider",
+                    "group": "regs_yyy_destructive@1"
+                },
+                {
                     "command": "vscode-docker.registries.azure.openInPortal",
                     "when": "view == dockerRegistries && viewItem =~ /azure(Subscription|;DockerV2;Registry;)/",
                     "group": "regs_zzz_common@1"

--- a/src/commands/registries/disconnectRegistry.ts
+++ b/src/commands/registries/disconnectRegistry.ts
@@ -3,10 +3,17 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
+import { IActionContext, InvalidTreeItem } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
+import { ICachedRegistryProvider } from "../../tree/registries/ICachedRegistryProvider";
 import { IRegistryProviderTreeItem } from "../../tree/registries/IRegistryProviderTreeItem";
 
-export async function disconnectRegistry(context: IActionContext, node?: IRegistryProviderTreeItem & AzExtTreeItem): Promise<void> {
-    await ext.registriesRoot.disconnectRegistry(context, node && node.cachedProvider);
+export async function disconnectRegistry(context: IActionContext, node?: InvalidTreeItem | IRegistryProviderTreeItem): Promise<void> {
+    let cachedProvider: ICachedRegistryProvider | undefined;
+    if (node instanceof InvalidTreeItem) {
+        cachedProvider = <ICachedRegistryProvider>node.data;
+    } else if (node) {
+        cachedProvider = node.cachedProvider;
+    }
+    await ext.registriesRoot.disconnectRegistry(context, cachedProvider);
 }

--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -58,22 +58,17 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
                     }
 
                     const parent = provider.isSingleRegistry ? this._connectedRegistriesTreeItem : this;
-                    const treeItem = this.initTreeItem(new provider.treeItemType(parent, cachedProvider));
-                    if (provider.isSingleRegistry) {
-                        this._connectedRegistriesTreeItem.children.push(treeItem);
-                        return undefined;
-                    } else {
-                        return treeItem;
-                    }
+                    return this.initTreeItem(new provider.treeItemType(parent, cachedProvider));
                 },
                 cachedInfo => cachedInfo.id
             );
 
+            this._connectedRegistriesTreeItem.children = children.filter(c => c.parent === this._connectedRegistriesTreeItem);
             if (this._connectedRegistriesTreeItem.children.length > 0) {
                 children.push(this._connectedRegistriesTreeItem);
             }
 
-            return children;
+            return children.filter(c => c.parent !== this._connectedRegistriesTreeItem);
         }
     }
 


### PR DESCRIPTION
The final piece that fixes https://github.com/microsoft/vscode-docker/issues/1155

Now if an invalid registry is connected, it'll be displayed in the tree and users can right click on it to disconnect:
![Screen Shot 2019-08-08 at 10 31 49 AM](https://user-images.githubusercontent.com/11282622/62724517-07626f00-b9c8-11e9-9e8d-aa6cd1eb62ea.png)
