### PR TITLE
Exclude bin folder from excluded Dockerfile items for Node.js

### DIFF
--- a/src/configureWorkspace/configure.ts
+++ b/src/configureWorkspace/configure.ts
@@ -112,32 +112,36 @@ function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: Pla
     }
 }
 
-function genDockerIgnoreFile(service: string, platformType: string, os: string, ports: number[]): string {
-    return `**/.classpath
-**/.dockerignore
-**/.env
-**/.git
-**/.gitignore
-**/.project
-**/.settings
-**/.toolstarget
-**/.vs
-**/.vscode
-**/*.*proj.user
-**/*.dbmdl
-**/*.jfm
-**/azds.yaml
-**/bin
-**/charts
-**/docker-compose*
-**/Dockerfile*
-**/node_modules
-**/npm-debug.log
-**/obj
-**/secrets.dev.yaml
-**/values.dev.yaml
-LICENSE
-README.md`;
+function genDockerIgnoreFile(service: string, platformType: Platform, os: string, ports: number[]): string {
+    const ignoredItems = [
+        '**/.classpath',
+        '**/.dockerignore',
+        '**/.env',
+        '**/.git',
+        '**/.gitignore',
+        '**/.project',
+        '**/.settings',
+        '**/.toolstarget',
+        '**/.vs',
+        '**/.vscode',
+        '**/*.*proj.user',
+        '**/*.dbmdl',
+        '**/*.jfm',
+        '**/azds.yaml',
+        platformType !== 'Node.js' ? '**/bin' : undefined,
+        '**/charts',
+        '**/docker-compose*',
+        '**/Dockerfile*',
+        '**/node_modules',
+        '**/npm-debug.log',
+        '**/obj',
+        '**/secrets.dev.yaml',
+        '**/values.dev.yaml',
+        'LICENSE',
+        'README.md'
+    ];
+
+    return ignoredItems.filter(item => item !== undefined).join('\n');
 }
 
 async function getPackageJson(folderPath: string): Promise<vscode.Uri[]> {


### PR DESCRIPTION
For Node.js applications, when configuring the workspace for use with Docker, exclude the `bin` folder from the `.dockerignore` file.  This resolves an [issue](#1219) with Express.js applications which, for whatever (historical) reason, defaults to having its startup script be `./bin/www`, which would otherwise be excluded from the Docker image and thus causing the container to fail to start.
