### PR TITLE
Suppress report issue on Add Docker Files when no workspace is open

### DIFF
--- a/src/configureWorkspace/scaffolding.ts
+++ b/src/configureWorkspace/scaffolding.ts
@@ -105,7 +105,16 @@ export async function scaffold(context: ScaffoldContext): Promise<ScaffoldedFile
         return captureCancelStep(step, context.telemetry.properties, prompt);
     }
 
-    const folder = context.folder ?? await captureStep('folder', promptForFolder)();
+    let folder: vscode.WorkspaceFolder;
+
+    try {
+        folder = context.folder ?? await captureStep('folder', promptForFolder)();
+    } catch (err) {
+        // Suppress reporting issues due to high volume
+        context.errorHandling.suppressReportIssue = true;
+        throw err;
+    }
+
     const rootFolder = context.rootFolder ?? folder.uri.fsPath;
     const telemetryProperties = <ConfigureTelemetryProperties>context.telemetry.properties;
 


### PR DESCRIPTION
We get a fairly large number of spurious issues (e.g. #1559, #1628, #1629, and more) that occur because the user has not opened a workspace folder. This is not a bug and therefore should not have the Report Issue button.