### PR TITLE
Command to pull image from Images tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "onCommand:vscode-docker.images.inspect",
         "onCommand:vscode-docker.images.prune",
         "onCommand:vscode-docker.images.push",
+        "onCommand:vscode-docker.images.pull",
         "onCommand:vscode-docker.images.refresh",
         "onCommand:vscode-docker.images.remove",
         "onCommand:vscode-docker.images.run",
@@ -319,9 +320,14 @@
                     "group": "images_2_general@2"
                 },
                 {
-                    "command": "vscode-docker.images.tag",
+                    "command": "vscode-docker.images.pull",
                     "when": "view == dockerImages && viewItem == image",
                     "group": "images_2_general@3"
+                },
+                {
+                    "command": "vscode-docker.images.tag",
+                    "when": "view == dockerImages && viewItem == image",
+                    "group": "images_2_general@4"
                 },
                 {
                     "command": "vscode-docker.images.remove",
@@ -1240,6 +1246,11 @@
             {
                 "command": "vscode-docker.images.push",
                 "title": "Push",
+                "category": "Docker Images"
+            },
+            {
+                "command": "vscode-docker.images.pull",
+                "title": "Pull",
                 "category": "Docker Images"
             },
             {

--- a/src/commands/images/pullImage.ts
+++ b/src/commands/images/pullImage.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../../extensionVariables';
+import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
+
+export async function pullImage(context: IActionContext, node: ImageTreeItem | undefined): Promise<void> {
+    if (!node) {
+        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, context);
+    }
+
+    const terminal = ext.terminalProvider.createTerminal(node.fullTag);
+    terminal.sendText(`docker pull ${node.fullTag}`);
+    terminal.show();
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -20,6 +20,7 @@ import { buildImage } from "./images/buildImage";
 import { configureImagesExplorer } from "./images/configureImagesExplorer";
 import { inspectImage } from "./images/inspectImage";
 import { pruneImages } from "./images/pruneImages";
+import { pullImage } from "./images/pullImage";
 import { pushImage } from "./images/pushImage";
 import { removeImage } from "./images/removeImage";
 import { runAzureCliImage } from "./images/runAzureCliImage";
@@ -48,7 +49,7 @@ import { disconnectRegistry } from "./registries/disconnectRegistry";
 import { openDockerHubInBrowser } from "./registries/dockerHub/openDockerHubInBrowser";
 import { logInToDockerCli } from "./registries/logInToDockerCli";
 import { logOutOfDockerCli } from "./registries/logOutOfDockerCli";
-import { pullImage, pullRepository } from "./registries/pullImages";
+import { pullImageFromRegistry, pullRepository } from "./registries/pullImages";
 import { setRegistryAsDefault } from "./registries/registrySettings";
 import { configureVolumesExplorer } from "./volumes/configureVolumesExplorer";
 import { inspectVolume } from "./volumes/inspectVolume";
@@ -78,6 +79,7 @@ export function registerCommands(): void {
     registerCommand('vscode-docker.images.inspect', inspectImage);
     registerCommand('vscode-docker.images.prune', pruneImages);
     registerCommand('vscode-docker.images.push', pushImage);
+    registerCommand('vscode-docker.images.pull', pullImage);
     registerCommand('vscode-docker.images.remove', removeImage);
     registerCommand('vscode-docker.images.run', runImage);
     registerCommand('vscode-docker.images.runAzureCli', runAzureCliImage);
@@ -96,7 +98,7 @@ export function registerCommands(): void {
     registerCommand('vscode-docker.registries.disconnectRegistry', disconnectRegistry);
     registerCommand('vscode-docker.registries.logInToDockerCli', logInToDockerCli);
     registerCommand('vscode-docker.registries.logOutOfDockerCli', logOutOfDockerCli);
-    registerCommand('vscode-docker.registries.pullImage', pullImage);
+    registerCommand('vscode-docker.registries.pullImage', pullImageFromRegistry);
     registerCommand('vscode-docker.registries.pullRepository', pullRepository);
     registerCommand('vscode-docker.registries.setAsDefault', setRegistryAsDefault);
 

--- a/src/commands/registries/pullImages.ts
+++ b/src/commands/registries/pullImages.ts
@@ -20,7 +20,7 @@ export async function pullRepository(context: IActionContext, node?: RemoteRepos
     await pullImages(context, node.parent, node.repoName + ' -a');
 }
 
-export async function pullImage(context: IActionContext, node?: RemoteTagTreeItem): Promise<void> {
+export async function pullImageFromRegistry(context: IActionContext, node?: RemoteTagTreeItem): Promise<void> {
     if (!node) {
         node = await ext.registriesTree.showTreeItemPicker<RemoteTagTreeItem>(registryExpectedContextValues.all.tag, context);
     }


### PR DESCRIPTION
Commonly, I need to pull a bunch of base images. Doing so from the command line is a chore, and the registries view is unwieldy for e.g. the MCR repository, so it'd be nice to be able to pull specific images that are already on your machine, to update them.