### PR TITLE
Aggregate Docker build/run task labels with VS Code defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -833,6 +833,13 @@
                             "labels": {
                                 "type": "object",
                                 "description": "Labels applied to the Docker image used for debugging.",
+                                "properties": {
+                                    "includeDefaults": {
+                                        "type": "boolean",
+                                        "description": "Whether to include the default set of labels defined by the Docker extension",
+                                        "default": true
+                                    }
+                                },
                                 "additionalProperties": {
                                     "type": "string"
                                 }
@@ -917,6 +924,13 @@
                             "labels": {
                                 "type": "object",
                                 "description": "Labels applied to the Docker container used for debugging.",
+                                "properties": {
+                                    "includeDefaults": {
+                                        "type": "boolean",
+                                        "description": "Whether to include the default set of labels defined by the Docker extension",
+                                        "default": true
+                                    }
+                                },
                                 "additionalProperties": {
                                     "type": "string"
                                 }

--- a/src/tasks/DockerBuildTaskDefinitionBase.ts
+++ b/src/tasks/DockerBuildTaskDefinitionBase.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TaskDefinitionBase } from './TaskDefinitionBase';
+import { DockerLabels, TaskDefinitionBase } from './TaskDefinitionBase';
 
 export interface DockerBuildOptions {
     buildArgs?: { [key: string]: string };
     context?: string;
     dockerfile?: string;
-    labels?: { [key: string]: string };
+    labels?: DockerLabels;
     tag?: string;
     target?: string;
     pull?: boolean;

--- a/src/tasks/DockerBuildTaskProvider.ts
+++ b/src/tasks/DockerBuildTaskProvider.ts
@@ -13,7 +13,7 @@ import { DockerBuildOptions } from './DockerBuildTaskDefinitionBase';
 import { DockerTaskProvider } from './DockerTaskProvider';
 import { NetCoreBuildTaskDefinition } from './netcore/NetCoreTaskHelper';
 import { NodeBuildTaskDefinition } from './node/NodeTaskHelper';
-import { DockerLabels } from './TaskDefinitionBase';
+import { defaultVsCodeLabels, getAggregateLabels } from './TaskDefinitionBase';
 import { DockerBuildTaskContext, TaskHelper, throwIfCancellationRequested } from './TaskHelper';
 
 export interface DockerBuildTaskDefinition extends NetCoreBuildTaskDefinition, NodeBuildTaskDefinition {
@@ -24,18 +24,6 @@ export interface DockerBuildTaskDefinition extends NetCoreBuildTaskDefinition, N
 
 export interface DockerBuildTask extends Task {
     definition: DockerBuildTaskDefinition;
-}
-
-const defaultBuildLabels: { [key: string]: string } = {
-    'com.microsoft.created-by': 'visual-studio-code'
-};
-
-function getAggregateLabels(labels: DockerLabels | undefined, defaultLabels: { [key: string]: string }): { [key: string]: string } {
-    const { includeDefaults, ...explicitLabels } = labels || {};
-
-    return (includeDefaults !== false)
-        ? { ...defaultLabels, ...explicitLabels }
-        : explicitLabels;
 }
 
 export class DockerBuildTaskProvider extends DockerTaskProvider {
@@ -97,7 +85,7 @@ export class DockerBuildTaskProvider extends DockerTaskProvider {
             .withFlagArg('--pull', options.pull)
             .withNamedArg('-f', options.dockerfile)
             .withKeyValueArgs('--build-arg', options.buildArgs)
-            .withKeyValueArgs('--label', getAggregateLabels(options.labels, defaultBuildLabels))
+            .withKeyValueArgs('--label', getAggregateLabels(options.labels, defaultVsCodeLabels))
             .withNamedArg('-t', options.tag)
             .withNamedArg('--target', options.target)
             .withQuotedArg(options.context);

--- a/src/tasks/DockerRunTaskDefinitionBase.ts
+++ b/src/tasks/DockerRunTaskDefinitionBase.ts
@@ -5,7 +5,7 @@
 
 import { ShellQuotedString } from 'vscode';
 import { PlatformOS } from '../utils/platform';
-import { TaskDefinitionBase } from './TaskDefinitionBase';
+import { DockerLabels, TaskDefinitionBase } from './TaskDefinitionBase';
 
 export interface DockerContainerExtraHost {
     hostname: string;
@@ -32,7 +32,7 @@ export interface DockerRunOptions {
     envFiles?: string[];
     extraHosts?: DockerContainerExtraHost[];
     image?: string;
-    labels?: { [key: string]: string };
+    labels?: DockerLabels;
     network?: string;
     networkAlias?: string;
     os?: PlatformOS;

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -11,6 +11,7 @@ import { DockerRunOptions } from './DockerRunTaskDefinitionBase';
 import { DockerTaskProvider } from './DockerTaskProvider';
 import { NetCoreRunTaskDefinition } from './netcore/NetCoreTaskHelper';
 import { NodeRunTaskDefinition } from './node/NodeTaskHelper';
+import { defaultVsCodeLabels, getAggregateLabels } from './TaskDefinitionBase';
 import { DockerRunTaskContext, getAssociatedDockerBuildTask, TaskHelper, throwIfCancellationRequested } from './TaskHelper';
 
 export interface DockerRunTaskDefinition extends NetCoreRunTaskDefinition, NodeRunTaskDefinition {
@@ -76,7 +77,7 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
             .withNamedArg('--network-alias', runOptions.networkAlias)
             .withKeyValueArgs('-e', runOptions.env)
             .withArrayArgs('--env-file', runOptions.envFiles)
-            .withKeyValueArgs('--label', runOptions.labels)
+            .withKeyValueArgs('--label', getAggregateLabels(runOptions.labels, defaultVsCodeLabels))
             .withArrayArgs('-v', runOptions.volumes, volume => `${volume.localPath}:${volume.containerPath}${volume.permissions ? ':' + volume.permissions : ''}`)
             .withArrayArgs('-p', runOptions.ports, port => `${port.hostPort ? port.hostPort + ':' : ''}${port.containerPort}${port.protocol ? '/' + port.protocol : ''}`)
             .withArrayArgs('--add-host', runOptions.extraHosts, extraHost => `${extraHost.hostname}:${extraHost.ip}`)

--- a/src/tasks/TaskDefinitionBase.ts
+++ b/src/tasks/TaskDefinitionBase.ts
@@ -13,3 +13,5 @@ export interface TaskDefinitionBase extends TaskDefinition {
     label?: string;
     dependsOn?: string[] | DependsOn;
 }
+
+export type DockerLabels = { includeDefaults?: boolean; } & { [key: string]: string; };

--- a/src/tasks/TaskDefinitionBase.ts
+++ b/src/tasks/TaskDefinitionBase.ts
@@ -15,3 +15,15 @@ export interface TaskDefinitionBase extends TaskDefinition {
 }
 
 export type DockerLabels = { includeDefaults?: boolean; } & { [key: string]: string; };
+
+export const defaultVsCodeLabels: { [key: string]: string } = {
+    'com.microsoft.created-by': 'visual-studio-code'
+};
+
+export function getAggregateLabels(labels: DockerLabels | undefined, defaultLabels: { [key: string]: string }): { [key: string]: string } {
+    const { includeDefaults, ...explicitLabels } = labels || {};
+
+    return (includeDefaults !== false)
+        ? { ...defaultLabels, ...explicitLabels }
+        : explicitLabels;
+}

--- a/src/tasks/netcore/NetCoreTaskHelper.ts
+++ b/src/tasks/netcore/NetCoreTaskHelper.ts
@@ -42,8 +42,6 @@ const MacNuGetPackageFallbackFolderPath = '/usr/local/share/dotnet/sdk/NuGetFall
 const LinuxNuGetPackageFallbackFolderPath = '/usr/share/dotnet/sdk/NuGetFallbackFolder';
 
 export class NetCoreTaskHelper implements TaskHelper {
-    private static readonly defaultLabels: { [key: string]: string } = { 'com.microsoft.created-by': 'visual-studio-code' };
-
     public async provideDockerBuildTasks(context: DockerTaskScaffoldContext, options?: NetCoreTaskScaffoldingOptions): Promise<DockerBuildTaskDefinition[]> {
         options = options || {};
         options.appProject = options.appProject || await NetCoreTaskHelper.inferAppProject(context.folder); // This method internally checks the user-defined input first
@@ -109,7 +107,6 @@ export class NetCoreTaskHelper implements TaskHelper {
         buildOptions.dockerfile = buildOptions.dockerfile || path.join('${workspaceFolder}', 'Dockerfile');
         // tslint:enable: no-invalid-template-strings
         buildOptions.tag = buildOptions.tag || getDefaultImageName(context.folder.name);
-        buildOptions.labels = buildOptions.labels || NetCoreTaskHelper.defaultLabels;
 
         return buildOptions;
     }
@@ -121,7 +118,6 @@ export class NetCoreTaskHelper implements TaskHelper {
         helperOptions.appProject = await NetCoreTaskHelper.inferAppProject(context.folder, helperOptions); // This method internally checks the user-defined input first
 
         runOptions.containerName = runOptions.containerName || getDefaultContainerName(context.folder.name);
-        runOptions.labels = runOptions.labels || NetCoreTaskHelper.defaultLabels;
         runOptions.os = runOptions.os || 'Linux';
         runOptions.image = inferImageName(runDefinition as DockerRunTaskDefinition, context, context.folder.name, 'dev');
 


### PR DESCRIPTION
Moves the addition of the default VS Code labels to Docker images/containers to the base task providers in order to apply to all platforms (instead of just .NET Core).  Also updates the logic so that default labels are included (by default) even if the user explicitly adds their own labels, with an option (by setting `docker[Build|Run].labels.includeDefaults = false`) to *not* include the default labels.

Resolves #1392 (except for discussion related to ports, which should be a separate PR).