### PR TITLE
add remaining commands to view/title

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,14 +217,38 @@
                     "group": "navigation@8"
                 },
                 {
-                    "command": "vscode-docker.networks.configureExplorer",
-                    "when": "view == dockerNetworks",
-                    "group": "navigation@8"
-                },
-                {
                     "command": "vscode-docker.containers.refresh",
                     "when": "view == dockerContainers",
                     "group": "navigation@9"
+                },
+                {
+                    "command": "vscode-docker.containers.attachShell",
+                    "when": "view == dockerContainers"
+                },
+                {
+                    "command": "vscode-docker.containers.inspect",
+                    "when": "view == dockerContainers"
+                },
+                {
+                    "command": "vscode-docker.containers.remove",
+                    "when": "view == dockerContainers"
+                },
+                {
+                    "command": "vscode-docker.containers.restart",
+                    "when": "view == dockerContainers"
+                },
+                {
+                    "command": "vscode-docker.containers.stop",
+                    "when": "view == dockerContainers"
+                },
+                {
+                    "command": "vscode-docker.containers.viewLogs",
+                    "when": "view == dockerContainers"
+                },
+                {
+                    "command": "vscode-docker.networks.configureExplorer",
+                    "when": "view == dockerNetworks",
+                    "group": "navigation@8"
                 },
                 {
                     "command": "vscode-docker.networks.create",
@@ -255,6 +279,34 @@
                     "command": "vscode-docker.images.refresh",
                     "when": "view == dockerImages",
                     "group": "navigation@9"
+                },
+                {
+                    "command": "vscode-docker.images.build",
+                    "when": "view == dockerImages"
+                },
+                {
+                    "command": "vscode-docker.images.inspect",
+                    "when": "view == dockerImages"
+                },
+                {
+                    "command": "vscode-docker.images.push",
+                    "when": "view == dockerImages"
+                },
+                {
+                    "command": "vscode-docker.images.remove",
+                    "when": "view == dockerImages"
+                },
+                {
+                    "command": "vscode-docker.images.run",
+                    "when": "view == dockerImages"
+                },
+                {
+                    "command": "vscode-docker.images.tag",
+                    "when": "view == dockerImages"
+                },
+                {
+                    "command": "vscode-docker.images.copyFullTag",
+                    "when": "view == dockerImages"
                 },
                 {
                     "command": "vscode-docker.registries.refresh",


### PR DESCRIPTION
Currently it is not possible to select multiple containers/images graphically and execute the same action with all of them (#331). However, it is possible to work around it by running some commands and selecting the items later. See https://github.com/microsoft/vscode-docker/issues/331#issuecomment-500477876.

As suggested in https://github.com/microsoft/vscode-docker/issues/331#issuecomment-518300409, this PR adds the commands which are not already being shown to the `view/title` of sections 'Containers' and 'Images'.

Some features work as expected, but others might need to be improved. Therefore, I'm keeping this PR as a draft for discussion.

---

- Containers:
  - **Attach Shell**: allows to select a single container. The 'select box' does NOT filter by container name; instead, it does by image name. This is unfortunate. Is there any other straighforward mechanism to search a container and attach to it?
  - **Inspect**, **View Logs**: allow to select a single container. Same issue as 'Attach Shell'. I think they should support selecting multiple containers.
  - **Remove**, **Restart**, **Stop**: allow to select multiple containers. OK.
  - **Browse**: is it sensible to add this too?
  - **Start**: produces a "No matching resources found" error.
  - **Select**: I am not sure about what this is expected to be used for.
- Images:
  - **Build**, **Run**, **Tag**: work as expected.
  - **Inspect**: same issue as with containers.
  - **Push**, **Remove**: allow to select a single image. Same issue as inspect.
  - **copyFullTag**: I am not sure about what this is expected to be used for.