### PR TITLE
Upgrade language server version to 0.0.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3156,39 +3156,40 @@
       }
     },
     "dockerfile-ast": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.16.tgz",
-      "integrity": "sha512-+HZToHjjiLPl46TqBrok5dMrg5oCkZFPSROMQjRmvin0zG4FxK0DJXTpV/CUPYY2zpmEvVza55XLwSHFx/xZMw==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.20.tgz",
+      "integrity": "sha512-VGFMBT0Av1Sk4SCjafsv2S/MCVy6+AuhLW+958wS2df86wb90JPl+WJXhTTGHk5DQVwQX0NoQQBzQQP1U7GaWg==",
       "requires": {
         "vscode-languageserver-types": "^3.5.0"
       }
     },
     "dockerfile-language-server-nodejs": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.21.tgz",
-      "integrity": "sha512-lZ7VFAlS4vTm5MvxmwpREcYMARB3RQaGX0OZdcY8oSytsu4i5mMGVa6mi9/pZ9soqcUC08uxEA8EcqIeL3lyAA==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.22.tgz",
+      "integrity": "sha512-Vf/Zieb/BBs/VQnaxntshlTExR3FyE6FO1NxS+yO3SVqzcEVHYkHMC8f/+XRRROVHFh41YfzVfPhSxdCxfbviQ==",
       "requires": {
-        "dockerfile-language-service": "0.0.8",
+        "dockerfile-language-service": "0.0.9",
         "dockerfile-utils": "0.0.11",
-        "vscode-languageserver": "^5.1.0"
+        "vscode-languageserver": "^6.1.0"
       }
     },
     "dockerfile-language-service": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.8.tgz",
-      "integrity": "sha512-peko1rQtZ81e3QK3VLZgkCKkCMnuoSqZxCQuudyEbtYqqAe6jJ4r0bwOnWD9hyH/FMg7jMvI5uLsoo7/dHLNYw==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.9.tgz",
+      "integrity": "sha512-g+TFMRG/Vv+yKqYJ2EE5KZlmwbPShWhlGhyG6tFEhUlHUt2Cd3wMr35popmc5Y9ra3OPwR3nY9cQFWIt8OP1Kw==",
       "requires": {
-        "dockerfile-ast": "0.0.16",
-        "dockerfile-utils": "0.0.13",
-        "vscode-languageserver-types": "^3.10.0"
+        "dockerfile-ast": "0.0.20",
+        "dockerfile-utils": "0.0.14",
+        "vscode-languageserver-protocol": "^3.15.1",
+        "vscode-languageserver-types": "^3.15.1"
       },
       "dependencies": {
         "dockerfile-utils": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.13.tgz",
-          "integrity": "sha512-+MAmhEnQ16B7+3C2UDWpmIS1D8EiKvpl4LDRjrMv94bOusaeRcLagRR0AvgV6NWT+oiRxDMLDyay6yjm6LESsw==",
+          "version": "0.0.14",
+          "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.14.tgz",
+          "integrity": "sha512-9S77f18SmnI4hJ1Ndv1h1/gPxm74uV/n9E/2JMp6I9D3cSLrNdBZwq3FpNiXX1TRJQAn+Ufl/5b7YzH63NZ6jA==",
           "requires": {
-            "dockerfile-ast": "0.0.16",
+            "dockerfile-ast": "0.0.20",
             "vscode-languageserver-types": "3.6.0"
           },
           "dependencies": {
@@ -3197,6 +3198,20 @@
               "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.0.tgz",
               "integrity": "sha512-GSgQtGmtza4PoNH0+iHWylWg/1sw2DODezqYWRxbN910dPchI3CQaSJN76csKcQGv55wsWgX82T6n74q8mFSpw=="
             }
+          }
+        },
+        "vscode-jsonrpc": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+          "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+        },
+        "vscode-languageserver-protocol": {
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.2.tgz",
+          "integrity": "sha512-GdL05JKOgZ76RDg3suiGCl9enESM7iQgGw4x93ibTh4sldvZmakHmTeZ4iUApPPGKf6O3OVBtrsksBXnHYaxNg==",
+          "requires": {
+            "vscode-jsonrpc": "^5.0.1",
+            "vscode-languageserver-types": "3.15.1"
           }
         }
       }
@@ -11044,71 +11059,56 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
     },
     "vscode-languageclient": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
-      "integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.0.tgz",
+      "integrity": "sha512-Tcp0VoOaa0YzxL4nEfK9tsmcy76Eo8jNLvFQZwh2c8oMm02luL8uGYPLQNAiZ3XGgegfcwiQFZMqbW7DNV0vxA==",
       "requires": {
-        "semver": "^5.5.0",
-        "vscode-languageserver-protocol": "3.14.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
+        "semver": "^6.3.0",
+        "vscode-languageserver-protocol": "^3.15.2"
       }
     },
     "vscode-languageserver": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz",
