### PR TITLE
Enable configuration for View Logs command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1513,6 +1513,20 @@
                     "default": "powershell",
                     "description": "Attach command to use for Windows containers"
                 },
+                "docker.viewLogsCommand.follow": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Follow log output"
+                },
+                "docker.viewLogsCommand.tail": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0,
+                    "default": null,
+                    "description": "Number of lines to show from the end of the logs"
+                },
                 "docker.dockerComposeBuild": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
Adds two configuration options, Follow and Tail, that match -f and --tail command line arguments of "docker logs" command.

Closes #1505.