### PR TITLE
Provide a useful error message and suppress report issue button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10993,9 +10993,9 @@
       }
     },
     "vscode-azureextensionui": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.29.1.tgz",
-      "integrity": "sha512-ri9r2aUdLyMXrrLQ4HtQ7yHcriyK8GmrezplKL1oTMPL0rEh+VdlzStTJYIknF/rS3Arh/YPe44p6mFG3ztzNg==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.29.5.tgz",
+      "integrity": "sha512-vS3L+uqd+2pNwoOOsjj/xJh5SZqhW0bGetCJgh29ACGI2r7a7CHS9YNh9Yv0AQY5Duu7GrJcyHOxr3ny6koGKg==",
       "requires": {
         "azure-arm-resource": "^3.0.0-preview",
         "azure-arm-storage": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -2048,7 +2048,7 @@
         "semver": "^6.3.0",
         "tar": "^5.0.5",
         "vscode-azureappservice": "^0.54.0",
-        "vscode-azureextensionui": "^0.29.1",
+        "vscode-azureextensionui": "^0.29.5",
         "vscode-languageclient": "^5.2.1",
         "xml2js": "^0.4.22"
     }

--- a/src/commands/containers/browseContainer.ts
+++ b/src/commands/containers/browseContainer.ts
@@ -59,7 +59,7 @@ export async function browseContainer(context: IActionContext, node?: ContainerT
         node = await captureBrowseCancelStep('node', telemetryProperties, () =>
             ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.runningContainerRegExp, {
                 ...context,
-                noItemFoundErrorMessage: 'No running containers are available to open in browser.'
+                noItemFoundErrorMessage: 'No running containers are available to open in a browser'
             }));
     }
 

--- a/src/commands/containers/browseContainer.ts
+++ b/src/commands/containers/browseContainer.ts
@@ -56,7 +56,11 @@ export async function browseContainer(context: IActionContext, node?: ContainerT
 
     if (!node) {
         /* eslint-disable-next-line @typescript-eslint/promise-function-async */
-        node = await captureBrowseCancelStep('node', telemetryProperties, () => ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.runningContainerRegExp, context));
+        node = await captureBrowseCancelStep('node', telemetryProperties, () =>
+            ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.runningContainerRegExp, {
+                ...context,
+                noItemFoundErrorMessage: 'No running containers are available to open in browser.'
+            }));
     }
 
     const inspectInfo = await node.getContainer().inspect();

--- a/src/commands/containers/inspectContainer.ts
+++ b/src/commands/containers/inspectContainer.ts
@@ -9,7 +9,10 @@ import { ContainerTreeItem } from "../../tree/containers/ContainerTreeItem";
 
 export async function inspectContainer(context: IActionContext, node?: ContainerTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.allContextRegExp, context);
+        node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.allContextRegExp, {
+            ...context,
+            noItemFoundErrorMessage: 'No containers are available to inspect'
+        });
     }
 
     const inspectInfo = await node.getContainer().inspect();