-      "integrity": "sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.1.0.tgz",
+      "integrity": "sha512-Q5kUJegYclTZMnKUaEcxJK41Ozp6qJhhoFJYj0w8y8j9JXdKT479LE945QCKRvSgWfsqTSUmgsozVTUIwQQxHw==",
       "requires": {
-        "vscode-languageserver-protocol": "3.14.1",
-        "vscode-uri": "^1.0.6"
+        "vscode-languageserver-protocol": "^3.15.2"
       },
       "dependencies": {
-        "vscode-languageserver-protocol": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-          "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
-          "requires": {
-            "vscode-jsonrpc": "^4.0.0",
-            "vscode-languageserver-types": "3.14.0"
-          }
+        "vscode-jsonrpc": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+          "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
         },
-        "vscode-languageserver-types": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-          "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+        "vscode-languageserver-protocol": {
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.2.tgz",
+          "integrity": "sha512-GdL05JKOgZ76RDg3suiGCl9enESM7iQgGw4x93ibTh4sldvZmakHmTeZ4iUApPPGKf6O3OVBtrsksBXnHYaxNg==",
+          "requires": {
+            "vscode-jsonrpc": "^5.0.1",
+            "vscode-languageserver-types": "3.15.1"
+          }
         }
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-      "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.2.tgz",
+      "integrity": "sha512-GdL05JKOgZ76RDg3suiGCl9enESM7iQgGw4x93ibTh4sldvZmakHmTeZ4iUApPPGKf6O3OVBtrsksBXnHYaxNg==",
       "requires": {
-        "vscode-jsonrpc": "^4.0.0",
-        "vscode-languageserver-types": "3.14.0"
-      },
-      "dependencies": {
-        "vscode-languageserver-types": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-          "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
-        }
+        "vscode-jsonrpc": "^5.0.1",
+        "vscode-languageserver-types": "3.15.1"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
-      "integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+      "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
     },
     "vscode-nls": {
       "version": "4.1.1",
@@ -11124,11 +11124,6 @@
         "http-proxy-agent": "^2.1.0",
         "https-proxy-agent": "^2.2.1"
       }
-    },
-    "vscode-uri": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.8.tgz",
-      "integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ=="
     },
     "watchpack": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -2035,7 +2035,7 @@
         "azure-storage": "^2.10.3",
         "deep-equal": "^1.1.1",
         "docker-modem": "^2.0.4",
-        "dockerfile-language-server-nodejs": "^0.0.21",
+        "dockerfile-language-server-nodejs": "^0.0.22",
         "dockerode": "^3.0.2",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.6",
@@ -2049,7 +2049,7 @@
         "tar": "^5.0.5",
         "vscode-azureappservice": "^0.54.0",
         "vscode-azureextensionui": "^0.29.5",
-        "vscode-languageclient": "^5.2.1",
+        "vscode-languageclient": "^6.1.0",
         "xml2js": "^0.4.22"
     }
 }


### PR DESCRIPTION
This pull request updates the language server to the newly released version 0.0.22. This update helps fix #1337 and #1492.

Otherwise, there aren't a lot of big changes here outside of newly added support for the `--platform` flag in `FROM` instructions which was introduced in Docker CE 18.04. However, judging by the fact that no one ever reported this, this clearly doesn't bother anyone here.

Please use the Dockerfile below to compare the before/after behaviours.
```Dockerfile
# escape=\
# escape=\
# declaring the escape parser directive two times will now be flagged as an error

# invoke code completion between FROM and scratch,
# you'll get the new --platform flag suggested
FROM       scratch

# hover over the --platform flag to get documentation
FROM --platform=arm64 scratch

# scratch is incorrectly flagged as an error
FROM --platform=arm64 scratch

# this incorrect PLATFORM flag name will be flagged as an error
# as it must be lowercase
FROM --PLATFORM= alpine

# this WORKDIR argument used to be a warning because of the quotes, see #1492
# https://github.com/microsoft/vscode-docker/issues/1492
WORKDIR "/src/."

# invoke code completion after the : to get Docker tag suggestions, see #1337
# https://github.com/microsoft/vscode-docker/issues/1337
FROM store/intersystems/iris-community:
```
This update also fixes a very, very obscure bug that you can replicate with the Dockerfile below. If you have this file open and use the "Output" panel to look at the logs of the "Dockerfile Language Server", you should see some errors. Feel free to take a look at rcjsuen/dockerfile-ast#66 if you are interested in the details (though as aforementioned it is very much an edge case that I don't expect the average user to encounter).
```Dockerfile
RUN alpin\
e
```