### PR TITLE
Add exit code to Error generated by spawnAsync()

### DIFF
--- a/src/utils/spawnAsync.ts
+++ b/src/utils/spawnAsync.ts
@@ -11,7 +11,8 @@ const DEFAULT_BUFFER_SIZE = 10 * 1024; // The default Node.js `exec` buffer size
 
 export type Progress = (content: string, process: cp.ChildProcess) => void;
 
-type ExecError = Error & { code, signal };
+// tslint:disable-next-line: no-any
+type ExecError = Error & { code: any, signal: any };
 
 export async function spawnAsync(
     command: string,


### PR DESCRIPTION
Adds `code` and `signal` properties to errors thrown by `spawnAsync()` to better replicate what callers expect (if `exec()`) had been called.

Resolves #1424.