### PR TITLE
Make web hook message independent of wizard.

### DIFF
--- a/src/commands/registries/azure/DockerWebhookCreateStep.ts
+++ b/src/commands/registries/azure/DockerWebhookCreateStep.ts
@@ -44,12 +44,21 @@ export class DockerWebhookCreateStep extends AzureWizardExecuteStep<IAppServiceW
             // http://cloud.docker.com/repository/docker/<registryName>/<repoName>/webHooks
             const dockerhubPrompt: string = "Copy & Open";
             const dockerhubUri: string = `https://cloud.docker.com/repository/docker/${this._treeItem.parent.parent.parent.username}/${this._treeItem.parent.repoName}/webHooks`;
-            let response: string = await vscode.window.showInformationMessage(`To set up a CI/CD webhook, open the page "${dockerhubUri}" and enter the URI to the created web app in your dockerhub account`, dockerhubPrompt);
-            if (response) {
-                vscode.env.clipboard.writeText(appUri);
-                // tslint:disable-next-line: no-floating-promises
-                openExternal(dockerhubUri);
-            }
+
+            // NOTE: The response to the information message is not awaited but handled independently of the wizard steps.
+            //       VS Code will hide such messages in the notifications pane after a period of time; awaiting them risks
+            //       the user never noticing them in the first place, which means the wizard would never complete, and the
+            //       user left with the impression that the action is hung.
+
+            vscode.window
+                .showInformationMessage(`To set up a CI/CD webhook, open the page "${dockerhubUri}" and enter the URI to the created web app in your dockerhub account`, dockerhubPrompt)
+                .then(response => {
+                    if (response) {
+                        vscode.env.clipboard.writeText(appUri);
+                        // tslint:disable-next-line: no-floating-promises
+                        openExternal(dockerhubUri);
+                    }
+                });
         }
     }
 


### PR DESCRIPTION
Resolves issue uncovered while investigating #1243, where users missing (i.e. not actively dismissing) the prompt to create a web hook during deployment of a Docker Hub image to Azure App Service can inadvertently lead to deployment appearing to take forever.

Deployment will not complete until the notification has been dismissed, but VS Code will automatically shift such notifications to the (hidden by default) notifications pane, effectively hiding them from the user and leaving only the initial "deploying..." notification shown.

This change makes handling responses to the web hook notification independent of the deployment process, so it will complete whether the users notices (and responds to) it or not.