### PR TITLE
debug dotnet by attaching to container

### DIFF
--- a/package.json
+++ b/package.json
@@ -694,10 +694,10 @@
                         }
                     },
                     {
-                        "label": "Docker: .NET Core Attach",
+                        "label": "Docker: .NET Core Attach (Preview)",
                         "description": "Docker: Attach to a .NET Core process in a container",
                         "body": {
-                            "name": "Docker .NET Core Attach",
+                            "name": "Docker .NET Core Attach (Preview)",
                             "type": "docker",
                             "request": "attach",
                             "platform": "netCore",

--- a/package.json
+++ b/package.json
@@ -653,10 +653,6 @@
                                     }
                                 ]
                             },
-                            "debuggerPath": {
-                                "type": "string",
-                                "description": "enter the path for the debugger on the target machine, for example /remote_debugger/vsdbg."
-                            },
                             "platform": {
                                 "type": "string",
                                 "description": "The target plaform for the application.",
@@ -672,6 +668,15 @@
                                 },
                                 "default": {
                                     "<insert-source-path-here>": "<insert-target-path-here>"
+                                }
+                            },
+                            "netCore": {
+                                "description": "Options for debugging .NET Core projects in Docker.",
+                                "properties": {
+                                    "debuggerPath": {
+                                        "type": "string",
+                                        "description": "enter the path for the debugger on the target machine, for example /remote_debugger/vsdbg."
+                                    }
                                 }
                             }
                         }

--- a/package.json
+++ b/package.json
@@ -628,6 +628,53 @@
                                 }
                             }
                         }
+                    },
+                    "attach": {
+                        "properties": {
+                            "containerName": {
+                                "type": "string",
+                                "description": "The container name to attach to. If not specified, then user will be prompted to pick a container."
+                            },
+                            "processName": {
+                                "type": "string",
+                                "description": "The process name to attach to. If this is used, 'processId' should not be used."
+                            },
+                            "processId": {
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                        "description": "The process id to attach to. Use \"${command:pickProcesss}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+                                        "default": "${command:pickProcess}"
+                                    },
+                                    {
+                                        "type": "integer",
+                                        "description": "The process id to attach to. Use \"${command:pickProcesss}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+                                        "default": 0
+                                    }
+                                ]
+                            },
+                            "debuggerPath": {
+                                "type": "string",
+                                "description": "enter the path for the debugger on the target machine, for example /remote_debugger/vsdbg."
+                            },
+                            "platform": {
+                                "type": "string",
+                                "description": "The target plaform for the application.",
+                                "enum": [
+                                    "netCore"
+                                ]
+                            },
+                            "sourceFileMap": {
+                                "type": "object",
+                                "description": "Optional source file mappings passed to the debug engine. Example: '{ \"/src\":\"${workspaceFolder}\" }'",
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "default": {
+                                    "<insert-source-path-here>": "<insert-target-path-here>"
+                                }
+                            }
+                        }
                     }
                 },
                 "configurationSnippets": [

--- a/package.json
+++ b/package.json
@@ -692,6 +692,19 @@
                             "name": "Docker: Attach to Node",
                             "remoteRoot": "/usr/src/app"
                         }
+                    },
+                    {
+                        "label": "Docker: .NET Core Attach",
+                        "description": "Docker: Attach to a .NET Core process in a container",
+                        "body": {
+                            "name": "Docker .NET Core Attach",
+                            "type": "docker",
+                            "request": "attach",
+                            "platform": "netCore",
+                            "sourceFileMap": {
+                                "/src": "^\"\\${workspaceFolder}\""
+                            }
+                        }
                     }
                 ]
             },

--- a/src/debugging/DockerDebugConfigurationProvider.ts
+++ b/src/debugging/DockerDebugConfigurationProvider.ts
@@ -17,6 +17,12 @@ export interface DockerDebugConfiguration extends NetCoreDockerDebugConfiguratio
     platform?: DockerPlatform;
 }
 
