### PR TITLE
Resolve Docker build issue when using Git bash on Windows

### DIFF
--- a/src/commands/images/buildImage.ts
+++ b/src/commands/images/buildImage.ts
@@ -45,16 +45,8 @@ export async function buildImage(context: IActionContext, dockerFileUri: vscode.
 
         await ext.context.globalState.update(dockerFileKey, imageName);
 
-        let relativeFilePath: string = dockerFileItem.relativeFilePath;
-
-        // NOTE: Prefer forward-slashes even on Windows, as they work both in CMD as well as bash-based shells.
-        if (process.platform === 'win32') {
-            contextPath = contextPath.replace(/\\/g, '/');
-            relativeFilePath = relativeFilePath.replace(/\\/g, '/');
-        }
-
         const terminal: vscode.Terminal = ext.terminalProvider.createTerminal('Docker');
-        terminal.sendText(`docker build --rm -f "${relativeFilePath}" -t ${imageName} "${contextPath}"`);
+        terminal.sendText(`docker build --rm -f "${dockerFileItem.relativeFilePath}" -t ${imageName} "${contextPath}"`);
         terminal.show();
     }
 }

--- a/src/commands/images/buildImage.ts
+++ b/src/commands/images/buildImage.ts
@@ -45,8 +45,16 @@ export async function buildImage(context: IActionContext, dockerFileUri: vscode.
 
         await ext.context.globalState.update(dockerFileKey, imageName);
 
+        let relativeFilePath: string = dockerFileItem.relativeFilePath;
+
+        // NOTE: Prefer forward-slashes even on Windows, as they work both in CMD as well as bash-based shells.
+        if (process.platform === 'win32') {
+            contextPath = contextPath.replace(/\\/g, '/');
+            relativeFilePath = relativeFilePath.replace(/\\/g, '/');
+        }
+
         const terminal: vscode.Terminal = ext.terminalProvider.createTerminal('Docker');
-        terminal.sendText(`docker build --rm -f "${dockerFileItem.relativeFilePath}" -t ${imageName} ${contextPath}`);
+        terminal.sendText(`docker build --rm -f "${relativeFilePath}" -t ${imageName} "${contextPath}"`);
         terminal.show();
     }
 }


### PR DESCRIPTION
If Git bash is the default VS Code shell, building an image from the Dockerfile context menu could fail if the build context contains directory separators (as the Windows separator would be interpreted as an escape character by Git bash).  Enclosing with quotes prevents the confusion.

Resolves #902