### PR TITLE
Use container name instead of image name for shell label.

### DIFF
--- a/src/commands/containers/attachShellContainer.ts
+++ b/src/commands/containers/attachShellContainer.ts
@@ -26,7 +26,7 @@ export async function attachShellContainer(context: IActionContext, node?: Conta
     }
     context.telemetry.properties.shellCommand = shellCommand;
 
-    const terminal = ext.terminalProvider.createTerminal(`Shell: ${node.fullTag}`);
+    const terminal = ext.terminalProvider.createTerminal(`Shell: ${node.containerName}`);
     terminal.sendText(`docker exec -it ${node.containerId} ${shellCommand}`);
     terminal.show();
 }

--- a/src/tree/containers/ContainerTreeItem.ts
+++ b/src/tree/containers/ContainerTreeItem.ts
@@ -32,6 +32,10 @@ export class ContainerTreeItem extends AzExtTreeItem {
         return this._item.containerId;
     }
 
+    public get containerName(): string {
+        return this._item.containerName;
+    }
+
     public get fullTag(): string {
         return this._item.fullTag;
     }


### PR DESCRIPTION
Uses the container name instead of the image name for the VS Code shell/terminal label, which helps disambiguate multiple terminal windows for containers which share a common base image.

Resolves #1463.