### PR TITLE
Enable YAML suggestions by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1502,6 +1502,15 @@
                 }
             }
         },
+        "configurationDefaults": {
+            "[yaml]": {
+                "editor.quickSuggestions": {
+                    "other": true,
+                    "comments": false,
+                    "strings": true
+                }
+            }
+        },
         "commands": [
             {
                 "command": "vscode-docker.api.configure",


### PR DESCRIPTION
Enable YAML suggestions by default so that Docker Compose IntelliSense provided by this extension is displayed without requiring CTRL+SPACE.  This is also what the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) does.

Users can disable this by setting `[yaml].editorQuickSuggestions.strings` to `false` in their settings.

Resolves #243.