### PR TITLE
Add multi-select to context menu commands that most need it

### DIFF
--- a/src/commands/containers/removeContainer.ts
+++ b/src/commands/containers/removeContainer.ts
@@ -4,28 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import vscode = require('vscode');
-import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
+import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
-export async function removeContainer(context: IActionContext, node: ContainerTreeItem | undefined): Promise<void> {
-    let nodes: ContainerTreeItem[] = [];
-    if (node) {
-        nodes = [node];
-    } else {
-        nodes = await ext.containersTree.showTreeItemPicker(ContainerTreeItem.allContextRegExp, {
-            ...context,
-            canPickMany: true,
-            noItemFoundErrorMessage: 'No containers are available to remove'
-        });
-    }
+export async function removeContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
+    nodes = await multiSelectNodes(
+        { ...context, noItemFoundErrorMessage: 'No containers are available to remove' },
+        ext.containersTree,
+        ContainerTreeItem.allContextRegExp,
+        node,
+        nodes
+    );
 
     let confirmRemove: string;
-    if (nodes.length === 0) {
-        throw new UserCancelledError();
-    } else if (nodes.length === 1) {
-        node = nodes[0];
-        confirmRemove = `Are you sure you want to remove container "${node.label}"?`;
+    if (nodes.length === 1) {
+        confirmRemove = `Are you sure you want to remove container "${nodes[0].label}"?`;
     } else {
         confirmRemove = "Are you sure you want to remove selected containers?";
     }

--- a/src/commands/containers/restartContainer.ts
+++ b/src/commands/containers/restartContainer.ts
@@ -9,18 +9,16 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { callDockerodeWithErrorHandling } from '../../utils/callDockerodeWithErrorHandling';
+import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
-export async function restartContainer(context: IActionContext, node: ContainerTreeItem | undefined): Promise<void> {
-    let nodes: ContainerTreeItem[];
-    if (node) {
-        nodes = [node];
-    } else {
-        nodes = await ext.containersTree.showTreeItemPicker(/^(created|dead|exited|paused|running)Container$/i, {
-            ...context,
-            canPickMany: true,
-            noItemFoundErrorMessage: 'No containers are available to restart'
-        });
-    }
+export async function restartContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
+    nodes = await multiSelectNodes(
+        { ...context, noItemFoundErrorMessage: 'No containers are available to restart' },
+        ext.containersTree,
+        /^(created|dead|exited|paused|running)Container$/i,
+        node,
+        nodes
+    );
 
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Restarting Container(s)..." }, async () => {
         await Promise.all(nodes.map(async n => {

--- a/src/commands/containers/startContainer.ts
+++ b/src/commands/containers/startContainer.ts
@@ -9,18 +9,16 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { callDockerodeWithErrorHandling } from '../../utils/callDockerodeWithErrorHandling';
+import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
-export async function startContainer(context: IActionContext, node: ContainerTreeItem | undefined): Promise<void> {
-    let nodes: ContainerTreeItem[];
-    if (node) {
-        nodes = [node];
-    } else {
-        nodes = await ext.containersTree.showTreeItemPicker(/^(created|dead|exited|paused)Container$/i, {
-            ...context,
-            canPickMany: true,
-            noItemFoundErrorMessage: 'No containers are available to start'
-        });
-    }
+export async function startContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
+    nodes = await multiSelectNodes(
+        { ...context, noItemFoundErrorMessage: 'No containers are available to start' },
+        ext.containersTree,
+        /^(created|dead|exited|paused)Container$/i,
+        node,
+        nodes
+    );
 
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Starting Container(s)..." }, async () => {
         await Promise.all(nodes.map(async n => {

--- a/src/commands/containers/stopContainer.ts
+++ b/src/commands/containers/stopContainer.ts
@@ -9,18 +9,16 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { callDockerodeWithErrorHandling } from '../../utils/callDockerodeWithErrorHandling';
+import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
-export async function stopContainer(context: IActionContext, node: ContainerTreeItem | undefined): Promise<void> {
-    let nodes: ContainerTreeItem[];
-    if (node) {
-        nodes = [node];
-    } else {
-        nodes = await ext.containersTree.showTreeItemPicker(/^(paused|restarting|running)Container$/i, {
-            ...context,
-            canPickMany: true,
-            noItemFoundErrorMessage: 'No containers are availble to stop'
-        });
-    }
+export async function stopContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
+    nodes = await multiSelectNodes(
+        { ...context, noItemFoundErrorMessage: 'No containers are availble to stop' },
+        ext.containersTree,
+        /^(paused|restarting|running)Container$/i,
+        node,
+        nodes
+    );
 
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Stopping Container(s)..." }, async () => {
         await Promise.all(nodes.map(async n => {

--- a/src/commands/images/removeImage.ts
+++ b/src/commands/images/removeImage.ts
@@ -4,29 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import vscode = require('vscode');
-import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
+import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
-export async function removeImage(context: IActionContext, node: ImageTreeItem | undefined): Promise<void> {
-    let nodes: ImageTreeItem[] = [];
-    if (node) {
-        nodes = [node];
-    } else {
-        nodes = await ext.imagesTree.showTreeItemPicker(ImageTreeItem.contextValue, {
-            ...context,
-            canPickMany: true,
-            suppressCreatePick: true,
-            noItemFoundErrorMessage: 'No images are available to remove'
-        });
-    }
+export async function removeImage(context: IActionContext, node?: ImageTreeItem, nodes?: ImageTreeItem[]): Promise<void> {
+    nodes = await multiSelectNodes(
+        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: 'No images are available to remove' },
+        ext.imagesTree,
+        new RegExp(ImageTreeItem.contextValue, 'i'),
+        node,
+        nodes
+    );
 
     let confirmRemove: string;
-    if (nodes.length === 0) {
-        throw new UserCancelledError();
-    } else if (nodes.length === 1) {
-        node = nodes[0];
-        confirmRemove = `Are you sure you want to remove image "${node.label}"? This will remove all matching and child images.`;
+    if (nodes.length === 1) {
+        confirmRemove = `Are you sure you want to remove image "${nodes[0].label}"? This will remove all matching and child images.`;
     } else {
         confirmRemove = "Are you sure you want to remove selected images? This will remove all matching and child images.";
     }

--- a/src/commands/networks/removeNetwork.ts
+++ b/src/commands/networks/removeNetwork.ts
@@ -4,29 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import vscode = require('vscode');
-import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { NetworkTreeItem } from '../../tree/networks/NetworkTreeItem';
+import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
-export async function removeNetwork(context: IActionContext, node: NetworkTreeItem | undefined): Promise<void> {
-    let nodes: NetworkTreeItem[] = [];
-    if (node) {
-        nodes = [node];
-    } else {
-        nodes = await ext.networksTree.showTreeItemPicker(NetworkTreeItem.contextValue, {
-            ...context,
-            canPickMany: true,
-            suppressCreatePick: true,
-            noItemFoundErrorMessage: 'No networks are available to remove'
-        });
-    }
+export async function removeNetwork(context: IActionContext, node?: NetworkTreeItem, nodes?: NetworkTreeItem[]): Promise<void> {
+    nodes = await multiSelectNodes(
+        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: 'No networks are available to remove' },
+        ext.networksTree,
+        new RegExp(NetworkTreeItem.contextValue, 'i'),
+        node,
+        nodes
+    );
 
     let confirmRemove: string;
-    if (nodes.length === 0) {
-        throw new UserCancelledError();
-    } else if (nodes.length === 1) {
-        node = nodes[0];
-        confirmRemove = `Are you sure you want to remove network "${node.label}"?`;
+    if (nodes.length === 1) {
+        confirmRemove = `Are you sure you want to remove network "${nodes[0].label}"?`;
     } else {
         confirmRemove = "Are you sure you want to remove selected networks?";
     }

--- a/src/commands/volumes/removeVolume.ts
+++ b/src/commands/volumes/removeVolume.ts
@@ -4,29 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import vscode = require('vscode');
-import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { VolumeTreeItem } from '../../tree/volumes/VolumeTreeItem';
+import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
-export async function removeVolume(context: IActionContext, node: VolumeTreeItem | undefined): Promise<void> {
-    let nodes: VolumeTreeItem[] = [];
-    if (node) {
-        nodes = [node];
-    } else {
-        nodes = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, {
-            ...context,
-            canPickMany: true,
-            suppressCreatePick: true,
-            noItemFoundErrorMessage: 'No volumes are available to remove'
-        });
-    }
+export async function removeVolume(context: IActionContext, node?: VolumeTreeItem, nodes?: VolumeTreeItem[]): Promise<void> {
+    nodes = await multiSelectNodes(
+        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: 'No volumes are available to remove' },
+        ext.volumesTree,
+        new RegExp(VolumeTreeItem.contextValue, 'i'),
+        node,
+        nodes
+    );
 
     let confirmRemove: string;
-    if (nodes.length === 0) {
-        throw new UserCancelledError();
-    } else if (nodes.length === 1) {
-        node = nodes[0];
-        confirmRemove = `Are you sure you want to remove volume "${node.label}"?`;
+    if (nodes.length === 1) {
+        confirmRemove = `Are you sure you want to remove volume "${nodes[0].label}"?`;
     } else {
         confirmRemove = "Are you sure you want to remove selected volumes?";
     }

--- a/src/tree/registerTrees.ts
+++ b/src/tree/registerTrees.ts
@@ -17,7 +17,7 @@ export function registerTrees(): void {
     ext.containersRoot = new ContainersTreeItem(undefined);
     const containersLoadMore = 'vscode-docker.containers.loadMore';
     ext.containersTree = new AzExtTreeDataProvider(ext.containersRoot, containersLoadMore);
-    ext.containersTreeView = window.createTreeView('dockerContainers', { treeDataProvider: ext.containersTree });
+    ext.containersTreeView = window.createTreeView('dockerContainers', { treeDataProvider: ext.containersTree, canSelectMany: true });
     ext.context.subscriptions.push(ext.containersTreeView);
     ext.containersRoot.registerRefreshEvents(ext.containersTreeView);
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
@@ -27,7 +27,7 @@ export function registerTrees(): void {
     ext.networksRoot = new NetworksTreeItem(undefined);
     const networksLoadMore = 'vscode-docker.networks.loadMore';
     ext.networksTree = new AzExtTreeDataProvider(ext.networksRoot, networksLoadMore);
-    ext.networksTreeView = window.createTreeView('dockerNetworks', { treeDataProvider: ext.networksTree });
+    ext.networksTreeView = window.createTreeView('dockerNetworks', { treeDataProvider: ext.networksTree, canSelectMany: true });
     ext.context.subscriptions.push(ext.networksTreeView);
     ext.networksRoot.registerRefreshEvents(ext.networksTreeView);
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
@@ -37,7 +37,7 @@ export function registerTrees(): void {
     ext.imagesRoot = new ImagesTreeItem(undefined);
     const imagesLoadMore = 'vscode-docker.images.loadMore';
     ext.imagesTree = new AzExtTreeDataProvider(ext.imagesRoot, imagesLoadMore);
-    ext.imagesTreeView = window.createTreeView('dockerImages', { treeDataProvider: ext.imagesTree });
+    ext.imagesTreeView = window.createTreeView('dockerImages', { treeDataProvider: ext.imagesTree, canSelectMany: true });
     ext.context.subscriptions.push(ext.imagesTreeView);
     ext.imagesRoot.registerRefreshEvents(ext.imagesTreeView);
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
@@ -47,7 +47,7 @@ export function registerTrees(): void {
     ext.registriesRoot = new RegistriesTreeItem();
     const registriesLoadMore = 'vscode-docker.registries.loadMore';
     ext.registriesTree = new AzExtTreeDataProvider(ext.registriesRoot, registriesLoadMore);
-    ext.registriesTreeView = window.createTreeView('dockerRegistries', { treeDataProvider: ext.registriesTree, showCollapseAll: true });
+    ext.registriesTreeView = window.createTreeView('dockerRegistries', { treeDataProvider: ext.registriesTree, showCollapseAll: true, canSelectMany: false });
     ext.context.subscriptions.push(ext.registriesTreeView);
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
     registerCommand(registriesLoadMore, (context: IActionContext, node: AzExtTreeItem) => ext.registriesTree.loadMore(node, context));
@@ -56,7 +56,7 @@ export function registerTrees(): void {
     ext.volumesRoot = new VolumesTreeItem(undefined);
     const volumesLoadMore = 'vscode-docker.volumes.loadMore';
     ext.volumesTree = new AzExtTreeDataProvider(ext.volumesRoot, volumesLoadMore);
-    ext.volumesTreeView = window.createTreeView('dockerVolumes', { treeDataProvider: ext.volumesTree });
+    ext.volumesTreeView = window.createTreeView('dockerVolumes', { treeDataProvider: ext.volumesTree, canSelectMany: true });
     ext.context.subscriptions.push(ext.volumesTreeView);
     ext.volumesRoot.registerRefreshEvents(ext.volumesTreeView);
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */

--- a/src/utils/multiSelectNodes.ts
+++ b/src/utils/multiSelectNodes.ts
@@ -37,7 +37,7 @@ export async function multiSelectNodes<T extends AzExtTreeItem>(
     }
 
     // Filter off parent items (i.e. group items), as it doesn't make sense to perform actions on them, when we don't allow actions to be performed on *only* them
-    nodes.filter(n => !(n instanceof AzExtParentTreeItem));
+    nodes = nodes.filter(n => !(n instanceof AzExtParentTreeItem));
 
     // If we end with no nodes, cancel
     if (nodes.length === 0) {

--- a/src/utils/multiSelectNodes.ts
+++ b/src/utils/multiSelectNodes.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtTreeItem, ITreeItemPickerContext, AzExtTreeDataProvider, UserCancelledError } from "vscode-azureextensionui";
+import { AzExtTreeItem, ITreeItemPickerContext, AzExtTreeDataProvider, UserCancelledError, AzExtParentTreeItem } from "vscode-azureextensionui";
 
 /**
  * Helps determine the full list of eligible selected tree item nodes for context menu and commands
@@ -35,6 +35,9 @@ export async function multiSelectNodes<T extends AzExtTreeItem>(
         // Otherwise if there's a filter, need to filter our selection to exclude ineligible nodes
         nodes = nodes.filter(n => expectedContextValue.test(n.contextValue));
     }
+
+    // Filter off parent items (i.e. group items), as it doesn't make sense to perform actions on them, when we don't allow actions to be performed on *only* them
+    nodes.filter(n => !(n instanceof AzExtParentTreeItem));
 
     // If we end with no nodes, cancel
     if (nodes.length === 0) {

--- a/src/utils/multiSelectNodes.ts
+++ b/src/utils/multiSelectNodes.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtTreeItem, ITreeItemPickerContext, AzExtTreeDataProvider, UserCancelledError } from "vscode-azureextensionui";
+
+/**
+ * Helps determine the full list of eligible selected tree item nodes for context menu and commands
+ * @param context Tree item context
+ * @param tree The tree for which to show an item picker (if no nodes were selected, i.e. it was run as a command, not context menu action)
+ * @param expectedContextValue Filters to allow an action only for specific context values
+ * @param node The primary selected node (if any)
+ * @param nodes All selected nodes. VSCode includes the primary by default, only if multiple were selected.
+ */
+export async function multiSelectNodes<T extends AzExtTreeItem>(
+    context: ITreeItemPickerContext,
+    tree: AzExtTreeDataProvider,
+    expectedContextValue?: RegExp,
+    node?: T,
+    nodes?: T[]): Promise<T[]> {
+
+    // Ensure it's not undefined
+    nodes = nodes || [];
+
+    if (nodes.length === 0 && node) {
+        // If there's no multi-selected nodes but primary node is defined, use it as the only element
+        nodes = [node];
+    }
+
+    if (nodes.length === 0) {
+        // If still no selected nodes, need to prompt
+        nodes = await tree.showTreeItemPicker<T>(expectedContextValue, { ...context, canPickMany: true });
+    } else if (expectedContextValue) {
+        // Otherwise if there's a filter, need to filter our selection to exclude ineligible nodes
+        nodes = nodes.filter(n => expectedContextValue.test(n.contextValue));
+    }
+
+    // If we end with no nodes, cancel
+    if (nodes.length === 0) {
+        throw new UserCancelledError();
+    }
+
+    return nodes;
+}

--- a/src/utils/multiSelectNodes.ts
+++ b/src/utils/multiSelectNodes.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtTreeItem, ITreeItemPickerContext, AzExtTreeDataProvider, UserCancelledError, AzExtParentTreeItem } from "vscode-azureextensionui";
+import { AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, ITreeItemPickerContext, UserCancelledError } from "vscode-azureextensionui";
 
 /**
  * Helps determine the full list of eligible selected tree item nodes for context menu and commands


### PR DESCRIPTION
Fixes #331, fixes #1453.

This PR is similar to #1620 (and also covers what #1494 does) but adds multi-select support to all of the explorer groups (except Registries), with multi-select support for the following commands:

Containers, Images, Networks, Volumes: Remove
Containers only: Start, Stop, Restart

It also will filter off nodes for which the action taken is not eligible (for example, parent nodes, or stopping an already-stopped container). Unfortunately it shows actions for whatever was the specific item in the selection set that was right-clicked (not actions that are valid for _all_ selected items) but we think that for the most part that will not be an issue.

Some of the remaining commands do not make sense as a multi-select (for example, Image > Copy full tag), some of the others _maybe_ make sense but we are leaving them as single-select at this time (for example, Inspect).