### PR TITLE
Filter and show only the container groups valid for that command

### DIFF
--- a/src/tree/LocalGroupTreeItemBase.ts
+++ b/src/tree/LocalGroupTreeItemBase.ts
@@ -11,7 +11,7 @@ export abstract class LocalGroupTreeItemBase<TItem extends ILocalItem, TProperty
     public parent: LocalRootTreeItemBase<TItem, TProperty>;
     public group: string;
     private _items: TItem[];
-    private _childrenTreeItems: AzExtTreeItem[];
+    private _childTreeItems: AzExtTreeItem[];
 
     public constructor(parent: LocalRootTreeItemBase<TItem, TProperty>, group: string, items: TItem[]) {
         super(parent);
@@ -32,9 +32,8 @@ export abstract class LocalGroupTreeItemBase<TItem extends ILocalItem, TProperty
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-        this._childrenTreeItems = this.getChildrenTreeItems();
-        return this._childrenTreeItems;
+        this._childTreeItems = this.getChildTreeItems();
+        return this._childTreeItems;
     }
 
     public hasMoreChildrenImpl(): boolean {
@@ -45,14 +44,14 @@ export abstract class LocalGroupTreeItemBase<TItem extends ILocalItem, TProperty
         return this.parent.compareChildrenImpl(ti1, ti2);
     }
 
-    public get ChildrenTreeItems(): AzExtTreeItem[] {
-        if (!this._childrenTreeItems) {
-            this._childrenTreeItems = this.getChildrenTreeItems();
+    public get ChildTreeItems(): AzExtTreeItem[] {
+        if (!this._childTreeItems) {
+            this._childTreeItems = this.getChildTreeItems();
         }
-        return this._childrenTreeItems;
+        return this._childTreeItems;
     }
 
-    private getChildrenTreeItems(): AzExtTreeItem[] {
+    private getChildTreeItems(): AzExtTreeItem[] {
         return this._items.map(i => new this.parent.childType(this, i));
     }
 }

--- a/src/tree/LocalGroupTreeItemBase.ts
+++ b/src/tree/LocalGroupTreeItemBase.ts
@@ -11,6 +11,7 @@ export abstract class LocalGroupTreeItemBase<TItem extends ILocalItem, TProperty
     public parent: LocalRootTreeItemBase<TItem, TProperty>;
     public group: string;
     private _items: TItem[];
+    private _childrenTreeItems: AzExtTreeItem[];
 
     public constructor(parent: LocalRootTreeItemBase<TItem, TProperty>, group: string, items: TItem[]) {
         super(parent);
@@ -31,7 +32,9 @@ export abstract class LocalGroupTreeItemBase<TItem extends ILocalItem, TProperty
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
-        return this._items.map(i => new this.parent.childType(this, i));
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        this._childrenTreeItems = this.getChildrenTreeItems();
+        return this._childrenTreeItems;
     }
 
     public hasMoreChildrenImpl(): boolean {
@@ -40,5 +43,16 @@ export abstract class LocalGroupTreeItemBase<TItem extends ILocalItem, TProperty
 
     public compareChildrenImpl(ti1: AzExtTreeItem, ti2: AzExtTreeItem): number {
         return this.parent.compareChildrenImpl(ti1, ti2);
+    }
+
+    public get ChildrenTreeItems(): AzExtTreeItem[] {
+        if (!this._childrenTreeItems) {
+            this._childrenTreeItems = this.getChildrenTreeItems();
+        }
+        return this._childrenTreeItems;
+    }
+
+    private getChildrenTreeItems(): AzExtTreeItem[] {
+        return this._items.map(i => new this.parent.childType(this, i));
     }
 }

--- a/src/tree/containers/ContainerGroupTreeItem.ts
+++ b/src/tree/containers/ContainerGroupTreeItem.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzExtTreeItem } from "vscode-azureextensionui";
 import { getThemedIconPath, IconPath } from "../IconPath";
 import { getImageGroupIcon } from "../images/ImageProperties";
 import { LocalGroupTreeItemBase } from "../LocalGroupTreeItemBase";
@@ -33,5 +34,14 @@ export class ContainerGroupTreeItem extends LocalGroupTreeItemBase<LocalContaine
         }
 
         return getThemedIconPath(icon);
+    }
+
+    public isAncestorOfImpl(expectedContextValue: string | RegExp): boolean {
+        return this.ChildrenTreeItems.some((container: AzExtTreeItem) => this.matchesValue(container, expectedContextValue));
+    }
+
+    private matchesValue(container: AzExtTreeItem, expectedContextValue: (string | RegExp)): boolean {
+        return container.contextValue === expectedContextValue
+            || (expectedContextValue instanceof RegExp && expectedContextValue.test(container.contextValue));
     }
 }

--- a/src/tree/containers/ContainerGroupTreeItem.ts
+++ b/src/tree/containers/ContainerGroupTreeItem.ts
@@ -37,7 +37,7 @@ export class ContainerGroupTreeItem extends LocalGroupTreeItemBase<LocalContaine
     }
 
     public isAncestorOfImpl(expectedContextValue: string | RegExp): boolean {
-        return this.ChildrenTreeItems.some((container: AzExtTreeItem) => this.matchesValue(container, expectedContextValue));
+        return this.ChildTreeItems.some((container: AzExtTreeItem) => this.matchesValue(container, expectedContextValue));
     }
 
     private matchesValue(container: AzExtTreeItem, expectedContextValue: (string | RegExp)): boolean {


### PR DESCRIPTION
Container related commands like start and stop is valid for certain containers based on state. If the containers are grouped (default), then the first level tree item picker shows all container groups. Now this is filtered to show the group that has a valid container.

Related to #1430