### PR TITLE
Update docker.svg icon to use line icon

### DIFF
--- a/resources/docker.svg
+++ b/resources/docker.svg
@@ -1,10 +1,103 @@
-<svg width="28" height="28" viewBox="0 0 28 28" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g id="Canvas" fill="none">
-<g id="Union">
-<g id="Union_2">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M 24.2177 7.03198C 25.3377 6.83008 26.7882 6.97705 27.4125 7.39917L 28 7.80322L 27.9082 8.00513C 27.7687 8.28418 27.6927 8.42554 27.6563 8.49341L 27.6328 8.5376C 26.5862 10.5205 24.5666 10.5388 23.6302 10.5205C 21.2433 16.2673 16.1575 19.4438 9.27228 19.4438C 6.09595 19.4438 3.65399 18.4707 2.03827 16.5427C -0.109927 14.0273 -0.109927 10.7224 0.0736672 9.67603L 0.11041 9.45557L 19.1319 9.45557C 20.105 9.47412 20.8578 9.19873 21.2433 8.99658C 20.8761 8.40918 20.7476 7.74805 20.7109 7.38086C 20.6191 6.33447 20.8761 5.23267 21.4086 4.44336L 21.8125 3.8374L 22.4184 4.24121C 23.4833 5.06738 24.0709 5.9856 24.2177 7.03198ZM 15.2946 2.62549L 12.4119 2.62549L 12.4119 0L 15.2946 0L 15.2946 2.62549ZM 15.2946 5.78345L 12.4119 5.78345L 12.4119 3.15796L 15.2946 3.15796L 15.2946 5.78345ZM 11.8795 5.78345L 8.99688 5.78345L 8.99688 3.15796L 11.8795 3.15796L 11.8795 5.78345ZM 8.46441 5.78345L 5.58185 5.78345L 5.58185 3.15796L 8.46441 3.15796L 8.46441 5.78345ZM 5.04938 8.94165L 2.16675 8.94165L 2.16675 6.29761L 5.04938 6.29761L 5.04938 8.94165ZM 8.46441 8.94165L 5.58185 8.94165L 5.58185 6.29761L 8.46441 6.29761L 8.46441 8.94165ZM 11.8795 8.94165L 8.99688 8.94165L 8.99688 6.29761L 11.8795 6.29761L 11.8795 8.94165ZM 15.2946 8.94165L 12.4119 8.94165L 12.4119 6.29761L 15.2946 6.29761L 15.2946 8.94165ZM 18.728 8.94165L 15.827 8.94165L 15.827 6.29761L 18.728 6.29761L 18.728 8.94165ZM 17.6997 18.8562C 17.9017 18.8562 18.067 18.6909 18.067 18.489C 18.067 18.2871 17.9017 18.1218 17.6997 18.1218C 17.4977 18.1218 17.3325 18.2871 17.3325 18.489C 17.3325 18.6909 17.4977 18.8562 17.6997 18.8562ZM 17.6997 18.7827C 17.5345 18.7827 17.4243 18.6543 17.4243 18.489C 17.4243 18.3237 17.5345 18.1953 17.6997 18.1953C 17.865 18.1953 17.9752 18.3237 17.9752 18.489C 17.9752 18.6543 17.865 18.7827 17.6997 18.7827ZM 17.5529 18.6726L 17.6447 18.6726L 17.6447 18.5073L 17.6814 18.5073C 17.7181 18.5073 17.7548 18.5256 17.7548 18.5625C 17.7629 18.5786 17.7674 18.5947 17.7715 18.6094C 17.7767 18.6279 17.7812 18.644 17.7915 18.6543L 17.8834 18.6543C 17.8834 18.636 17.8834 18.6177 17.865 18.5625C 17.8466 18.5073 17.8282 18.489 17.7915 18.4707C 17.8282 18.4524 17.865 18.4155 17.865 18.3789C 17.865 18.342 17.8466 18.3237 17.8282 18.3054C 17.813 18.3054 17.801 18.3022 17.7869 18.2986C 17.7668 18.2935 17.7427 18.2871 17.6997 18.2871C 17.6567 18.2871 17.6263 18.2935 17.6011 18.2986C 17.5832 18.3022 17.5681 18.3054 17.5529 18.3054L 17.5529 18.6726ZM 17.6814 18.4707L 17.6447 18.4707L 17.6447 18.3606L 17.6997 18.3606C 17.7548 18.3606 17.7732 18.3789 17.7732 18.4155C 17.7732 18.4524 17.7364 18.4707 17.6814 18.4707Z" transform="translate(0.867859 4.73779)" fill="#ffffff"/>
-</g>
-</g>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   fill="none"
+   version="1.1"
+   id="svg34"
+   sodipodi:docname="docker.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata40">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs38" />
+  <sodipodi:namedview
+     pagecolor="#ff6f1d"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="740"
+     id="namedview36"
+     showgrid="false"
+     inkscape:pagecheckerboard="false"
+     inkscape:zoom="6.9532165"
+     inkscape:cx="4.594229"
+     inkscape:cy="15.901386"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer7" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="Body"
+     style="display:inline" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="Eye"
+     style="display:inline" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer7"
+     inkscape:label="Containers"
+     style="display:inline">
+    <g
+       id="g4569"
+       transform="translate(-5.3724895e-8,-1.4937927)">
+      <g
+         transform="matrix(0.99449524,0,0,0.99999353,0.06605737,1.7458297)"
+         id="g932"
+         style="display:inline">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#fefefe;stroke-width:1.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+           stroke-miterlimit="10"
+           d="m 15.524074,11.945498 c 1.729882,0 2.508679,-0.656276 2.755603,-0.804616 -0.324851,-0.424374 -0.490093,-0.938406 -0.539854,-1.4881174 -0.153975,-1.7012422 0.806496,-2.4955318 0.806496,-2.4955318 0,0 1.397985,0.7938202 1.732693,2.5593754 1.849586,-0.5074624 2.987502,0.4309438 2.987502,0.4309438 0,0 -0.578815,2.032195 -3.512333,1.920938 -1.993232,4.964306 -6.259485,7.388014 -11.5096804,7.388014 -5.65203,0 -7.51100372,-4.114623 -7.51100372,-6.685263 0,-0.465214 0.0647824,-0.825743 0.0647824,-0.825743 0,0 12.85696572,0 14.72579472,0 z"
+           id="path2" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#fcffff;stroke-width:1.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+           stroke-miterlimit="10"
+           d="M 5.467576,15.815075 2.349118,16.559652"
+           id="path8" />
+      </g>
+      <circle
+         r="0.5"
+         cy="16.670015"
+         cx="8.2910395"
+         id="path935"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#fcffff;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path6"
+         d="m 12.922481,10.318682 h 2.651991 v 2.66665 h -2.651991 z m -2.651992,0 h 2.651992 v 2.66665 h -2.651992 z m -2.6519867,0 h 2.6519867 v 2.66665 H 7.6185023 Z m -2.6519875,0 h 2.6519875 v 2.66665 H 4.9665148 Z m -2.6519878,0 h 2.6519878 v 2.66665 H 2.314527 Z m 7.955962,-5.3332992 h 2.651992 v 2.6666481 h -2.651992 z m 0,2.6666481 h 2.651992 v 2.6666511 h -2.651992 z m -2.6519867,0 H 10.270489 V 10.318682 H 7.6185023 Z m -2.6519875,0 H 7.6185023 V 10.318682 H 4.9665148 Z"
+         stroke-miterlimit="10"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.8127619;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
 </svg>
-


### PR DESCRIPTION
VS Code version has updated product icons to have uniform style, color and size. This svg icon follows the same specifications with new vs code icons.

![Docker icon preview](https://user-images.githubusercontent.com/16473630/62744108-cf9e0a80-ba4d-11e9-93f0-2bb471a7264f.png)

This PR is for docker.svg only. There is already a pull request for other icons:

https://github.com/microsoft/vscode-docker/pull/1192