### PR TITLE
Enable consuming the local package using npm link

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
 		"javascriptreact",
 		"typescript"
 	],
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,14 @@
         "noUnusedLocals": true,
         "noUnusedParameters": false, // TODO
         "strictNullChecks": false, // TODO
-        "strict": true
+        "strict": true,
+        "baseUrl": "./",
+        "paths": {
+            "*": [
+                "node_modules/vscode/*",
+                "*"
+            ]
+        }
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
When a local package is linked, it includes types from original vscode.d.ts and the one from the link. This results into duplicate type during compile.