### PR TITLE
Enable edit-refresh in ASP.NET Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "onCommand:workbench.action.tasks.runTask",
         "onDebugInitialConfigurations",
         "onDebugResolve:docker-coreclr",
-        "onDebugResolve:docker-launch",
+        "onDebugResolve:docker",
         "onLanguage:dockerfile",
         "onLanguage:yaml",
         "onView:dockerContainers",

--- a/src/tasks/netcore/NetCoreTaskHelper.ts
+++ b/src/tasks/netcore/NetCoreTaskHelper.ts
@@ -128,8 +128,10 @@ export class NetCoreTaskHelper implements TaskHelper {
         const ssl = helperOptions.configureSsl !== undefined ? helperOptions.configureSsl : await NetCoreTaskHelper.inferSsl(context.folder, helperOptions);
         const userSecrets = ssl === true ? true : await this.inferUserSecrets(helperOptions);
 
+        runOptions.env = runOptions.env || {};
+        runOptions.env.DOTNET_USE_POLLING_FILE_WATCHER = runOptions.env.DOTNET_USE_POLLING_FILE_WATCHER || '1';
+
         if (userSecrets) {
-            runOptions.env = runOptions.env || {};
             runOptions.env.ASPNETCORE_ENVIRONMENT = runOptions.env.ASPNETCORE_ENVIRONMENT || 'Development';
 
             if (ssl) {


### PR DESCRIPTION
* Enable edit-refresh in ASP.NET Core with DOTNET_USE_POLLING_FILE_WATCHER environment variable, resolves #1302 
* Fix unrelated bug where debug resolve didn't activate the extension