--- a/src/commands/containers/removeContainer.ts
+++ b/src/commands/containers/removeContainer.ts
@@ -13,7 +13,11 @@ export async function removeContainer(context: IActionContext, node: ContainerTr
     if (node) {
         nodes = [node];
     } else {
-        nodes = await ext.containersTree.showTreeItemPicker(ContainerTreeItem.allContextRegExp, { ...context, canPickMany: true, suppressCreatePick: true });
+        nodes = await ext.containersTree.showTreeItemPicker(ContainerTreeItem.allContextRegExp, {
+            ...context,
+            canPickMany: true,
+            noItemFoundErrorMessage: 'No containers are available to remove'
+        });
     }
 
     let confirmRemove: string;

--- a/src/commands/containers/restartContainer.ts
+++ b/src/commands/containers/restartContainer.ts
@@ -13,7 +13,11 @@ export async function restartContainer(context: IActionContext, node: ContainerT
     if (node) {
         nodes = [node];
     } else {
-        nodes = await ext.containersTree.showTreeItemPicker(/^(created|dead|exited|paused|running)Container$/i, { ...context, canPickMany: true });
+        nodes = await ext.containersTree.showTreeItemPicker(/^(created|dead|exited|paused|running)Container$/i, {
+            ...context,
+            canPickMany: true,
+            noItemFoundErrorMessage: 'No containers are available to restart'
+        });
     }
 
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Restarting Container(s)..." }, async () => {

--- a/src/commands/containers/selectContainer.ts
+++ b/src/commands/containers/selectContainer.ts
@@ -16,7 +16,7 @@ export async function selectContainer(context: IActionContext): Promise<string> 
 
     node = await ext.containersTree.showTreeItemPicker(/^runningContainer$/i, {
         ...context,
-        noItemFoundErrorMessage: 'No running containers are available.'
+        noItemFoundErrorMessage: 'No running containers are available'
     });
 
     return node.containerId;

--- a/src/commands/containers/selectContainer.ts
+++ b/src/commands/containers/selectContainer.ts
@@ -14,7 +14,10 @@ export async function selectContainer(context: IActionContext): Promise<string> 
     // Expecting running containers to change often as this is a debugging scenario.
     await ext.containersTree.refresh();
 
-    node = await ext.containersTree.showTreeItemPicker(/^runningContainer$/i, { ...context });
+    node = await ext.containersTree.showTreeItemPicker(/^runningContainer$/i, {
+        ...context,
+        noItemFoundErrorMessage: 'No running containers are available.'
+    });
 
     return node.containerId;
 }

--- a/src/commands/containers/startContainer.ts
+++ b/src/commands/containers/startContainer.ts
@@ -13,7 +13,11 @@ export async function startContainer(context: IActionContext, node: ContainerTre
     if (node) {
         nodes = [node];
     } else {
-        nodes = await ext.containersTree.showTreeItemPicker(/^(created|dead|exited|paused)Container$/i, { ...context, canPickMany: true });
+        nodes = await ext.containersTree.showTreeItemPicker(/^(created|dead|exited|paused)Container$/i, {
+            ...context,
+            canPickMany: true,
+            noItemFoundErrorMessage: 'No containers are available to start'
+        });
     }
 
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Starting Container(s)..." }, async () => {

--- a/src/commands/containers/stopContainer.ts
+++ b/src/commands/containers/stopContainer.ts
@@ -16,7 +16,7 @@ export async function stopContainer(context: IActionContext, node: ContainerTree
         nodes = await ext.containersTree.showTreeItemPicker(/^(paused|restarting|running)Container$/i, {
             ...context,
             canPickMany: true,
-            noItemFoundErrorMessage: 'No containers are availble to stop.'
+            noItemFoundErrorMessage: 'No containers are availble to stop'
         });
     }
 

--- a/src/commands/containers/stopContainer.ts
+++ b/src/commands/containers/stopContainer.ts
@@ -13,7 +13,11 @@ export async function stopContainer(context: IActionContext, node: ContainerTree
     if (node) {
         nodes = [node];
     } else {
-        nodes = await ext.containersTree.showTreeItemPicker(/^(paused|restarting|running)Container$/i, { ...context, canPickMany: true });
+        nodes = await ext.containersTree.showTreeItemPicker(/^(paused|restarting|running)Container$/i, {
+            ...context,
+            canPickMany: true,
+            noItemFoundErrorMessage: 'No containers are availble to stop.'
+        });
     }
 
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Stopping Container(s)..." }, async () => {

--- a/src/commands/containers/viewContainerLogs.ts
+++ b/src/commands/containers/viewContainerLogs.ts
@@ -9,7 +9,10 @@ import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 
 export async function viewContainerLogs(context: IActionContext, node?: ContainerTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.allContextRegExp, context);
+        node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.allContextRegExp, {
+            ...context,
+            noItemFoundErrorMessage: 'No continers are available to view logs'
+        });
     }
 
     const terminal = ext.terminalProvider.createTerminal(node.fullTag);

--- a/src/commands/images/copyFullTag.ts
+++ b/src/commands/images/copyFullTag.ts
@@ -10,7 +10,10 @@ import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 
 export async function copyFullTag(context: IActionContext, node: ImageTreeItem | undefined): Promise<string> {
     if (!node) {
-        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, context);
+        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
+            ...context,
+            noItemFoundErrorMessage: 'No images are availalbe to copy tag'
+        });
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     vscode.env.clipboard.writeText(node.fullTag);

