### PR TITLE
Catch errors removing passwords from cache.

### DIFF
--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -166,7 +166,15 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
         context.telemetry.properties.providerId = cachedProvider.id;
         context.telemetry.properties.providerApi = cachedProvider.api;
 
-        await deleteRegistryPassword(cachedProvider);
+        // NOTE: Do not let failure prevent removal of the tree item.
+
+        try {
+            await deleteRegistryPassword(cachedProvider);
+        } catch (err) {
+            // Don't wait, no input to wait for anyway
+            // tslint:disable-next-line: no-floating-promises
+            ext.ui.showWarningMessage(`The registry password could not be removed from the cache: ${err}`);
+        }
 
         const index = this._cachedProviders.findIndex(n => n === cachedProvider);
         if (index !== -1) {


### PR DESCRIPTION
Ancillary errors thrown while removing a registry node shouldn't prevent the tree item from being removed, so we catch (and report) exceptions when those occur.

Resolves #1480.