### PR TITLE
Handle in-use remove image

### DIFF
--- a/src/tree/images/ImageTreeItem.ts
+++ b/src/tree/images/ImageTreeItem.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Image } from 'dockerode';
-import { AzExtParentTreeItem, AzExtTreeItem } from "vscode-azureextensionui";
+import { window } from 'vscode';
+import { AzExtParentTreeItem, AzExtTreeItem, IParsedError, parseError } from "vscode-azureextensionui";
 import { ext } from '../../extensionVariables';
 import { getThemedIconPath, IconPath } from '../IconPath';
 import { ILocalImageInfo } from './LocalImageInfo';
@@ -60,6 +61,21 @@ export class ImageTreeItem extends AzExtTreeItem {
     }
 
     public async deleteTreeItemImpl(): Promise<void> {
-        await this.getImage().remove({ force: true });
+        const image: Image = this.getImage();
+        try {
+            await image.remove({ force: true });
+        } catch (error) {
+            const parsedError: IParsedError = parseError(error);
+
+            // error code 409 is returned for conflicts like the image is used by a running container or another image.
+            // Such errors are not really an error, it should be treated as warning.
+            if (parsedError.errorType === '409') {
+                ext.outputChannel.appendLog('Warning: ' + parsedError.message);
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                window.showWarningMessage(parsedError.message);
+            } else {
+                throw error;
+            }
+        }
     }
 }


### PR DESCRIPTION
Remove image will fail for images that are used by running container or other images. These failures are treated as error and report issue options is shown to user, which leads user to believe that it a bug in the extension. Now, these errors are shown to user as warning and no report issue button is shown.

Related to #1398.