--- a/src/commands/images/inspectImage.ts
+++ b/src/commands/images/inspectImage.ts
@@ -9,7 +9,10 @@ import { ImageTreeItem } from "../../tree/images/ImageTreeItem";
 
 export async function inspectImage(context: IActionContext, node?: ImageTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, context);
+        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
+            ...context,
+            noItemFoundErrorMessage: 'No images are availalbe to inspect'
+        });
     }
 
     const inspectInfo = await node.getImage().inspect();

--- a/src/commands/images/pushImage.ts
+++ b/src/commands/images/pushImage.ts
@@ -13,7 +13,10 @@ import { addImageTaggingTelemetry, tagImage } from './tagImage';
 
 export async function pushImage(context: IActionContext, node: ImageTreeItem | undefined): Promise<void> {
     if (!node) {
-        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, context);
+        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
+            ...context,
+            noItemFoundErrorMessage: 'No images are availalbe to push'
+        });
     }
 
     const defaultRegistryPath = vscode.workspace.getConfiguration('docker').get(configurationKeys.defaultRegistryPath);

--- a/src/commands/images/removeImage.ts
+++ b/src/commands/images/removeImage.ts
@@ -13,7 +13,12 @@ export async function removeImage(context: IActionContext, node: ImageTreeItem |
     if (node) {
         nodes = [node];
     } else {
-        nodes = await ext.imagesTree.showTreeItemPicker(ImageTreeItem.contextValue, { ...context, canPickMany: true, suppressCreatePick: true });
+        nodes = await ext.imagesTree.showTreeItemPicker(ImageTreeItem.contextValue, {
+            ...context,
+            canPickMany: true,
+            suppressCreatePick: true,
+            noItemFoundErrorMessage: 'No images are available to remove'
+        });
     }
 
     let confirmRemove: string;

--- a/src/commands/images/runImage.ts
+++ b/src/commands/images/runImage.ts
@@ -17,7 +17,10 @@ export async function runImageInteractive(context: IActionContext, node?: ImageT
 
 async function runImageCore(context: IActionContext, node: ImageTreeItem | undefined, interactive: boolean): Promise<void> {
     if (!node) {
-        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, context);
+        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
+            ...context,
+            noItemFoundErrorMessage: 'No images are availalbe to run'
+        });
     }
 
     const inspectInfo = await node.getImage().inspect();

--- a/src/commands/images/tagImage.ts
+++ b/src/commands/images/tagImage.ts
@@ -13,7 +13,10 @@ import { extractRegExGroups } from '../../utils/extractRegExGroups';
 
 export async function tagImage(context: IActionContext, node: ImageTreeItem | undefined): Promise<string> {
     if (!node) {
-        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, context);
+        node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
+            ...context,
+            noItemFoundErrorMessage: 'No images are availalbe to tag'
+        });
     }
 
     addImageTaggingTelemetry(context, node.fullTag, '.before');

--- a/src/commands/networks/inspectNetwork.ts
+++ b/src/commands/networks/inspectNetwork.ts
@@ -9,7 +9,10 @@ import { NetworkTreeItem } from "../../tree/networks/NetworkTreeItem";
 
 export async function inspectNetwork(context: IActionContext, node?: NetworkTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.networksTree.showTreeItemPicker<NetworkTreeItem>(NetworkTreeItem.contextValue, context);
+        node = await ext.networksTree.showTreeItemPicker<NetworkTreeItem>(NetworkTreeItem.contextValue, {
+            ...context,
+            noItemFoundErrorMessage: 'No images are availalbe to inspect'
+        });
     }
 
     // tslint:disable-next-line: no-unsafe-any

