### PR TITLE
Show a warning with Learn More link if SSH is in use without a working ssh-agent

### DIFF
--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -3,8 +3,23 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export async function delay(ms: number): Promise<void> {
-    return new Promise<void>(resolve => {
-        setTimeout(() => { resolve(); }, ms);
+import * as vscode from 'vscode';
+
+export async function delay(ms: number, token?: vscode.CancellationToken): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        let cancellationListener: vscode.Disposable;
+
+        const timeout = setTimeout(() => {
+            cancellationListener?.dispose();
+            resolve();
+        }, ms);
+
+        if (token) {
+            cancellationListener = token.onCancellationRequested(() => {
+                cancellationListener.dispose();
+                clearTimeout(timeout);
+                reject();
+            });
+        }
     });
 }

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -10,6 +10,7 @@ export async function delay(ms: number, token?: vscode.CancellationToken): Promi
         let cancellationListener: vscode.Disposable;
 
         const timeout = setTimeout(() => {
+            /* eslint-disable-next-line no-unused-expressions */
             cancellationListener?.dispose();
             resolve();
         }, ms);

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -8,9 +8,3 @@ export async function delay(ms: number): Promise<void> {
         setTimeout(() => { resolve(); }, ms);
     });
 }
-
-export async function delayWithResult<T>(ms: number, result: T): Promise<T> {
-    return new Promise<T>(resolve => {
-        setTimeout(() => { resolve(result); }, ms);
-    });
-}

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -8,3 +8,9 @@ export async function delay(ms: number): Promise<void> {
         setTimeout(() => { resolve(); }, ms);
     });
 }
+
+export async function delayWithResult<T>(ms: number, result: T): Promise<T> {
+    return new Promise<T>(resolve => {
+        setTimeout(() => { resolve(result); }, ms);
+    });
+}

--- a/src/utils/refreshDockerode.ts
+++ b/src/utils/refreshDockerode.ts
@@ -9,7 +9,7 @@ import { Socket } from 'net';
 import { ext } from '../extensionVariables';
 import { addDockerSettingsToEnv } from './addDockerSettingsToEnv';
 import { cloneObject } from './cloneObject';
-import { delayWithResult } from './delay';
+import { delay } from './delay';
 import { isWindows } from './osUtils';
 import { execAsync } from './spawnAsync';
 
@@ -103,7 +103,7 @@ async function validateSshAuthSock(newEnv: NodeJS.ProcessEnv): Promise<boolean> 
     });
 
     // Unfortunately Socket.setTimeout() does not actually work when attempting to establish a connection, so we need to race
-    const result = await Promise.race([connectPromise, delayWithResult(1000, false)]);
+    const result = await Promise.race([connectPromise, delay(1000).then(() => false)]);
     authSock.end();
 
     return result;

--- a/src/utils/refreshDockerode.ts
+++ b/src/utils/refreshDockerode.ts
@@ -107,7 +107,11 @@ async function validateSshAuthSock(newEnv: NodeJS.ProcessEnv): Promise<boolean> 
     });
 
     // Unfortunately Socket.setTimeout() does not actually work when attempting to establish a connection, so we need to race
-    return await Promise.race([connectPromise, delay(1000, cts.token).then(() => false)]).finally(() => authSock.end());
+    return await Promise.race([connectPromise, delay(1000, cts.token).then(() => false)])
+        .finally(() => {
+            authSock.end();
+            cts.dispose();
+        });
 }
 
 async function getDefaultDockerContext(): Promise<DockerOptions | undefined> {

--- a/src/utils/refreshDockerode.ts
+++ b/src/utils/refreshDockerode.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Socket } from 'net';
-import { DockerOptions } from 'dockerode';
 import Dockerode = require('dockerode');
+import { DockerOptions } from 'dockerode';
+import { Socket } from 'net';
 import { ext } from '../extensionVariables';
 import { addDockerSettingsToEnv } from './addDockerSettingsToEnv';
 import { cloneObject } from './cloneObject';


### PR DESCRIPTION
Resolves #1458 with @zifik's suggestion. Because an ssh-agent is required by the `ssh2` Node package (used by Dockerode) when using an SSH connection to a remote Docker daemon, we will show a warning with a Learn More link if SSH is in use without a working ssh-agent.

The check is done by looking at the value for `SSH_AUTH_SOCK` (which on Windows can be defaulted to `\\.\pipe\openssh-ssh-agent`), and then trying to connect to that pipe to ensure it is actually working.

The warning:
![image](https://user-images.githubusercontent.com/36966225/74459811-eccaf000-4e59-11ea-9867-4c4a08b6198c.png)

The link: https://aka.ms/AA7assy