### PR TITLE
Add setting `docker.dockerComposeProjectName` to set Compose project name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1523,6 +1523,11 @@
                     "default": true,
                     "description": "Set to true to include --d (detached) option when docker-compose command is invoked"
                 },
+                "docker.dockerComposeProjectName": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Overrides the project name for Compose"
+                },
                 "docker.showRemoteWorkspaceWarning": {
                     "type": "boolean",
                     "default": true,

--- a/src/commands/compose.ts
+++ b/src/commands/compose.ts
@@ -69,10 +69,15 @@ async function compose(commands: ('up' | 'down')[], message: string, dockerCompo
     const build: string = configOptions.get('dockerComposeBuild', true) ? '--build' : '';
     const detached: string = configOptions.get('dockerComposeDetached', true) ? '-d' : '';
 
+    let projectName: string = configOptions.get('dockerComposeProjectName', '');
+    if (projectName !== '') {
+        projectName = `-p "${projectName}"`;
+    }
+
     terminal.sendText(`cd "${folder.uri.fsPath}"`);
     for (let command of commands) {
         selectedItems.forEach((item: Item) => {
-            terminal.sendText(command.toLowerCase() === 'up' ? `docker-compose -f "${item.file}" ${command} ${detached} ${build}` : `docker-compose -f "${item.file}" ${command}`);
+            terminal.sendText(command.toLowerCase() === 'up' ? `docker-compose ${projectName} -f "${item.file}" ${command} ${detached} ${build}` : `docker-compose ${projectName} -f "${item.file}" ${command}`);
         });
         terminal.show();
     }


### PR DESCRIPTION
This adds a string setting `docker.dockerComposeProjectName` to set the `-p` option in Docker Compose.

This closes issue https://github.com/microsoft/vscode-docker/issues/1593
