### PR TITLE
Conform to new extensionKind property schema.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "license": "SEE LICENSE IN LICENSE.md",
     "icon": "resources/docker.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
-    "extensionKind": "workspace",
+    "extensionKind": [
+        "workspace",
+        "ui"
+    ],
     "galleryBanner": {
         "color": "#1289B9",
         "theme": "dark"


### PR DESCRIPTION
With `1.40.x` of VS Code, the `extensionKind` property of `package.json` can be an array which indicates the "preference" of the extension with respect to which "side" of the editor on which it should run. With this change, it indicates that the Docker extension should prefer the side on which the workspace is opened (e.g. the remote development side, if the extension is installed on that side), otherwise it runs on the UI side.

Resolves #1440
