### PR TITLE
.Net Core compose support

### DIFF
--- a/src/configureWorkspace/configure.ts
+++ b/src/configureWorkspace/configure.ts
@@ -349,7 +349,7 @@ async function configureCore(context: ScaffolderContext, options: ConfigureApiOp
     let generateComposeFiles = true;
 
     if (platformType === 'Node.js') {
-        generateComposeFiles = await context.captureStep('compose', quickPickGenerateComposeFiles)();
+        generateComposeFiles = await context.promptForCompose();
         if (generateComposeFiles) {
             properties.orchestration = 'docker-compose';
         }

--- a/src/configureWorkspace/configure.ts
+++ b/src/configureWorkspace/configure.ts
@@ -19,7 +19,7 @@ import { configureNode } from './configureNode';
 import { configureOther } from './configureOther';
 import { configurePython } from './configurePython';
 import { configureRuby } from './configureRuby';
-import { ConfigureTelemetryProperties, genCommonDockerIgnoreFile, getSubfolderDepth, quickPickGenerateComposeFiles } from './configUtils';
+import { ConfigureTelemetryProperties, genCommonDockerIgnoreFile, getSubfolderDepth } from './configUtils';
 import { registerScaffolder, scaffold, Scaffolder, ScaffolderContext, ScaffoldFile } from './scaffolding';
 
 export interface PackageInfo {

--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -286,7 +286,7 @@ ${portsArray}`;
     }
 
     let environmentVariables: string = '';
-    if (platform === 'ASP.NET Core') {
+    if (platform === '.NET: ASP.NET Core') {
         environmentVariables = `    environment:
       - ASPNETCORE_ENVIRONMENT=Development`;
         // For now assume the first port is http and the second is https. (default scaffolding behavior)

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -1398,7 +1398,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                             os: "Linux",
                             ports: [1234]
                         },
-                        ['.NET Core Console'],
+                        ['.NET Core Console', 'No'],
                         ['serviceFolder/Dockerfile', 'serviceFolder/.dockerignore', 'serviceFolder/somefile1.cs', 'serviceFolder/aspnetapp.csproj']
                     );
                     assertFileContains('serviceFolder/Dockerfile', 'ENTRYPOINT ["dotnet", "aspnetapp.dll"]');
@@ -1417,7 +1417,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                             os: "Windows",
                             ports: [1234]
                         },
-                        ['.NET Core Console'],
+                        ['.NET Core Console', 'No'],
                         ['serviceFolder/Dockerfile', 'serviceFolder/.dockerignore', 'serviceFolder/subfolder1/somefile1.cs', 'serviceFolder/subfolder1/aspnetapp.csproj']
                     );
                     assertFileContains('serviceFolder/Dockerfile', 'ENTRYPOINT ["dotnet", "aspnetapp.dll"]');
@@ -1435,7 +1435,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                             os: "Windows",
                             ports: [1234, 5678]
                         },
-                        ['ASP.NET Core'], ['serviceFolder/subfolder1/Dockerfile', 'serviceFolder/subfolder1/.dockerignore', 'serviceFolder/subfolder1/somefile1.cs', 'serviceFolder/subfolder1/aspnetapp.csproj']
+                        ['ASP.NET Core', 'No'], ['serviceFolder/subfolder1/Dockerfile', 'serviceFolder/subfolder1/.dockerignore', 'serviceFolder/subfolder1/somefile1.cs', 'serviceFolder/subfolder1/aspnetapp.csproj']
                     );
                     assertFileContains('serviceFolder/subfolder1/Dockerfile', 'ENTRYPOINT ["dotnet", "aspnetapp.dll"]');
                 });

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -403,7 +403,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     packageFileType: '.csproj',
                     packageFileSubfolderDepth: projectFolder.includes('/') ? '2' : '1'
                 },
-                [os /* it doesn't ask for a port, so we don't specify one here */],
+                [os, 'No' /* it doesn't ask for a port, so we don't specify one here */],
                 [`${projectFolder}/Dockerfile`, '.dockerignore', `${projectFolder}/Program.cs`, `${projectFolder}/${projectFileName}`]
             );
 
@@ -434,7 +434,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     packageFileType: '.csproj',
                     packageFileSubfolderDepth: '1'
                 },
-                [os, '1234'],
+                [os, 'No', '1234'],
                 [`${projectFolder}/Dockerfile`, '.dockerignore', `${projectFolder}/Program.cs`, `${projectFolder}/${projectFileName}`]
             );
 
@@ -632,14 +632,14 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                         packageFileType: undefined,
                         packageFileSubfolderDepth: undefined
                     },
-                    ['Windows']
+                    ['Windows', 'No']
                 ),
                 { message: "No .csproj or .fsproj file could be found. You need a C# or F# project file in the workspace to generate Docker files for the selected platform." }
             );
         });
 
         testInEmptyFolder("ASP.NET Core no project file", async () => {
-            await assertEx.throwsOrRejectsAsync(async () => testConfigureDocker('ASP.NET Core', {}, ['Windows', '1234']),
+            await assertEx.throwsOrRejectsAsync(async () => testConfigureDocker('ASP.NET Core', {}, ['Windows', 'No', '1234']),
                 { message: "No .csproj or .fsproj file could be found. You need a C# or F# project file in the workspace to generate Docker files for the selected platform." }
             );
         });
@@ -655,7 +655,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     packageFileType: '.csproj',
                     packageFileSubfolderDepth: '1'
                 },
-                ['Windows', 'projectFolder2/aspnetapp.csproj'],
+                ['Windows', 'No', 'projectFolder2/aspnetapp.csproj'],
                 ['projectFolder2/Dockerfile', '.dockerignore', 'projectFolder1/aspnetapp.csproj', 'projectFolder2/aspnetapp.csproj']
             );
 
@@ -872,7 +872,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             await testConfigureDocker(
                 'ASP.NET Core',
                 undefined,
-                ['Windows', TestInput.UseDefaultValue]
+                ['Windows', 'No', TestInput.UseDefaultValue]
             );
 
             assertFileContains('projectFolder1/Dockerfile', 'EXPOSE 80');
@@ -883,7 +883,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             await testConfigureDocker(
                 'ASP.NET Core',
                 undefined,
-                ['Windows', '']
+                ['Windows', 'No', '']
             );
 
             assertNotFileContains('projectFolder1/Dockerfile', 'EXPOSE');
@@ -1355,6 +1355,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                         os: "Linux"
                     },
                     [
+                        'No',
                         'projectFolder2/aspnetapp.csproj'
                     ],
                     ['Dockerfile', '.dockerignore', 'projectFolder1/aspnetapp.csproj', 'projectFolder2/aspnetapp.csproj']


### PR DESCRIPTION
Now the dotnet core scaffolding will ask whether to generate compose files or not similar to node.js.
If an existing compose file is present, it will create docker-compose(n).yaml