### PR TITLE
Don't send PR emails to vscodeazuretools team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Microsoft/vscodeazuretools
+* @Microsoft/vscodedocker


### PR DESCRIPTION
I mentioned this offline in an email a while ago, but there are a lot of people on the `vscodeazuretools` team that don't want emails about every single PR. We already changed the CODEOWNERS in other repos to a smaller "dev" team subset (see [here](https://github.com/microsoft/vscode-azurefunctions/pull/1486) as an example), but that team didn't feel accurate for this repo. @philliphoff @bwateratmsft you can create a new team here if you want: https://github.com/orgs/microsoft/teams/vscodeazuretools/teams