### PR TITLE
Create a release-ish task in .NET Core apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1052,6 +1052,10 @@
                                 "type": "string",
                                 "description": "The .NET Core project (.csproj, .fsproj, etc.) to build."
                             },
+                            "enableDebugging": {
+                                "type": "boolean",
+                                "description": "Whether to enable debugging within the container."
+                            },
                             "configureSsl": {
                                 "type": "boolean",
                                 "description": "Whether to configure certificate and other settings to enable SSL on ASP.NET Core web services."


### PR DESCRIPTION
It became necessary to add an `enableDebugging` flag like Node had. Otherwise, we map `/src`, `/app`, and others. `/app` in particular prevents the release mode from working because we overwrite the `/app` folder, containing the relevant binary directly, with the project folder on the host machine, which contains the (debug, aka wrong) binary a few folders down (`bin/Debug/netcoreapp3.0` or similar).

The SSL-related folders still need to be mapped, along with `ASPNETCORE_ENVIRONMENT=Development` in order to make SSL work. In a real production build, they would need to map in user secrets differently.

The diff is super weird; we're just guarding several volumes inside `if (helperOptions.enableDebugging)`.