--- a/src/commands/networks/removeNetwork.ts
+++ b/src/commands/networks/removeNetwork.ts
@@ -13,7 +13,12 @@ export async function removeNetwork(context: IActionContext, node: NetworkTreeIt
     if (node) {
         nodes = [node];
     } else {
-        nodes = await ext.networksTree.showTreeItemPicker(NetworkTreeItem.contextValue, { ...context, canPickMany: true, suppressCreatePick: true });
+        nodes = await ext.networksTree.showTreeItemPicker(NetworkTreeItem.contextValue, {
+            ...context,
+            canPickMany: true,
+            suppressCreatePick: true,
+            noItemFoundErrorMessage: 'No networks are available to remove'
+        });
     }
 
     let confirmRemove: string;

--- a/src/commands/registries/azure/untagAzureImage.ts
+++ b/src/commands/registries/azure/untagAzureImage.ts
@@ -15,7 +15,7 @@ export async function untagAzureImage(context: IActionContext, node?: RemoteTagT
         node = await ext.registriesTree.showTreeItemPicker<RemoteTagTreeItem>(registryExpectedContextValues.azure.tag, {
             ...context,
             suppressCreatePick: true,
-            noItemFoundErrorMessage: 'No images are available to untag.'
+            noItemFoundErrorMessage: 'No images are available to untag'
         });
     }
 

--- a/src/commands/registries/azure/untagAzureImage.ts
+++ b/src/commands/registries/azure/untagAzureImage.ts
@@ -12,7 +12,11 @@ import { registryRequest } from "../../../utils/registryRequestUtils";
 
 export async function untagAzureImage(context: IActionContext, node?: RemoteTagTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.registriesTree.showTreeItemPicker<RemoteTagTreeItem>(registryExpectedContextValues.azure.tag, { ...context, suppressCreatePick: true });
+        node = await ext.registriesTree.showTreeItemPicker<RemoteTagTreeItem>(registryExpectedContextValues.azure.tag, {
+            ...context,
+            suppressCreatePick: true,
+            noItemFoundErrorMessage: 'No images are available to untag.'
+        });
     }
 
     const confirmUntag: string = `Are you sure you want to untag "${node.repoNameAndTag}"? This does not delete the manifest referenced by the tag.`;

--- a/src/commands/registries/copyRemoteImageDigest.ts
+++ b/src/commands/registries/copyRemoteImageDigest.ts
@@ -13,7 +13,10 @@ import { nonNullProp } from "../../utils/nonNull";
 
 export async function copyRemoteImageDigest(context: IActionContext, node?: DockerV2TagTreeItem | AzureTaskRunTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.registriesTree.showTreeItemPicker<DockerV2TagTreeItem>(registryExpectedContextValues.dockerV2.tag, context);
+        node = await ext.registriesTree.showTreeItemPicker<DockerV2TagTreeItem>(registryExpectedContextValues.dockerV2.tag, {
+            ...context,
+            noItemFoundErrorMessage: 'No remote images are available to copy the digest'
+        });
     }
 
     let digest: string;

--- a/src/commands/registries/deleteRemoteImage.ts
+++ b/src/commands/registries/deleteRemoteImage.ts
@@ -11,7 +11,11 @@ import { registryExpectedContextValues } from '../../tree/registries/registryCon
 
 export async function deleteRemoteImage(context: IActionContext, node?: DockerV2TagTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.registriesTree.showTreeItemPicker<DockerV2TagTreeItem>(registryExpectedContextValues.dockerV2.tag, { ...context, suppressCreatePick: true });
+        node = await ext.registriesTree.showTreeItemPicker<DockerV2TagTreeItem>(registryExpectedContextValues.dockerV2.tag, {
+            ...context,
+            suppressCreatePick: true,
+            noItemFoundErrorMessage: 'No remote images are available to delete'
+        });
     }
 
     const confirmDelete = `Are you sure you want to delete image "${node.repoNameAndTag}"? This will delete all images that have the same digest.`;

--- a/src/commands/registries/dockerHub/openDockerHubInBrowser.ts
+++ b/src/commands/registries/dockerHub/openDockerHubInBrowser.ts
@@ -14,7 +14,10 @@ import { openExternal } from "../../../utils/openExternal";
 
 export async function openDockerHubInBrowser(context: IActionContext, node?: DockerHubNamespaceTreeItem | DockerHubRepositoryTreeItem | RemoteTagTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.registriesTree.showTreeItemPicker<DockerHubNamespaceTreeItem>(registryExpectedContextValues.dockerHub.registry, context);
+        node = await ext.registriesTree.showTreeItemPicker<DockerHubNamespaceTreeItem>(registryExpectedContextValues.dockerHub.registry, {
+            ...context,
+            noItemFoundErrorMessage: 'No Docker Hub registries available to browse.'
+        });
     }
 
     let url = dockerHubUrl;

--- a/src/commands/registries/dockerHub/openDockerHubInBrowser.ts
+++ b/src/commands/registries/dockerHub/openDockerHubInBrowser.ts
@@ -16,7 +16,7 @@ export async function openDockerHubInBrowser(context: IActionContext, node?: Doc
     if (!node) {
         node = await ext.registriesTree.showTreeItemPicker<DockerHubNamespaceTreeItem>(registryExpectedContextValues.dockerHub.registry, {
             ...context,
-            noItemFoundErrorMessage: 'No Docker Hub registries available to browse.'
+            noItemFoundErrorMessage: 'No Docker Hub registries available to browse'
         });
     }
 

--- a/src/commands/volumes/inspectVolume.ts
+++ b/src/commands/volumes/inspectVolume.ts
@@ -9,7 +9,7 @@ import { VolumeTreeItem } from "../../tree/volumes/VolumeTreeItem";
 
 export async function inspectVolume(context: IActionContext, node?: VolumeTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, { ...context, noItemFoundErrorMessage: 'No volumes are available to inspect.' });
+        node = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, { ...context, noItemFoundErrorMessage: 'No volumes are available to inspect' });
     }
 
     const inspectInfo = await node.getVolume().inspect();

