### PR TITLE
Don't show 'report issue' in docker commands on volume and network inspect and delete

### DIFF
--- a/src/commands/containers/inspectContainer.ts
+++ b/src/commands/containers/inspectContainer.ts
@@ -19,7 +19,6 @@ export async function inspectContainer(context: IActionContext, node?: Container
 
     const container = node.getContainer();
     // eslint-disable-next-line @typescript-eslint/promise-function-async
-    let inspectInfo: ContainerInspectInfo = await callDockerodeWithErrorHandling(() => container.inspect(), context);
-
+    const inspectInfo: ContainerInspectInfo = await callDockerodeWithErrorHandling(() => container.inspect(), context);
     await openReadOnlyJson(node, inspectInfo);
 }

--- a/src/commands/networks/inspectNetwork.ts
+++ b/src/commands/networks/inspectNetwork.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Network } from "dockerode";
 import { IActionContext, openReadOnlyJson } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { NetworkTreeItem } from "../../tree/networks/NetworkTreeItem";
+import { callDockerodeWithErrorHandling } from "../../utils/callDockerodeWithErrorHandling";
 
 export async function inspectNetwork(context: IActionContext, node?: NetworkTreeItem): Promise<void> {
     if (!node) {
@@ -15,7 +17,8 @@ export async function inspectNetwork(context: IActionContext, node?: NetworkTree
         });
     }
 
-    // tslint:disable-next-line: no-unsafe-any
-    const inspectInfo: {} = await node.getNetwork().inspect(); // inspect is missing type in @types/dockerode
+    const network: Network = node.getNetwork()
+    // eslint-disable-next-line @typescript-eslint/promise-function-async, @typescript-eslint/tslint/config
+    const inspectInfo: {} = await callDockerodeWithErrorHandling(() => network.inspect(), context); // inspect is missing type in @types/dockerode
     await openReadOnlyJson(node, inspectInfo);
 }

--- a/src/commands/volumes/inspectVolume.ts
+++ b/src/commands/volumes/inspectVolume.ts
@@ -3,15 +3,19 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Volume } from "dockerode";
 import { IActionContext, openReadOnlyJson } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { VolumeTreeItem } from "../../tree/volumes/VolumeTreeItem";
+import { callDockerodeWithErrorHandling } from "../../utils/callDockerodeWithErrorHandling";
 
 export async function inspectVolume(context: IActionContext, node?: VolumeTreeItem): Promise<void> {
     if (!node) {
         node = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, { ...context, noItemFoundErrorMessage: 'No volumes are available to inspect' });
     }
 
-    const inspectInfo = await node.getVolume().inspect();
+    const volume: Volume = node.getVolume();
+    // eslint-disable-next-line @typescript-eslint/promise-function-async
+    const inspectInfo = await callDockerodeWithErrorHandling(() => volume.inspect(), context);
     await openReadOnlyJson(node, inspectInfo);
 }

--- a/src/tree/networks/NetworkTreeItem.ts
+++ b/src/tree/networks/NetworkTreeItem.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Network } from "dockerode";
-import { AzExtParentTreeItem, AzExtTreeItem } from "vscode-azureextensionui";
+import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
+import { callDockerodeWithErrorHandling } from "../../utils/callDockerodeWithErrorHandling";
 import { getThemedIconPath, IconPath } from '../IconPath';
 import { LocalNetworkInfo } from "./LocalNetworkInfo";
 
@@ -47,7 +48,9 @@ export class NetworkTreeItem extends AzExtTreeItem {
         return ext.dockerode.getNetwork(this.networkId);
     }
 
-    public async deleteTreeItemImpl(): Promise<void> {
-        await this.getNetwork().remove({ force: true });
+    public async deleteTreeItemImpl(context: IActionContext): Promise<void> {
+        const network: Network = this.getNetwork();
+        // eslint-disable-next-line @typescript-eslint/promise-function-async
+        await callDockerodeWithErrorHandling(() => network.remove({ force: true }), context);
     }
 }

--- a/src/tree/volumes/VolumeTreeItem.ts
+++ b/src/tree/volumes/VolumeTreeItem.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Volume } from "dockerode";
-import { AzExtParentTreeItem, AzExtTreeItem } from "vscode-azureextensionui";
+import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
+import { callDockerodeWithErrorHandling } from "../../utils/callDockerodeWithErrorHandling";
 import { getThemedIconPath, IconPath } from "../IconPath";
 import { LocalVolumeInfo } from "./LocalVolumeInfo";
 
@@ -47,7 +48,9 @@ export class VolumeTreeItem extends AzExtTreeItem {
         return ext.dockerode.getVolume(this.volumeName);
     }
 
-    public async deleteTreeItemImpl(): Promise<void> {
-        await this.getVolume().remove({ force: true });
+    public async deleteTreeItemImpl(context: IActionContext): Promise<void> {
+        const volume: Volume = this.getVolume();
+        // eslint-disable-next-line @typescript-eslint/promise-function-async
+        await callDockerodeWithErrorHandling(() => volume.remove({ force: true }), context);
     }
 }


### PR DESCRIPTION
Added error handling for volume and network inspect and delete. This will not show 'report issue' button.
related to #1528 