### PR TITLE
Allow attach shell only on running containers

### DIFF
--- a/src/commands/containers/attachShellContainer.ts
+++ b/src/commands/containers/attachShellContainer.ts
@@ -11,7 +11,7 @@ import { getDockerOSType } from '../../utils/osUtils';
 
 export async function attachShellContainer(context: IActionContext, node?: ContainerTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.allContextRegExp, {
+        node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.runningContainerRegExp, {
             ...context,
             noItemFoundErrorMessage: 'No containers are available to attach.'
         });

--- a/src/commands/containers/attachShellContainer.ts
+++ b/src/commands/containers/attachShellContainer.ts
@@ -13,7 +13,7 @@ export async function attachShellContainer(context: IActionContext, node?: Conta
     if (!node) {
         node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.runningContainerRegExp, {
             ...context,
-            noItemFoundErrorMessage: 'No containers are available to attach.'
+            noItemFoundErrorMessage: 'No running containers are available to attach'
         });
     }
 

--- a/src/commands/containers/selectContainer.ts
+++ b/src/commands/containers/selectContainer.ts
@@ -14,7 +14,7 @@ export async function selectContainer(context: IActionContext): Promise<string> 
     // Expecting running containers to change often as this is a debugging scenario.
     await ext.containersTree.refresh();
 
-    node = await ext.containersTree.showTreeItemPicker(/^runningContainer$/i, {
+    node = await ext.containersTree.showTreeItemPicker(ContainerTreeItem.runningContainerRegExp, {
         ...context,
         noItemFoundErrorMessage: 'No running containers are available'
     });


### PR DESCRIPTION
The attach shell command execution from command pallet was enabled on all containers. Now it is filtered to running container like how this command shows up in docker view.

Fixes #1576 