### PR TITLE
Rename docker node.js debug config

### DIFF
--- a/src/debugging/node/NodeDebugHelper.ts
+++ b/src/debugging/node/NodeDebugHelper.ts
@@ -39,7 +39,7 @@ export class NodeDebugHelper implements DebugHelper {
     public async provideDebugConfigurations(context: DockerDebugScaffoldContext): Promise<DockerDebugConfiguration[]> {
         return [
             {
-                name: 'Docker Node.js Launch and Attach',
+                name: 'Docker Node.js Launch',
                 type: 'docker',
                 request: 'launch',
                 preLaunchTask: 'docker-run: debug',


### PR DESCRIPTION
Rename launch configuration "Docker Node.js Launch and Attach" to "Docker Node.js Launch
Fixes #1599