### PR TITLE
Remove LICENSE from .dockerignore file.

### DIFF
--- a/src/configureWorkspace/configure.ts
+++ b/src/configureWorkspace/configure.ts
@@ -138,7 +138,6 @@ function genDockerIgnoreFile(service: string, platformType: Platform, os: string
         '**/obj',
         '**/secrets.dev.yaml',
         '**/values.dev.yaml',
-        'LICENSE',
         'README.md'
     ];
 


### PR DESCRIPTION
Removes the `LICENSE` file from the `.dockerignore` file, allowing it to be part of the Docker build context.  It was found to have been required in some `Dockerfile`s and there should be little impact, optimization-wise, in allowing it.

Resolves #1331.