+export interface DockerAttachConfiguration extends NetCoreDockerDebugConfiguration, NodeDockerDebugConfiguration {
+    debuggerFilePath?: string;
+    processName?: string;
+    processId?: string | number;
+}
+
 export class DockerDebugConfigurationProvider implements DebugConfigurationProvider {
     public constructor(
         private readonly dockerClient: DockerClient,
@@ -42,7 +48,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
     public resolveDebugConfiguration(folder: WorkspaceFolder | undefined, debugConfiguration: DockerDebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration | undefined> {
         return callWithTelemetryAndErrorHandling(
-            'docker-launch',
+            debugConfiguration.request === 'attach' ? 'docker-attach' : 'docker-launch',
             async (actionContext: IActionContext) => {
                 if (!folder) {
                     folder = workspace.workspaceFolders[0];
@@ -56,6 +62,10 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
                     // If type is undefined, they may be doing F5 without creating any real launch.json, which won't work
                     // VSCode subsequently will call provideDebugConfigurations which will show an error message
                     return null;
+                }
+
+                if (!debugConfiguration.request) {
+                    throw new Error('The property "request" must be specified in the debug config.')
                 }
 
                 const debugPlatform = getPlatform(debugConfiguration);

--- a/src/debugging/DockerDebugConfigurationProvider.ts
+++ b/src/debugging/DockerDebugConfigurationProvider.ts
@@ -18,7 +18,7 @@ export interface DockerDebugConfiguration extends NetCoreDockerDebugConfiguratio
 }
 
 export interface DockerAttachConfiguration extends NetCoreDockerDebugConfiguration, NodeDockerDebugConfiguration {
-    debuggerFilePath?: string;
+    debuggerPath?: string;
     processName?: string;
     processId?: string | number;
 }

--- a/src/debugging/DockerDebugConfigurationProvider.ts
+++ b/src/debugging/DockerDebugConfigurationProvider.ts
@@ -18,7 +18,6 @@ export interface DockerDebugConfiguration extends NetCoreDockerDebugConfiguratio
 }
 
 export interface DockerAttachConfiguration extends NetCoreDockerDebugConfiguration, NodeDockerDebugConfiguration {
-    debuggerPath?: string;
     processName?: string;
     processId?: string | number;
 }

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -279,7 +279,7 @@ export class NetCoreDebugHelper implements DebugHelper {
 
     private async installDebuggerInContainer(containerName: string): Promise<string> {
         const yesItem: MessageItem = DialogResponses.yes;
-        const install = (yesItem === await window.showInformationMessage('Attaching to container requiers .NET Core debugger in the container. Do you want to install debugger in the container?', ...[DialogResponses.yes, DialogResponses.no]));
+        const install = (yesItem === await window.showInformationMessage('Attaching to container requires .NET Core debugger in the container. Do you want to install debugger in the container?', ...[DialogResponses.yes, DialogResponses.no]));
         if (!install) {
             throw new UserCancelledError("User didn't grand permission to install .NET Core debugger.");
         }

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -29,6 +29,7 @@ import { DockerAttachConfiguration, DockerDebugConfiguration } from '../DockerDe
 
 export interface NetCoreDebugOptions extends NetCoreTaskOptions {
     appOutput?: string;
+    debuggerPath?: string;
 }
 
 export interface NetCoreDockerDebugConfiguration extends DebugConfiguration {
@@ -199,7 +200,7 @@ export class NetCoreDebugHelper implements DebugHelper {
         const containerName: string = debugConfiguration.containerName ?? await this.getContainerNameToAttach();
 
         // If debugger path is not specified, install the debugger
-        const debuggerPath: string = debugConfiguration.debuggerPath ?? await this.installDebuggerInContainer(containerName);
+        const debuggerPath: string = debugConfiguration.netCore?.debuggerPath ?? await this.installDebuggerInContainer(containerName);
 
         return {
             ...debugConfiguration, // Gets things like name, preLaunchTask, serverReadyAction, etc.

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -6,8 +6,8 @@
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { DebugConfiguration } from 'vscode';
-import { IActionContext } from 'vscode-azureextensionui';
+import { DebugConfiguration, MessageItem, window } from 'vscode';
+import { DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { NetCoreTaskHelper, NetCoreTaskOptions } from '../../tasks/netcore/NetCoreTaskHelper';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
@@ -287,6 +287,12 @@ export class NetCoreDebugHelper implements DebugHelper {
     }
 
     private async installDebuggerInContainer(containerName: string): Promise<string> {
+        const yesItem: MessageItem = DialogResponses.yes;
+        const install = (yesItem === await window.showInformationMessage('Attaching to container requiers .NET Core debugger in the container. Do you want to install debugger in the container?', ...[DialogResponses.yes, DialogResponses.no]));
+        if (!install) {
+            throw new UserCancelledError("User didn't grand permission to install .NET Core debugger.");
+        }
+
         const debuggerPath: string = '/remote_debugger';
         const installUnZip: string = '/bin/sh -c "apt-get update && apt-get install unzip"';
         const installDebugger: string = `/bin/sh -c "curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${debuggerPath}"`;

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -7,12 +7,15 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import { DebugConfiguration } from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { NetCoreTaskHelper, NetCoreTaskOptions } from '../../tasks/netcore/NetCoreTaskHelper';
+import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { pathNormalize } from '../../utils/pathNormalize';
 import { PlatformOS } from '../../utils/platform';
 import { unresolveWorkspaceFolder } from '../../utils/resolveVariables';
 import { ChildProcessProvider } from '../coreclr/ChildProcessProvider';
+import CliDockerClient from '../coreclr/CliDockerClient';
 import { CommandLineDotNetClient } from '../coreclr/CommandLineDotNetClient';
 import { LocalFileSystemProvider } from '../coreclr/fsProvider';
 import { AspNetCoreSslManager, LocalAspNetCoreSslManager } from '../coreclr/LocalAspNetCoreSslManager';
@@ -22,7 +25,7 @@ import { DefaultOutputManager } from '../coreclr/outputManager';
 import { OSTempFileProvider } from '../coreclr/tempFileProvider';
 import { RemoteVsDbgClient, VsDbgClient } from '../coreclr/vsdbgClient';
 import { DebugHelper, DockerDebugContext, DockerDebugScaffoldContext, inferContainerName, ResolvedDebugConfiguration, resolveDockerServerReadyAction } from '../DebugHelper';
-import { DockerDebugConfiguration } from '../DockerDebugConfigurationProvider';
+import { DockerAttachConfiguration, DockerDebugConfiguration } from '../DockerDebugConfigurationProvider';
 
 export interface NetCoreDebugOptions extends NetCoreTaskOptions {
     appOutput?: string;
@@ -94,11 +97,34 @@ export class NetCoreDebugHelper implements DebugHelper {
                 netCore: {
                     appProject: unresolveWorkspaceFolder(options.appProject, context.folder)
                 }
+            },
+            {
+                name: 'Docker .NET Core Attach',
+                type: 'docker',
+                request: 'attach',
+                platform: 'netCore',
+                sourceFileMap: {
+                    // eslint-disable-next-line no-template-curly-in-string
+                    '/src': '${workspaceFolder}'
+                }
             }
         ];
     }
 
     public async resolveDebugConfiguration(context: DockerDebugContext, debugConfiguration: DockerDebugConfiguration): Promise<ResolvedDebugConfiguration | undefined> {
+        switch (debugConfiguration.request) {
+            case 'launch':
+                return this.resolveLauchDebugConfiguration(context, debugConfiguration);
+                break;
+            case 'attach':
+                return this.resolveAttachDebugConfiguration(context, debugConfiguration);
+                break;
+            default:
+                throw Error(`Unknown request ${debugConfiguration.request} specified in the debug config.`);
+        }
+    }
+
+    public async resolveLauchDebugConfiguration(context: DockerDebugContext, debugConfiguration: DockerDebugConfiguration): Promise<ResolvedDebugConfiguration | undefined> {
         debugConfiguration.netCore = debugConfiguration.netCore || {};
         debugConfiguration.netCore.appProject = await NetCoreTaskHelper.inferAppProject(context.folder, debugConfiguration.netCore); // This method internally checks the user-defined input first
 
@@ -167,6 +193,37 @@ export class NetCoreDebugHelper implements DebugHelper {
         };
     }
 
+    public async resolveAttachDebugConfiguration(context: DockerDebugContext, debugConfiguration: DockerAttachConfiguration): Promise<ResolvedDebugConfiguration | undefined> {
+        // TODO: Validate the target container OS and fail debugging
+        // Get Container Name if missing
+        const containerName: string = debugConfiguration.containerName ?? await this.getContainerNameToAttach();
+
+        // If debugger path is not specified, install the debugger
+        const debuggerFilePath: string = debugConfiguration.debuggerFilePath ?? await this.InstallDebuggerOnContainer(containerName);
+
+        return {
+            ...debugConfiguration, // Gets things like name, preLaunchTask, serverReadyAction, etc.
+            type: 'coreclr',
+            request: 'attach',
+            "justMyCode": false,
+            // if processId is specified in the debugConfiguration, then it will take precedences
+            // and processName will be ignored.
+            processName: debugConfiguration.processName || "dotnet",
+            pipeTransport: {
+                pipeProgram: 'docker',
+                pipeArgs: ['exec', '-i', containerName],
+                // eslint-disable-next-line no-template-curly-in-string
+                pipeCwd: '${workspaceFolder}',
+                debuggerPath: debuggerFilePath,
+                quoteArgs: false,
+            },
+            sourceFileMap: debugConfiguration.sourceFileMap || {
+                // eslint-disable-next-line no-template-curly-in-string
+                '/src': '${workspaceFolder}'
+            }
+        };
+    }
+
     public static getHostDebuggerPathBase(): string {
         return path.join(os.homedir(), '.vsdbg');
     }
@@ -227,6 +284,39 @@ export class NetCoreDebugHelper implements DebugHelper {
             path.posix.join('/app', relativePath);
 
         return pathNormalize(result, platformOS);
+    }
+
+    private async InstallDebuggerOnContainer(containerName: string): Promise<string> {
+        const debuggerPath: string = '/remote_debugger';
+        const installUnZip: string = '/bin/sh -c "apt-get update && apt-get install unzip"';
+        const installDebugger: string = `/bin/sh -c "curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${debuggerPath}"`;
+
+        const outputManager = new DefaultOutputManager(ext.outputChannel);
+        const dockerClient = new CliDockerClient(new ChildProcessProvider());
+        const options = { interactive: true };
+
+        await outputManager.performOperation(
+            'Installing the latest .NET Core debugger...',
+            async (output) => {
+                let result = await dockerClient.exec(containerName, installUnZip, options);
+                output.appendLine(result);
+                await dockerClient.exec(containerName, installDebugger, options);
+                output.appendLine(result);
+            },
+            'Debugger installed',
+            'Unable to install the .NET Core debugger.'
+        );
+
+        return `${debuggerPath}/vsdbg`;
+    }
+
+    private async getContainerNameToAttach(): Promise<string> {
+        const context: IActionContext = { telemetry: { properties: {}, measurements: {} }, errorHandling: { issueProperties: {} } };
+        const containerItem: ContainerTreeItem = await ext.containersTree.showTreeItemPicker(ContainerTreeItem.runningContainerRegExp, {
+            ...context,
+            noItemFoundErrorMessage: 'No running containers are availble to attach'
+        });
+        return containerItem.containerName;
     }
 }
 

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -199,22 +199,22 @@ export class NetCoreDebugHelper implements DebugHelper {
         const containerName: string = debugConfiguration.containerName ?? await this.getContainerNameToAttach();
 
         // If debugger path is not specified, install the debugger
-        const debuggerFilePath: string = debugConfiguration.debuggerFilePath ?? await this.InstallDebuggerOnContainer(containerName);
+        const debuggerPath: string = debugConfiguration.debuggerPath ?? await this.installDebuggerInContainer(containerName);
 
         return {
             ...debugConfiguration, // Gets things like name, preLaunchTask, serverReadyAction, etc.
             type: 'coreclr',
             request: 'attach',
-            "justMyCode": false,
+            'justMyCode': false,
             // if processId is specified in the debugConfiguration, then it will take precedences
             // and processName will be ignored.
-            processName: debugConfiguration.processName || "dotnet",
+            processName: debugConfiguration.processName || 'dotnet',
             pipeTransport: {
                 pipeProgram: 'docker',
                 pipeArgs: ['exec', '-i', containerName],
                 // eslint-disable-next-line no-template-curly-in-string
                 pipeCwd: '${workspaceFolder}',
-                debuggerPath: debuggerFilePath,
+                debuggerPath: debuggerPath,
                 quoteArgs: false,
             },
             sourceFileMap: debugConfiguration.sourceFileMap || {
@@ -286,7 +286,7 @@ export class NetCoreDebugHelper implements DebugHelper {
         return pathNormalize(result, platformOS);
     }
 
-    private async InstallDebuggerOnContainer(containerName: string): Promise<string> {
+    private async installDebuggerInContainer(containerName: string): Promise<string> {
         const debuggerPath: string = '/remote_debugger';
         const installUnZip: string = '/bin/sh -c "apt-get update && apt-get install unzip"';
         const installDebugger: string = `/bin/sh -c "curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${debuggerPath}"`;
@@ -314,7 +314,7 @@ export class NetCoreDebugHelper implements DebugHelper {
         const context: IActionContext = { telemetry: { properties: {}, measurements: {} }, errorHandling: { issueProperties: {} } };
         const containerItem: ContainerTreeItem = await ext.containersTree.showTreeItemPicker(ContainerTreeItem.runningContainerRegExp, {
             ...context,
-            noItemFoundErrorMessage: 'No running containers are availble to attach'
+            noItemFoundErrorMessage: 'No running containers are available to attach'
         });
         return containerItem.containerName;
     }


### PR DESCRIPTION
The existing commands 'Add Docker Files to Workspace...' and 'Initialize for Docker Debugging' will add a new debug launch config 'Docker .NET Core Attach'.
This launch config does the following as part of resolve
1. Ask user to select a running container, if it is not provided in the launch config.
2. Install the remote debugger, if the remote debug path is not provided in the launch config.
3. Generate a coreclr attach launch config which will handle the actual attach.

related to #1543 