### PR TITLE
Ask some active users to take NPS survey

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import { addDockerSettingsToEnv } from './utils/addDockerSettingsToEnv';
 import { addUserAgent } from './utils/addUserAgent';
 import { getTrustedCertificates } from './utils/getTrustedCertificates';
 import { Keytar } from './utils/keytar';
+import { nps } from './utils/nps';
 import { DefaultTerminalProvider } from './utils/TerminalProvider';
 import { tryGetDefaultDockerContext } from './utils/tryGetDefaultDockerContext';
 import { wrapError } from './utils/wrapError';
@@ -131,6 +132,10 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
         activateLanguageClient(ctx);
 
         registerListeners(ctx);
+
+        // Don't wait
+        // tslint:disable-next-line: no-floating-promises
+        nps(ctx.globalState);
     });
 }
 

--- a/src/utils/nps.ts
+++ b/src/utils/nps.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// Loosely adapted from https://github.com/microsoft/vscode-azure-account/blob/2f497562cab5f3db09f983ab5101040f27dceb70/src/nps.ts
+
 import { env, Memento, MessageItem, Uri, window } from "vscode";
 import { ext } from "vscode-azureappservice/out/src/extensionVariables";
 

--- a/src/utils/nps.ts
+++ b/src/utils/nps.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { env, Memento, MessageItem, Uri, window } from "vscode";
+import { ext } from "vscode-azureappservice/out/src/extensionVariables";
+
+const PROBABILITY = 0.15;
+const MIN_SESSION_COUNT = 10;
+
+const SURVEY_NAME = 'nps1';
+const SURVEY_URL = 'https://www.surveymonkey.com/r/vscodedockernpsinproduct';
+
+const SESSION_COUNT_KEY = `${SURVEY_NAME}/sessioncount`;
+const LAST_SESSION_DATE_KEY = `${SURVEY_NAME}/lastsessiondate`;
+const IS_CANDIDATE_KEY = `${SURVEY_NAME}/iscandidate`;
+
+export async function nps(globalState: Memento): Promise<void> {
+    try {
+        // If not English-language, don't ask
+        if (env.language !== 'en' && !env.language.startsWith('en-')) {
+            return;
+        }
+
+        let isCandidate: boolean | undefined = globalState.get(IS_CANDIDATE_KEY);
+
+        // If not a candidate, don't ask
+        if (isCandidate === false) {
+            return;
+        }
+
+        const sessionCount = globalState.get(SESSION_COUNT_KEY, 0) + 1;
+        const sessionDate = new Date().toDateString();
+
+        // If this session is on same date as last session, don't count it
+        if (sessionDate === globalState.get(LAST_SESSION_DATE_KEY, new Date(0).toDateString())) {
+            return;
+        }
+
+        // Count this session
+        await globalState.update(SESSION_COUNT_KEY, sessionCount);
+        await globalState.update(LAST_SESSION_DATE_KEY, sessionDate);
+
+        // If under the MIN_SESSION_COUNT, don't ask
+        if (sessionCount < MIN_SESSION_COUNT) {
+            return;
+        }
+
+        // Decide if they are a candidate (if we previously decided they are and they did Remind Me Later, we will not do probability again)
+        // tslint:disable-next-line: insecure-random
+        isCandidate = isCandidate || Math.random() < PROBABILITY;
+        await globalState.update(IS_CANDIDATE_KEY, isCandidate);
+
+        // If not a candidate, don't ask
+        if (!isCandidate) {
+            return;
+        }
+
+        const take: MessageItem = { title: 'Take Survey' };
+        const remind: MessageItem = { title: 'Remind Me Later' };
+        const never: MessageItem = { title: 'Don\'t Show Again' };
+
+        const result = await window.showInformationMessage('Do you mind taking a quick feedback survey about the Docker Extension for VS Code?', take, remind, never);
+
+        if (!result || result === remind) {
+            // If they hit the X or Remind Me Later, ask again in 3 sessions
+            ext.reporter.sendTelemetryEvent('nps', { survey: SURVEY_NAME, response: 'remind' });
+            await globalState.update(SESSION_COUNT_KEY, sessionCount - 3);
+        } else if (result === never) {
+            // If they hit Never, don't ask again (for this survey name)
+            ext.reporter.sendTelemetryEvent('nps', { survey: SURVEY_NAME, response: 'never' });
+            await globalState.update(IS_CANDIDATE_KEY, false);
+        } else if (result === take) {
+            // If they hit Take, don't ask again (for this survey name), and open the survey
+            ext.reporter.sendTelemetryEvent('nps', { survey: SURVEY_NAME, response: 'take' });
+            await globalState.update(IS_CANDIDATE_KEY, false);
+            await env.openExternal(Uri.parse(`${SURVEY_URL}?o=${encodeURIComponent(process.platform)}&m=${encodeURIComponent(env.machineId)}`));
+        }
+    } catch { } // Best effort
+}


### PR DESCRIPTION
After ten sessions on different days (i.e. multiple sessions in one day count as just one), choose 15% of users to prompt to take the NPS survey for the Docker extension. Prompt has Take Survey, Remind Me Later (will remind after 3 more sessions), and Don't Show Again.

![image](https://user-images.githubusercontent.com/36966225/67425172-86b61680-f5a5-11e9-87d0-1719481f2eed.png)