### PR TITLE
Ensure webhookName meets requirements

### DIFF
--- a/src/commands/registries/azure/DockerWebhookCreateStep.ts
+++ b/src/commands/registries/azure/DockerWebhookCreateStep.ts
@@ -17,6 +17,7 @@ import { DockerHubRepositoryTreeItem } from '../../../tree/registries/dockerHub/
 import { RemoteTagTreeItem } from '../../../tree/registries/RemoteTagTreeItem';
 import { nonNullProp } from "../../../utils/nonNull";
 import { openExternal } from '../../../utils/openExternal';
+import { randomUtils } from '../../../utils/randomUtils';
 
 export class DockerWebhookCreateStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
     public priority: number = 141; // execute after DockerSiteCreate
@@ -67,19 +68,17 @@ export class DockerWebhookCreateStep extends AzureWizardExecuteStep<IAppServiceW
     }
 
     private async createWebhookForApp(node: RemoteTagTreeItem, site: Site, appUri: string): Promise<Webhook | undefined> {
-        // fields derived from the app service wizard
-        let siteName: string = site.name;
-        let baseName = `webapp${siteName}`;
-        let webhookName: string = baseName;
+        let webhookName: string = site.name;
+        // remove disallowed characters
+        webhookName = webhookName.replace(/[^a-zA-Z0-9]/g, '');
+        // add random chars for uniqueness and to ensure min length is met
+        webhookName += randomUtils.getRandomHexString(6);
+        // trim to max length
+        webhookName = webhookName.substr(0, 50);
+
         // variables derived from the container registry
         const registryTreeItem: AzureRegistryTreeItem = (<AzureRepositoryTreeItem>node.parent).parent;
         const crmClient = createAzureClient(registryTreeItem.parent.root, ContainerRegistryManagementClient);
-        const existingWebhooks = await crmClient.webhooks.list(registryTreeItem.resourceGroup, registryTreeItem.registryName);
-        let dedupeCount: number = 0;
-        while (existingWebhooks.find((hook) => hook.name === webhookName)) {
-            webhookName = `${baseName}_${dedupeCount}`;
-            dedupeCount++;
-        }
         let webhookCreateParameters: WebhookCreateParameters = {
             location: registryTreeItem.registryLocation,
             serviceUri: appUri,

--- a/src/commands/registries/azure/DockerWebhookCreateStep.ts
+++ b/src/commands/registries/azure/DockerWebhookCreateStep.ts
@@ -68,13 +68,16 @@ export class DockerWebhookCreateStep extends AzureWizardExecuteStep<IAppServiceW
     }
 
     private async createWebhookForApp(node: RemoteTagTreeItem, site: Site, appUri: string): Promise<Webhook | undefined> {
+        const maxLength: number = 50;
+        const numRandomChars: number = 6;
+
         let webhookName: string = site.name;
         // remove disallowed characters
         webhookName = webhookName.replace(/[^a-zA-Z0-9]/g, '');
-        // add random chars for uniqueness and to ensure min length is met
-        webhookName += randomUtils.getRandomHexString(6);
         // trim to max length
-        webhookName = webhookName.substr(0, 50);
+        webhookName = webhookName.substr(0, maxLength - numRandomChars);
+        // add random chars for uniqueness and to ensure min length is met
+        webhookName += randomUtils.getRandomHexString(numRandomChars);
 
         // variables derived from the container registry
         const registryTreeItem: AzureRegistryTreeItem = (<AzureRepositoryTreeItem>node.parent).parent;

--- a/src/utils/randomUtils.ts
+++ b/src/utils/randomUtils.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as crypto from "crypto";
+
+export namespace randomUtils {
+    export function getRandomHexString(length: number = 10): string {
+        const buffer: Buffer = crypto.randomBytes(Math.ceil(length / 2));
+        return buffer.toString('hex').slice(0, length);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-docker/issues/1270

Per the portal, a webhook name has these requirements
![Screen Shot 2019-09-13 at 10 22 14 AM](https://user-images.githubusercontent.com/11282622/64882778-abb48280-d612-11e9-9384-e4873ae74d73.png)

But a site name has looser requirements (allows hyphens and 3-64 characters I think). I scrapped the existing logic to generate a name and based it more closely off what the portal does:
![Screen Shot 2019-09-13 at 10 15 57 AM](https://user-images.githubusercontent.com/11282622/64882872-dbfc2100-d612-11e9-843e-5f8713b5faa0.png)