### PR TITLE
Adds telemetry property for "Add Docker files" command

### DIFF
--- a/src/configureWorkspace/configUtils.ts
+++ b/src/configureWorkspace/configUtils.ts
@@ -98,7 +98,7 @@ export async function quickPickOS(): Promise<PlatformOS> {
 
 export async function quickPickGenerateComposeFiles(): Promise<boolean> {
     let opt: vscode.QuickPickOptions = {
-        placeHolder: 'Include Docker Compose files'
+        placeHolder: 'Include optional Docker Compose files?'
     }
 
     let response = await ext.ui.showQuickPick(


### PR DESCRIPTION
Captures telemetry data for the "step" (i.e. prompt) at which the user cancels adding Docker files to the workspace, in order to measure if and, at what point, users change their minds about taking the action.

Also updates the wording of the Docker Compose files prompt for Node.js, to emphasize that either option is ok.