### PR TITLE
use default files in docker-compose

### DIFF
--- a/src/commands/compose.ts
+++ b/src/commands/compose.ts
@@ -78,11 +78,15 @@ async function compose(commands: ('up' | 'down')[], message: string, dockerCompo
 
     terminal.sendText(`cd "${folder.uri.fsPath}"`);
     for (let command of commands) {
-        const fileParameter: string = selectedItems.map(i => `-f "${i.file}"`).join(' ');
-        terminal.sendText(command.toLowerCase() === 'up' ? `docker-compose ${fileParameter} ${command} ${detached} ${build}` : `docker-compose ${fileParameter} ${command}`);
+        if (selectedItems.length === 0) {
+            terminal.sendText(command.toLowerCase() === 'up' ? `docker-compose ${command} ${detached} ${build}` : `docker-compose ${command}`);
+        } else {
+            selectedItems.forEach((item: Item) => {
+                terminal.sendText(command.toLowerCase() === 'up' ? `docker-compose -f "${item.file}" ${command} ${detached} ${build}` : `docker-compose -f "${item.file}" ${command}`);
+            });
+        }
         terminal.show();
     }
-
 }
 
 function isDefaultDockerComposeFile(fileName: string): boolean {

--- a/src/commands/compose.ts
+++ b/src/commands/compose.ts
@@ -61,7 +61,14 @@ async function compose(commands: ('up' | 'down')[], message: string, dockerCompo
         }
 
         const items: vscode.QuickPickItem[] = computeItems(folder, uris);
-        selectedItems = [<Item>await ext.ui.showQuickPick(items, { placeHolder: `Choose Docker Compose file ${message}` })];
+
+        if ((items.length === 1 && isDefaultDockerComposeFile(items[0].label))
+            || (items.length === 2 && items.some(i => isDefaultDockerComposeFile(i.label)) && items.some(i => isDefaultDockerComposeOverrideFile(i.label)))) {
+            // if the current set of docker files contain only docker-compose.yml or docker-compose.yml with override file,
+            // don't ask user for a docker file and let docker-compose automatically pick these files.
+        } else {
+            selectedItems = [<Item>await ext.ui.showQuickPick(items, { placeHolder: `Choose Docker Compose file ${message}` })];
+        }
     }
 
     const terminal: vscode.Terminal = ext.terminalProvider.createTerminal('Docker Compose');
@@ -71,12 +78,29 @@ async function compose(commands: ('up' | 'down')[], message: string, dockerCompo
 
     terminal.sendText(`cd "${folder.uri.fsPath}"`);
     for (let command of commands) {
-        selectedItems.forEach((item: Item) => {
-            terminal.sendText(command.toLowerCase() === 'up' ? `docker-compose -f "${item.file}" ${command} ${detached} ${build}` : `docker-compose -f "${item.file}" ${command}`);
-        });
+        const fileParameter: string = selectedItems.map(i => `-f "${i.file}"`).join(' ');
+        terminal.sendText(command.toLowerCase() === 'up' ? `docker-compose ${fileParameter} ${command} ${detached} ${build}` : `docker-compose ${fileParameter} ${command}`);
         terminal.show();
     }
 
+}
+
+function isDefaultDockerComposeFile(fileName: string): boolean {
+    if (fileName) {
+        const lowerCasefileName: string = fileName.toLowerCase();
+        return lowerCasefileName === 'docker-compose.yml' || lowerCasefileName === 'docker-compose.yaml'
+    }
+
+    return false;
+}
+
+function isDefaultDockerComposeOverrideFile(fileName: string): boolean {
+    if (fileName) {
+        const lowerCasefileName: string = fileName.toLowerCase();
+        return lowerCasefileName === 'docker-compose.override.yml' || lowerCasefileName === 'docker-compose.override.yaml'
+    }
+
+    return false;
 }
 
 export async function composeUp(_context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {


### PR DESCRIPTION
If the workspace container only the default docker-compose files 
1. Just one file and it is named 'docker-compose.y(a)ml'
2. Two files docker-compose.y(a)ml and docker-compose.override.y(a)ml

then -f is not used and let the docker-compose pick these files.

Fixes #370 