### PR TITLE
Add `pull` property to Docker built task scaffolding.

### DIFF
--- a/src/tasks/netcore/NetCoreTaskHelper.ts
+++ b/src/tasks/netcore/NetCoreTaskHelper.ts
@@ -59,6 +59,7 @@ export class NetCoreTaskHelper implements TaskHelper {
                     dockerfile: unresolveWorkspaceFolder(context.dockerfile, context.folder),
                     // tslint:disable-next-line: no-invalid-template-strings
                     context: '${workspaceFolder}',
+                    pull: true
                 },
                 netCore: {
                     appProject: unresolveWorkspaceFolder(options.appProject, context.folder)
@@ -73,6 +74,7 @@ export class NetCoreTaskHelper implements TaskHelper {
                     dockerfile: unresolveWorkspaceFolder(context.dockerfile, context.folder),
                     // tslint:disable-next-line: no-invalid-template-strings
                     context: '${workspaceFolder}',
+                    pull: true
                 },
                 netCore: {
                     appProject: unresolveWorkspaceFolder(options.appProject, context.folder)

--- a/src/tasks/node/NodeTaskHelper.ts
+++ b/src/tasks/node/NodeTaskHelper.ts
@@ -44,6 +44,7 @@ export class NodeTaskHelper implements TaskHelper {
                     dockerfile: unresolveWorkspaceFolder(context.dockerfile, context.folder),
                     // tslint:disable-next-line: no-invalid-template-strings
                     context: '${workspaceFolder}',
+                    pull: true
                 }
             }
         ];


### PR DESCRIPTION
Sets the `pull` property to `true` when scaffolding .NET/Node.js Docker build tasks, which causes Docker to pull the latest image on build.  Previously, the property was omitted which meant that Docker would *not* pull the latest image.

Resolves #1409.