### PR TITLE
Use appropriate drives based on docker engine os

### DIFF
--- a/src/commands/networks/createNetwork.ts
+++ b/src/commands/networks/createNetwork.ts
@@ -16,7 +16,7 @@ export async function createNetwork(_context: IActionContext): Promise<void> {
     });
 
     const engineVersion = await ext.dockerode.version();
-    const drivers = engineVersion.Os === "windows"
+    const drivers = engineVersion.Os === 'windows'
         ? [
             { label: 'nat' },
             { label: 'transparent' }

--- a/src/commands/networks/createNetwork.ts
+++ b/src/commands/networks/createNetwork.ts
@@ -15,13 +15,22 @@ export async function createNetwork(_context: IActionContext): Promise<void> {
         prompt: 'Name of the network'
     });
 
-    const driverSelection = await ext.ui.showQuickPick(
-        [
+    const engineVersion = await ext.dockerode.version();
+    const drivers = engineVersion.Os === "windows"
+        ? [
+            { label: 'nat' },
+            { label: 'transparent' },
+            { label: 'overlay' }
+        ]
+        : [
             { label: 'bridge' },
             { label: 'host' },
             { label: 'overlay' },
             { label: 'macvlan' }
-        ],
+        ];
+
+    const driverSelection = await ext.ui.showQuickPick(
+        drivers,
         {
             canPickMany: false,
             placeHolder: 'Select the network driver to use (default is "bridge").'

--- a/src/commands/networks/createNetwork.ts
+++ b/src/commands/networks/createNetwork.ts
@@ -19,13 +19,11 @@ export async function createNetwork(_context: IActionContext): Promise<void> {
     const drivers = engineVersion.Os === "windows"
         ? [
             { label: 'nat' },
-            { label: 'transparent' },
-            { label: 'overlay' }
+            { label: 'transparent' }
         ]
         : [
             { label: 'bridge' },
             { label: 'host' },
-            { label: 'overlay' },
             { label: 'macvlan' }
         ];
 


### PR DESCRIPTION
Earlier static set of drivers were used during create network. Some of these drivers are not applicable for windows os. Now based on engine os version, right set of drivers are provided to user.
This fixex #1444 