--- a/src/commands/volumes/inspectVolume.ts
+++ b/src/commands/volumes/inspectVolume.ts
@@ -9,7 +9,7 @@ import { VolumeTreeItem } from "../../tree/volumes/VolumeTreeItem";
 
 export async function inspectVolume(context: IActionContext, node?: VolumeTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, context);
+        node = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, { ...context, noItemFoundErrorMessage: 'No volumes are available to inspect.' });
     }
 
     const inspectInfo = await node.getVolume().inspect();

--- a/src/commands/volumes/removeVolume.ts
+++ b/src/commands/volumes/removeVolume.ts
@@ -13,7 +13,12 @@ export async function removeVolume(context: IActionContext, node: VolumeTreeItem
     if (node) {
         nodes = [node];
     } else {
-        nodes = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, { ...context, canPickMany: true, suppressCreatePick: true });
+        nodes = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, {
+            ...context,
+            canPickMany: true,
+            suppressCreatePick: true,
+            noItemFoundErrorMessage: 'No volumes are available to remove.'
+        });
     }
 
     let confirmRemove: string;

--- a/src/commands/volumes/removeVolume.ts
+++ b/src/commands/volumes/removeVolume.ts
@@ -17,7 +17,7 @@ export async function removeVolume(context: IActionContext, node: VolumeTreeItem
             ...context,
             canPickMany: true,
             suppressCreatePick: true,
-            noItemFoundErrorMessage: 'No volumes are available to remove.'
+            noItemFoundErrorMessage: 'No volumes are available to remove'
         });
     }
 


### PR DESCRIPTION
If no matching item found while selecting an item in tree item picker, then a generic error message 'No resource found' with 'report issue' button is offered to user.
Now a customized message is given (like no running container are available to stop) and the 'report issue' button is not shown to user. The azuretools extension behavior is changed to not show 'report issue' when a custom message is provided (refer https://github.com/microsoft/vscode-azuretools/pull/644).

related to #1528