### PR TITLE
Change extension to run in remote workspace by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "license": "SEE LICENSE IN LICENSE.md",
     "icon": "resources/docker.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
+    "extensionKind": "workspace",
     "galleryBanner": {
         "color": "#1289B9",
         "theme": "dark"
@@ -1118,6 +1119,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Run docker-compose with the --d (detached) argument, defaults to true"
+                },
+                "docker.showRemoteWorkspaceWarning": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show a prompt to switch from \"UI\" extension to \"Workspace\" extension if an operation is not supported."
                 }
             }
         },
@@ -1521,7 +1527,7 @@
         }
     },
     "engines": {
-        "vscode": "^1.31.0"
+        "vscode": "^1.36.0"
     },
     "scripts": {
         "vscode:prepublish": "npm run webpack-prod",

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -30,6 +30,7 @@ import { inspectNetwork } from "./networks/inspectNetwork";
 import { pruneNetworks } from "./networks/pruneNetworks";
 import { removeNetwork } from "./networks/removeNetwork";
 import { pruneSystem } from "./pruneSystem";
+import { registerWorkspaceCommand } from "./registerWorkspaceCommand";
 import { createAzureRegistry } from "./registries/azure/createAzureRegistry";
 import { deleteAzureRegistry } from "./registries/azure/deleteAzureRegistry";
 import { deleteAzureRepository } from "./registries/azure/deleteAzureRepository";
@@ -56,14 +57,14 @@ import { pruneVolumes } from "./volumes/pruneVolumes";
 import { removeVolume } from "./volumes/removeVolume";
 
 export function registerCommands(): void {
-    registerCommand('vscode-docker.api.configure', configureApi);
-    registerCommand('vscode-docker.compose.down', composeDown);
-    registerCommand('vscode-docker.compose.restart', composeRestart);
-    registerCommand('vscode-docker.compose.up', composeUp);
-    registerCommand('vscode-docker.configure', configure);
+    registerWorkspaceCommand('vscode-docker.api.configure', configureApi);
+    registerWorkspaceCommand('vscode-docker.compose.down', composeDown);
+    registerWorkspaceCommand('vscode-docker.compose.restart', composeRestart);
+    registerWorkspaceCommand('vscode-docker.compose.up', composeUp);
+    registerWorkspaceCommand('vscode-docker.configure', configure);
     registerCommand('vscode-docker.pruneSystem', pruneSystem);
 
-    registerCommand('vscode-docker.containers.attachShell', attachShellContainer);
+    registerWorkspaceCommand('vscode-docker.containers.attachShell', attachShellContainer);
     registerCommand('vscode-docker.containers.inspect', inspectContainer);
     registerCommand('vscode-docker.containers.configureExplorer', configureContainersExplorer);
     registerCommand('vscode-docker.containers.prune', pruneContainers);
@@ -71,17 +72,17 @@ export function registerCommands(): void {
     registerCommand('vscode-docker.containers.restart', restartContainer);
     registerCommand('vscode-docker.containers.start', startContainer);
     registerCommand('vscode-docker.containers.stop', stopContainer);
-    registerCommand('vscode-docker.containers.viewLogs', viewContainerLogs);
+    registerWorkspaceCommand('vscode-docker.containers.viewLogs', viewContainerLogs);
 
-    registerCommand('vscode-docker.images.build', buildImage);
+    registerWorkspaceCommand('vscode-docker.images.build', buildImage);
     registerCommand('vscode-docker.images.configureExplorer', configureImagesExplorer);
     registerCommand('vscode-docker.images.inspect', inspectImage);
     registerCommand('vscode-docker.images.prune', pruneImages);
-    registerCommand('vscode-docker.images.push', pushImage);
+    registerWorkspaceCommand('vscode-docker.images.push', pushImage);
     registerCommand('vscode-docker.images.remove', removeImage);
-    registerCommand('vscode-docker.images.run', runImage);
-    registerCommand('vscode-docker.images.runAzureCli', runAzureCliImage);
-    registerCommand('vscode-docker.images.runInteractive', runImageInteractive);
+    registerWorkspaceCommand('vscode-docker.images.run', runImage);
+    registerWorkspaceCommand('vscode-docker.images.runAzureCli', runAzureCliImage);
+    registerWorkspaceCommand('vscode-docker.images.runInteractive', runImageInteractive);
     registerCommand('vscode-docker.images.tag', tagImage);
 
     registerCommand('vscode-docker.networks.configureExplorer', configureNetworksExplorer);
@@ -94,21 +95,21 @@ export function registerCommands(): void {
     registerCommand('vscode-docker.registries.deleteImage', deleteRemoteImage);
     registerCommand('vscode-docker.registries.deployImageToAzure', deployImageToAzure);
     registerCommand('vscode-docker.registries.disconnectRegistry', disconnectRegistry);
-    registerCommand('vscode-docker.registries.logInToDockerCli', logInToDockerCli);
-    registerCommand('vscode-docker.registries.logOutOfDockerCli', logOutOfDockerCli);
-    registerCommand('vscode-docker.registries.pullImage', pullImage);
-    registerCommand('vscode-docker.registries.pullRepository', pullRepository);
+    registerWorkspaceCommand('vscode-docker.registries.logInToDockerCli', logInToDockerCli);
+    registerWorkspaceCommand('vscode-docker.registries.logOutOfDockerCli', logOutOfDockerCli);
+    registerWorkspaceCommand('vscode-docker.registries.pullImage', pullImage);
+    registerWorkspaceCommand('vscode-docker.registries.pullRepository', pullRepository);
     registerCommand('vscode-docker.registries.setAsDefault', setRegistryAsDefault);
 
     registerCommand('vscode-docker.registries.dockerHub.openInBrowser', openDockerHubInBrowser);
 
-    registerCommand('vscode-docker.registries.azure.buildImage', buildImageInAzure);
+    registerWorkspaceCommand('vscode-docker.registries.azure.buildImage', buildImageInAzure);
     registerCommand('vscode-docker.registries.azure.createRegistry', createAzureRegistry);
     registerCommand('vscode-docker.registries.azure.deleteRegistry', deleteAzureRegistry);
     registerCommand('vscode-docker.registries.azure.deleteRepository', deleteAzureRepository);
     registerCommand('vscode-docker.registries.azure.openInPortal', openInAzurePortal);
     registerCommand('vscode-docker.registries.azure.runTask', runAzureTask);
-    registerCommand('vscode-docker.registries.azure.runFileAsTask', runFileAsAzureTask);
+    registerWorkspaceCommand('vscode-docker.registries.azure.runFileAsTask', runFileAsAzureTask);
     registerCommand('vscode-docker.registries.azure.selectSubscriptions', () => commands.executeCommand("azure-account.selectSubscriptions"));
     registerCommand('vscode-docker.registries.azure.untagImage', untagAzureImage);
     registerCommand('vscode-docker.registries.azure.viewProperties', viewAzureProperties);

--- a/src/commands/registerWorkspaceCommand.ts
+++ b/src/commands/registerWorkspaceCommand.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { commands, ConfigurationTarget, MessageItem, workspace, WorkspaceConfiguration } from 'vscode';
+import { callWithTelemetryAndErrorHandling, IActionContext, registerCommand, UserCancelledError } from 'vscode-azureextensionui';
+import { extensionId } from '../constants';
+import { ext } from '../extensionVariables';
+import { DockerExtensionKind, getVSCodeRemoteInfo, IVSCodeRemoteInfo, RemoteKind } from '../utils/getVSCodeRemoteInfo';
+
+/**
+ * Registers a command that requires running in the "workspace" environment (as opposed to a "ui" extension).
+ * The most common reason this is required is when using the file system and/or a terminal.
+ */
+// tslint:disable-next-line: no-any
+export function registerWorkspaceCommand(commandId: string, callback: (context: IActionContext, ...args: any[]) => any, debounce?: number): void {
+    registerCommand(
+        commandId,
+        // tslint:disable-next-line: no-any
+        async (context, ...args: any[]) => {
+            await verifyIsRunningInWorkspace(context);
+            return callback(context, ...args);
+        },
+        debounce
+    );
+}
+
+async function verifyIsRunningInWorkspace(context: IActionContext): Promise<void> {
+    const config: WorkspaceConfiguration = workspace.getConfiguration('docker');
+    if (!!config.get('showRemoteWorkspaceWarning')) {
+        const remoteInfo: IVSCodeRemoteInfo = getVSCodeRemoteInfo(context);
+        if (remoteInfo.extensionKind === DockerExtensionKind.ui) {
+            let message: string;
+            let switchTitle: string;
+            let learnMoreLink: string;
+            switch (remoteInfo.remoteKind) {
+                case RemoteKind.ssh:
+                    message = 'This operation is not supported because the Docker extension is currently running on your local machine.';
+                    switchTitle = 'Switch to Remote SSH';
+                    learnMoreLink = 'https://aka.ms/AA5y2rd';
+                    break;
+                case RemoteKind.wsl:
+                    message = 'This operation is not supported because the Docker extension is currently running outside of WSL.';
+                    switchTitle = 'Switch to WSL';
+                    learnMoreLink = 'https://aka.ms/AA5xvjn';
+                    break;
+                case RemoteKind.devContainer:
+                    message = 'This operation is not supported because the Docker extension is currently running outside of your container.';
+                    switchTitle = 'Switch to Container';
+                    learnMoreLink = 'https://aka.ms/AA5xva6';
+                    break;
+                default:
+                    // Assume this works rather than block users on unknown remotes
+                    return;
+            }
+
+            context.telemetry.properties.cancelStep = 'switchExtensionKind';
+            const switchBtn: MessageItem = { title: switchTitle };
+            await ext.ui.showWarningMessage(message, { learnMoreLink }, switchBtn);
+            updateExtensionKind('workspace');
+
+            context.telemetry.properties.cancelStep = 'requiresReload';
+            let reloadMessage: string = 'This change to the Docker extension requires reloading VS Code to take effect.';
+            let reload: MessageItem = { title: 'Reload Now' };
+            await ext.ui.showWarningMessage(reloadMessage, reload);
+
+            // Add a one-off event here before reloading the window otherwise we'll lose telemetry for this code path
+            await callWithTelemetryAndErrorHandling('verifyIsWorkspaceExtension', (newContext: IActionContext) => {
+                Object.assign(newContext, context);
+            });
+
+            await commands.executeCommand('workbench.action.reloadWindow');
+
+            context.telemetry.properties.cancelStep = 'reloading';
+            // throw an exception just to make sure we don't try to continue the command before the window is fully reloaded
+            throw new UserCancelledError();
+        }
+    }
+}
+
+function updateExtensionKind(newKind: string): void {
+    const settingKey: string = 'remote.extensionKind';
+    const config: WorkspaceConfiguration = workspace.getConfiguration();
+    const values = config.inspect(settingKey);
+    let target: ConfigurationTarget;
+    let value: {};
+
+    // If the setting is already defined as a workspace setting - overwrite that
+    if (typeof values.workspaceValue === 'object' && values.workspaceValue !== null && values.workspaceValue[extensionId]) {
+        target = ConfigurationTarget.Workspace;
+        value = values.workspaceValue;
+    } else { // otherwise update the global setting
+        target = ConfigurationTarget.Global;
+        if (typeof values.globalValue === 'object' && values.globalValue !== null) {
+            value = values.globalValue || {};
+        } else {
+            value = {};
+        }
+    }
+
+    value[extensionId] = newKind;
+    config.update(settingKey, value, target);
+}

--- a/src/commands/registerWorkspaceCommand.ts
+++ b/src/commands/registerWorkspaceCommand.ts
@@ -93,7 +93,7 @@ function updateExtensionKind(newKind: string): void {
     } else { // otherwise update the global setting
         target = ConfigurationTarget.Global;
         if (typeof values.globalValue === 'object' && values.globalValue !== null) {
-            value = values.globalValue || {};
+            value = values.globalValue;
         } else {
             value = {};
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,3 +39,5 @@ export const FSPROJ_GLOB_PATTERN = '**/*.{[fF][sS][pP][rR][oO][jJ]}';
 export const FILE_SEARCH_MAX_RESULT = 1000;
 
 export const dockerHubUrl: string = 'https://hub.docker.com/';
+
+export const extensionId: string = 'ms-azuretools.vscode-docker';

--- a/src/utils/getVSCodeRemoteInfo.ts
+++ b/src/utils/getVSCodeRemoteInfo.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { env, ExtensionKind, extensions } from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
+import { extensionId } from '../constants';
+
+export enum DockerExtensionKind {
+    /**
+     * Extension running in a remote environment
+     */
+    workspace = 'workspace',
+
+    /**
+     * Extension running in local environment, but remote enironment does exist
+     */
+    ui = 'ui',
+
+    /**
+     * No remote environment
+     */
+    local = 'local'
+}
+
+export enum RemoteKind {
+    ssh = 'ssh',
+    wsl = 'wsl',
+    devContainer = 'devContainer',
+    unknown = 'unknown'
+}
+
+export interface IVSCodeRemoteInfo {
+    extensionKind: DockerExtensionKind;
+    remoteKind: RemoteKind | undefined;
+}
+
+export function getVSCodeRemoteInfo(context: IActionContext): IVSCodeRemoteInfo {
+    let extensionKind: DockerExtensionKind;
+    let remoteKind: RemoteKind | undefined;
+
+    const remoteName: string | undefined = env.remoteName;
+    const extension = extensions.getExtension(extensionId);
+    if (remoteName && extension) {
+        switch (remoteName.toLowerCase()) {
+            case 'ssh-remote':
+                remoteKind = RemoteKind.ssh;
+                break;
+            case 'wsl':
+                remoteKind = RemoteKind.wsl;
+                break;
+            case 'attached-container':
+            case 'dev-container':
+                // We don't actually care about the difference between the above two types
+                remoteKind = RemoteKind.devContainer;
+                break;
+            default:
+                remoteKind = RemoteKind.unknown;
+        }
+
+        if (extension.extensionKind === ExtensionKind.UI) {
+            extensionKind = DockerExtensionKind.ui;
+        } else {
+            extensionKind = DockerExtensionKind.workspace;
+        }
+    } else {
+        extensionKind = DockerExtensionKind.local;
+    }
+
+    context.telemetry.properties.extensionKind = extensionKind;
+    context.telemetry.properties.remoteKind = remoteKind;
+    context.telemetry.properties.rawRemoteKind = remoteName;
+
+    return {
+        extensionKind,
+        remoteKind
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-docker/issues/954. See that issue for more info on _why_ we want to default to workspace extension instead of ui extension.

In addition to changing the default (which is the most important change), I added some helpful error messages to common scenarios.

## Scenario 1

User has Docker installed as "ui" extension. Currently they will see a bunch of random errors for unsupported actions like this:
![Screen Shot 2019-08-27 at 11 36 12 AM](https://user-images.githubusercontent.com/11282622/63814412-a43c6c00-c8e5-11e9-8283-125a5ddff318.png)
![Screen Shot 2019-08-27 at 11 36 39 AM](https://user-images.githubusercontent.com/11282622/63814417-a7375c80-c8e5-11e9-86a7-6f72a757b41e.png)

I added this error message instead:
![Screen Shot 2019-08-28 at 2 55 03 PM](https://user-images.githubusercontent.com/11282622/63895385-d9a78f00-c9a3-11e9-9125-cbbc25fac6b4.png)

## Scenario 2
User has Docker installed as "workspace" extension in dev container. "Add Docker Files to Workspace" should work, but any commands using the terminal won't work and the explorer won't show anything.

All I did was add a link in the explorer. The docs still need to be written, but we will likely direct them to one of these options:
1. Forward some ports so that the explorer works when running as a workspace extension
1. Just open a local VS Code instance if you want to see local containers in the explorer
1. Last resort docker in docker
![Screen Shot 2019-08-27 at 2 31 48 PM](https://user-images.githubusercontent.com/11282622/63814459-c930df00-c8e5-11e9-9fd3-6dd7e1ad1cd2.png)

In terms of commands that require a terminal - I still think the long term fix is to move those over to Dockerode anyways.