### PR TITLE
Clearer error message for duplicate registry

### DIFF
--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -98,8 +98,8 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
             context.telemetry.properties.cancelStep = 'learnHowToContribute';
             throw new UserCancelledError();
         } else if (provider.onlyOneAllowed && this._cachedProviders.find(c => c.id === provider.id)) {
-            await ext.ui.showWarningMessage(`The "${provider.id}" registry is already connected.`);
-            context.telemetry.properties.cancelStep = 'registryAlreadyAdded';
+            await ext.ui.showWarningMessage(`The "${provider.id}" registry provider is already connected.`);
+            context.telemetry.properties.cancelStep = 'registryProviderAlreadyAdded';
             throw new UserCancelledError();
         }
 

--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -98,7 +98,7 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
             context.telemetry.properties.cancelStep = 'learnHowToContribute';
             throw new UserCancelledError();
         } else if (provider.onlyOneAllowed && this._cachedProviders.find(c => c.id === provider.id)) {
-            throw new Error(`Only one provider with id "${provider.id}" is allowed at a time.`);
+            throw new Error(`The "${provider.id}" registry is already connected.`);
         }
 
         context.telemetry.properties.providerId = provider.id;

--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -98,7 +98,9 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
             context.telemetry.properties.cancelStep = 'learnHowToContribute';
             throw new UserCancelledError();
         } else if (provider.onlyOneAllowed && this._cachedProviders.find(c => c.id === provider.id)) {
-            await ext.ui.showWarningMessage(`The "${provider.label}" registry provider is already connected.`);
+            // Don't wait, no input to wait for anyway
+            // tslint:disable-next-line: no-floating-promises
+            ext.ui.showWarningMessage(`The "${provider.label}" registry provider is already connected.`);
             context.telemetry.properties.cancelStep = 'registryProviderAlreadyAdded';
             throw new UserCancelledError();
         }

--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -98,7 +98,9 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
             context.telemetry.properties.cancelStep = 'learnHowToContribute';
             throw new UserCancelledError();
         } else if (provider.onlyOneAllowed && this._cachedProviders.find(c => c.id === provider.id)) {
-            throw new Error(`The "${provider.id}" registry is already connected.`);
+            await ext.ui.showWarningMessage(`The "${provider.id}" registry is already connected.`);
+            context.telemetry.properties.cancelStep = 'registryAlreadyAdded';
+            throw new UserCancelledError();
         }
 
         context.telemetry.properties.providerId = provider.id;

--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -98,7 +98,7 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
             context.telemetry.properties.cancelStep = 'learnHowToContribute';
             throw new UserCancelledError();
         } else if (provider.onlyOneAllowed && this._cachedProviders.find(c => c.id === provider.id)) {
-            await ext.ui.showWarningMessage(`The "${provider.id}" registry provider is already connected.`);
+            await ext.ui.showWarningMessage(`The "${provider.label}" registry provider is already connected.`);
             context.telemetry.properties.cancelStep = 'registryProviderAlreadyAdded';
             throw new UserCancelledError();
         }


### PR DESCRIPTION
Resolves #1310

The user will see a clear warning message instead:
![image](https://user-images.githubusercontent.com/36966225/66772432-bb7deb80-ee8a-11e9-9540-8672073ea812.png)

