### PR TITLE
Use ctx.subscriptions to manage disposables

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -9,8 +9,8 @@
  * everything else will be in private modules in extension.bundle.js.
  */
 
-// Export activate/deactivate for main.js
-export { activateInternal, deactivateInternal } from './src/extension';
+// Export activate for main.js
+export { activateInternal } from './src/extension';
 
 // Exports for tests
 // The tests are not packaged with the webpack bundle and therefore only have access to code exported from this file.

--- a/main.js
+++ b/main.js
@@ -25,7 +25,7 @@ async function activate(ctx) {
 }
 
 async function deactivate(ctx) {
-    return await extension.deactivateInternal();
+    // No-op
 }
 
 exports.activate = activate;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,11 +185,6 @@ async function setRequestDefaults(): Promise<void> {
     ext.request = requestWithDefaults;
 }
 
-export async function deactivateInternal(): Promise<void> {
-    // No-op
-    return;
-}
-
 namespace Configuration {
     export function computeConfiguration(params: ConfigurationParams): vscode.WorkspaceConfiguration[] {
         let result: vscode.WorkspaceConfiguration[] = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
         refreshDockerode();
 
         await consolidateDefaultRegistrySettings();
-        activateLanguageClient();
+        activateLanguageClient(ctx);
     });
 }
 
@@ -186,17 +186,11 @@ async function setRequestDefaults(): Promise<void> {
 }
 
 export async function deactivateInternal(): Promise<void> {
-    if (!client) {
-        return undefined;
-    }
-    // perform cleanup
-    Configuration.dispose();
-    return await client.stop();
+    // No-op
+    return;
 }
 
 namespace Configuration {
-    let configurationListener: vscode.Disposable;
-
     export function computeConfiguration(params: ConfigurationParams): vscode.WorkspaceConfiguration[] {
         let result: vscode.WorkspaceConfiguration[] = [];
         for (let item of params.items) {
@@ -215,8 +209,8 @@ namespace Configuration {
         return result;
     }
 
-    export function initialize(): void {
-        configurationListener = vscode.workspace.onDidChangeConfiguration(
+    export function initialize(ctx: vscode.ExtensionContext): void {
+        ctx.subscriptions.push(vscode.workspace.onDidChangeConfiguration(
             async (e: vscode.ConfigurationChangeEvent) => {
                 // notify the language server that settings have change
                 client.sendNotification(DidChangeConfigurationNotification.type, {
@@ -237,18 +231,11 @@ namespace Configuration {
                     setRequestDefaults();
                 }
             }
-        );
-    }
-
-    export function dispose(): void {
-        if (configurationListener) {
-            // remove this listener when disposed
-            configurationListener.dispose();
-        }
+        ));
     }
 }
 
-function activateLanguageClient(): void {
+function activateLanguageClient(ctx: vscode.ExtensionContext): void {
     // Don't wait
     callWithTelemetryAndErrorHandling('docker.languageclient.activate', async (context: IActionContext) => {
         context.telemetry.properties.isActivationEvent = 'true';
@@ -300,9 +287,10 @@ function activateLanguageClient(): void {
         // tslint:disable-next-line:no-floating-promises
         client.onReady().then(() => {
             // attach the VS Code settings listener
-            Configuration.initialize();
+            Configuration.initialize(ctx);
         });
-        client.start();
+
+        ctx.subscriptions.push(client.start());
     });
 }
 


### PR DESCRIPTION
The whole of `deactivateInternal` can be refactored to be disposables pushed onto `ctx.subscriptions`. This is assuming that calling `dispose()` on the Disposable from `start()` is equivalent to, or at least also calls, `stop()`.