### PR TITLE
Adds "active use" tracking for survey purposes (#1626)

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -43,4 +43,9 @@ export { trimWithElipsis } from './src/utils/trimWithElipsis';
 export { recursiveFindTaskByType } from './src/tasks/TaskHelper';
 export { TaskDefinitionBase } from './src/tasks/TaskDefinitionBase';
 export { DebugConfigurationBase } from './src/debugging/DockerDebugConfigurationBase';
+export { TelemetryPublisher } from './src/telemetry/TelemetryPublisher';
+export { TelemetryReporterProxy } from './src/telemetry/TelemetryReporterProxy';
+export { ITelemetryPublisher, TelemetryEvent } from './src/telemetry/TelemetryPublisher';
+export { activeUseSurvey } from './src/telemetry/surveys/activeUseSurvey';
+
 export * from 'vscode-azureextensionui';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,9 @@ import { DockerfileCompletionItemProvider } from './dockerfileCompletionItemProv
 import { ext } from './extensionVariables';
 import { registerListeners } from './registerListeners';
 import { registerTaskProviders } from './tasks/TaskHelper';
+import { registerActiveUseSurvey } from './telemetry/surveys/activeUseSurvey';
+import { TelemetryPublisher } from './telemetry/TelemetryPublisher';
+import { TelemetryReporterProxy } from './telemetry/TelemetryReporterProxy';
 import { registerTrees } from './tree/registerTrees';
 import { AzureAccountExtensionListener } from './utils/AzureAccountExtensionListener';
 import { Keytar } from './utils/keytar';
@@ -57,7 +60,13 @@ function initializeExtensionVariables(ctx: vscode.ExtensionContext): void {
     if (!ext.terminalProvider) {
         ext.terminalProvider = new DefaultTerminalProvider();
     }
-    ext.reporter = createTelemetryReporter(ctx);
+
+    const publisher = new TelemetryPublisher();
+    ctx.subscriptions.push(publisher);
+
+    ctx.subscriptions.push(registerActiveUseSurvey(publisher, ctx.globalState));
+
+    ext.reporter = new TelemetryReporterProxy(publisher, createTelemetryReporter(ctx));
     if (!ext.keytar) {
         ext.keytar = Keytar.tryCreate();
     }

--- a/src/telemetry/TelemetryPublisher.ts
+++ b/src/telemetry/TelemetryPublisher.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export interface TelemetryEvent {
+    eventName: string;
+    measurements?: { [key: string]: number };
+    properties?: { [key: string]: string };
+}
+
+export interface ITelemetryPublisher {
+    onEvent: vscode.Event<TelemetryEvent>;
+    publishEvent(event: TelemetryEvent): void;
+}
+
+export class TelemetryPublisher extends vscode.Disposable implements ITelemetryPublisher {
+    private readonly onEventEmitter: vscode.EventEmitter<TelemetryEvent>;
+
+    public constructor() {
+        super(() => this.onEventEmitter.dispose());
+
+        this.onEventEmitter = new vscode.EventEmitter<TelemetryEvent>();
+    }
+
+    public get onEvent(): vscode.Event<TelemetryEvent> {
+        return this.onEventEmitter.event;
+    }
+
+    public publishEvent(event: TelemetryEvent): void {
+        this.onEventEmitter.fire(event);
+    }
+}

--- a/src/telemetry/TelemetryReporterProxy.ts
+++ b/src/telemetry/TelemetryReporterProxy.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITelemetryReporter } from "vscode-azureextensionui";
+import { ITelemetryPublisher } from "./TelemetryPublisher";
+
+export class TelemetryReporterProxy implements ITelemetryReporter {
+    public constructor(
+        private readonly publisher: ITelemetryPublisher,
+        private readonly wrappedReporter: ITelemetryReporter) {
+    }
+
+    public sendTelemetryEvent(eventName: string, properties?: { [key: string]: string; }, measurements?: { [key: string]: number; }): void {
+        this.wrappedReporter.sendTelemetryEvent(eventName, properties, measurements);
+
+        this.publisher.publishEvent({
+            eventName,
+            measurements,
+            properties
+        });
+    }
+}

--- a/src/telemetry/surveys/activeUseSurvey.ts
+++ b/src/telemetry/surveys/activeUseSurvey.ts
@@ -1,0 +1,193 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { ext } from 'vscode-azureappservice/out/src/extensionVariables';
+import { ITelemetryPublisher } from '../TelemetryPublisher';
+
+const surveyUrl = 'https://aka.ms/vscodedockeractiveusesurvey';
+const lastUseDateKey = 'telemetry.surveys.activeUseSurvey.lastUseDate';
+const isCandidateKey = 'telemetry.surveys.activeUseSurvey.isCandidate';
+const useLimitInDays = 22;
+
+function getIsoDateString(date: Date): string {
+    const isoString = date.toISOString();
+
+    return isoString.split('T')[0];
+}
+
+function getIsoDate(clock: () => Date): Date {
+    const now = clock();
+    const isoDateString = getIsoDateString(now);
+
+    return new Date(isoDateString);
+}
+
+function isEnglishLanguage(): boolean {
+    return vscode.env.language === 'en' || vscode.env.language.startsWith('en-');
+}
+
+function select25Percent(): boolean {
+    // tslint:disable-next-line: insecure-random
+    return Math.random() < 0.25; // Select 25% of eligible candidates.
+}
+
+async function surveyPrompt(): Promise<boolean> {
+    const prompt = 'We noticed you haven’t used the Docker extension lately, would you take a quick survey?';
+    const yes = { title: 'Yes' };
+    const no = { title: 'No' };
+
+    const result = (await vscode.window.showInformationMessage(prompt, yes, no)) ?? no;
+
+    return result === yes;
+}
+
+async function surveyOpen(): Promise<void> {
+    await vscode.env.openExternal(vscode.Uri.parse(`${surveyUrl}?o=${encodeURIComponent(process.platform)}&m=${encodeURIComponent(vscode.env.machineId)}`));
+}
+
+function tryUpdate(state: vscode.Memento, key: string, value: unknown): void {
+    state.update(lastUseDateKey, value).then(() => {}, () => {});
+}
+
+function sendSurveyTelemetryEvent(eventName: string, properties?: { [key: string]: string }): void {
+    // NOTE: isActivationEvent must be 'true' to avoid survey telemetry being counted as "real" use.
+    ext.reporter.sendTelemetryEvent(eventName, { isActivationEvent: 'true', ...(properties ?? {}) });
+}
+
+export class ActiveUseSurveyDisposable extends vscode.Disposable {
+    public constructor(public readonly postActivationTask: Promise<void>, postActivationTimer: NodeJS.Timeout, telemetryListener: vscode.Disposable) {
+        super(
+            () => {
+                clearTimeout(postActivationTimer);
+
+                telemetryListener.dispose();
+            });
+    }
+}
+
+// tslint:disable-next-line: max-func-body-length
+export function activeUseSurvey(activationDelay: number, clock: () => Date, isChosenLanguage: () => boolean, publisher: ITelemetryPublisher, selector: () => boolean, state: vscode.Memento, promptForSurvey: () => Promise<boolean>, openSurvey: () => Promise<void>): ActiveUseSurveyDisposable {
+    try {
+        const activationDate = getIsoDate(clock);
+
+        const lastUseDateString = state.get<string>(lastUseDateKey);
+
+        let lastUseDate: Date;
+
+        if (lastUseDateString) {
+            lastUseDate = new Date(lastUseDateString);
+        } else {
+            //
+            // This is (likely) the first activation of the extension; consider "last use" to be the same as this activation date, for use in future activations.
+            //
+
+            lastUseDate = activationDate;
+
+            tryUpdate(state, lastUseDateKey, getIsoDateString(lastUseDate));
+        }
+
+        //
+        // If the user invoked a command that caused the extension to be activated, the activation would be followed by activation events and then "real use" events.
+        // It would be weird to ask the user "why aren't you using our tools" immediately after the user *just used our tools*. Hence, we wait for a period to allow
+        // those events to flow through, potentially resetting the last use date, before checking whether the survey prompt is needed.
+        //
+
+        let postActivationTimer: NodeJS.Timeout;
+
+        const postActivationTask = new Promise<void>(
+            resolve => {
+                postActivationTimer = setTimeout(
+                    async () => {
+                        try {
+                            const activationTime = activationDate.getTime();
+                            const lastUseTime = lastUseDate.getTime();
+                            const useLimitTime = useLimitInDays * 24 * 60 * 60 * 1000; // day * hour/day * min/hour * sec/min * ms/sec
+                            const inactiveTime = activationTime - lastUseTime;
+
+                            // Has it been more than X number of days since the last "real use" by the user?
+                            if (inactiveTime >= useLimitTime) {
+                                sendSurveyTelemetryEvent('surveys.activeUseSurvey.inactive', { inactiveTimeInMs: inactiveTime.toString() })
+
+                                // Is the user a known candidate (or not)?
+                                let isCandidate = state.get<boolean>(isCandidateKey);
+
+                                // If undecided, run the user through the selection process...
+                                if (isCandidate === undefined) {
+                                    isCandidate = selector();
+
+                                    // ...and update the user as a known candidate (or not).
+                                    await state.update(isCandidateKey, isCandidate);
+                                }
+
+                                // Is the user (assumed to be) a speaker of the survey-chosen language?
+                                // NOTE: The user remains a candidate in case she switches languages.
+                                if (!isChosenLanguage()) {
+                                    isCandidate = false;
+                                }
+
+                                // Is the user still considered a candidate?
+                                if (isCandidate) {
+                                    sendSurveyTelemetryEvent('surveys.activeUseSurvey.eligibleCandidate');
+
+                                    const response = await promptForSurvey();
+
+                                    // Regardless of the response, user is no longer a candidate.
+                                    await state.update(isCandidateKey, false);
+
+                                    //
+                                    // NOTE: The prompt only resolves if the user actually responds.
+                                    //
+
+                                    if (response) {
+                                        await openSurvey();
+                                    }
+
+                                    sendSurveyTelemetryEvent('surveys.activeUseSurvey.response', { response: response.toString() });
+                                }
+                            }
+                        } catch {
+                            // NOTE: Best effort.
+                        }
+
+                        resolve();
+                    },
+                    activationDelay);
+            });
+
+        const telemetryListener = publisher.onEvent(
+            event => {
+                try {
+                    if (event.properties?.isActivationEvent !== 'true') {
+                        const eventDate = getIsoDate(clock);
+
+                        if (lastUseDate.getTime() !== eventDate.getTime()) {
+                            lastUseDate = eventDate;
+
+                            tryUpdate(state, lastUseDateKey, getIsoDateString(lastUseDate));
+                        }
+                    }
+                } catch {
+                    // NOTE: Best effort.
+                }
+            });
+
+        return new ActiveUseSurveyDisposable(postActivationTask, postActivationTimer, telemetryListener);
+    } catch {
+        // NOTE: Best effort.
+    }
+}
+
+export function registerActiveUseSurvey(publisher: ITelemetryPublisher, state: vscode.Memento): ActiveUseSurveyDisposable {
+    return activeUseSurvey(
+        60 * 1000,                  // Check for eligibility 1 minute after activation.
+        () => new Date(),           // Use the current clock (i.e. date).
+        isEnglishLanguage,
+        publisher,
+        select25Percent,
+        state,
+        surveyPrompt,
+        surveyOpen);
+}

--- a/test/telemetry/TelemetryPublisher.test.ts
+++ b/test/telemetry/TelemetryPublisher.test.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+
+import { TelemetryPublisher } from '../../extension.bundle';
+
+suite('telemetry/TelemetryPublisher', () => {
+    test('Listeners are notified of published events', () => {
+        const eventName = 'event';
+        const measurements = {};
+        const properties = {};
+
+        let wasPublished = false;
+
+        const publisher = new TelemetryPublisher();
+
+        publisher.onEvent(
+            e => {
+                assert.equal(e.eventName, eventName);
+                assert.equal(e.measurements, measurements);
+                assert.equal(e.properties, properties);
+
+                wasPublished = true;
+            });
+
+        publisher.publishEvent({ eventName, measurements, properties });
+
+        assert(wasPublished);
+    });
+});

--- a/test/telemetry/TelemetryReporterProxy.test.ts
+++ b/test/telemetry/TelemetryReporterProxy.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+
+import { TelemetryReporterProxy } from '../../extension.bundle';
+import { ITelemetryReporter } from 'vscode-azureextensionui';
+import { ITelemetryPublisher } from '../../extension.bundle';
+
+suite('telemetry/TelemetryReporterProxy', () => {
+    test('Events sent to both reporter and publisher', () => {
+        const eventName = 'event';
+        const measurements = {};
+        const properties = {};
+
+        let eventPublished = false;
+        let eventSent = false;
+
+        const publisher: ITelemetryPublisher = {
+            onEvent: undefined,
+            publishEvent: e => {
+                assert.equal(e.eventName, eventName);
+                assert.equal(e.measurements, measurements);
+                assert.equal(e.properties, properties);
+
+                eventPublished = true;
+            }
+        };
+
+        const wrappedReporter: ITelemetryReporter = {
+            sendTelemetryEvent: (e, p, m) => {
+                assert.equal(e, eventName);
+                assert.equal(m, measurements);
+                assert.equal(p, properties);
+
+                eventSent = true;
+            }
+        };
+
+        const proxy = new TelemetryReporterProxy(publisher, wrappedReporter);
+
+        proxy.sendTelemetryEvent(eventName, properties, measurements);
+
+        assert(eventPublished);
+        assert(eventSent);
+    });
+});

--- a/test/telemetry/surveys/activeUseSurvey.test.ts
+++ b/test/telemetry/surveys/activeUseSurvey.test.ts
@@ -1,0 +1,178 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { activeUseSurvey } from '../../../extension.bundle';
+import { TelemetryEvent } from '../../../extension.bundle';
+import { ITelemetryPublisher } from '../../../src/telemetry/TelemetryPublisher';
+
+interface TelemetryEventData {
+    date: string;
+    event: TelemetryEvent;
+};
+
+interface TestOptions {
+    activationDate: string;
+    lastUseDate?: string;
+    isCandidate?: boolean;
+    isSelected?: boolean;
+    isChosenLanguage?: boolean;
+    promptResponse?: boolean;
+    preActivationTelemetry?: TelemetryEventData[];
+    postActivationTelemetry?: TelemetryEventData[];
+}
+
+suite('telemetry/surveys/activeUseSurvey', () => {
+    const lastUseDateKey = 'telemetry.surveys.activeUseSurvey.lastUseDate';
+    const isCandidateKey = 'telemetry.surveys.activeUseSurvey.isCandidate';
+
+    function buildTest(name: string, options: TestOptions) {
+        test(name, async () => {
+            const eventPublisher = new vscode.EventEmitter<TelemetryEvent>()
+
+            const publisher: ITelemetryPublisher = {
+                onEvent: eventPublisher.event,
+                publishEvent: undefined
+            };
+
+            const lastUseDateUpdates = [];
+            const isCandidateUpdates = [];
+
+            const state: vscode.Memento = {
+                get: (key, defaultValue = undefined) => {
+                    switch (key) {
+                        case lastUseDateKey: return options.lastUseDate ?? defaultValue;
+                        case isCandidateKey: return options.isCandidate ?? defaultValue;
+                    }
+
+                    return defaultValue;
+                },
+                update: (key, value) => {
+                    switch (key) {
+                        case lastUseDateKey:
+                            lastUseDateUpdates.push(value);
+                            break;
+
+                        case isCandidateKey:
+                            isCandidateUpdates.push(value);
+                            break;
+                    }
+
+                    return Promise.resolve();
+                }
+            }
+
+            let wasSelected = false;
+            let wasPrompted = false;
+            let wasOpened = false;
+
+            const selector = () => {
+                wasSelected = true;
+
+                return options.isSelected;
+            };
+
+            const surveyPrompt = () => {
+                wasPrompted = true;
+
+                return Promise.resolve(options.promptResponse);
+            };
+
+            const surveyOpen = () => {
+                wasOpened = true;
+
+                return Promise.resolve();
+            }
+
+            const nonActivationPostActivationTelemetry = (options.postActivationTelemetry ?? []).filter(telemetry => telemetry.event.properties?.isActivationEvent !== 'true');
+
+            const dates = [
+                new Date(options.activationDate),
+                ...(options.preActivationTelemetry ?? []).map(event => new Date(event.date)),
+                ...nonActivationPostActivationTelemetry.map(event => new Date(event.date))
+            ];
+
+            const clock = () => {
+                return dates.shift();
+            };
+
+            const survey =
+                activeUseSurvey(
+                    10,
+                    clock,
+                    () => options.isChosenLanguage ?? true,
+                    publisher,
+                    selector,
+                    state,
+                    surveyPrompt,
+                    surveyOpen);
+
+            if (options.preActivationTelemetry) {
+                options.preActivationTelemetry.forEach(telemetry => eventPublisher.fire(telemetry.event));
+            }
+
+            await survey.postActivationTask;
+
+            if (options.postActivationTelemetry) {
+                options.postActivationTelemetry.forEach(telemetry => eventPublisher.fire(telemetry.event));
+            }
+
+            // If this was the first activation, the "last use" should be set to the activation date.
+            if (options.lastUseDate === undefined) {
+                assert(lastUseDateUpdates.length === 1 && lastUseDateUpdates[0] === options.activationDate);
+            }
+
+            // If the user is a known candidate, she should not go through the selection process.
+            if (options.isCandidate !== undefined) {
+                assert(!wasSelected);
+            }
+
+            // If the user was selected, their candidicy should first be saved.
+            if (options.isCandidate === undefined && options.isSelected !== undefined) {
+                assert(isCandidateUpdates.length > 0 && isCandidateUpdates[0] === options.isSelected);
+            }
+
+            // If the user responded, their candidicy should lastly be revoked.
+            if (options.promptResponse !== undefined) {
+                assert(isCandidateUpdates.length > 0 && isCandidateUpdates[isCandidateUpdates.length - 1] === false);
+            }
+
+            // The last use update should be the last non-activation-event telemetry date.
+            if (nonActivationPostActivationTelemetry.length > 0) {
+                assert(lastUseDateUpdates.length > 0 && lastUseDateUpdates[lastUseDateUpdates.length - 1] === nonActivationPostActivationTelemetry[nonActivationPostActivationTelemetry.length - 1].date);
+            }
+
+            assert((options.isSelected !== undefined && wasSelected) || (options.isSelected === undefined && !wasSelected));
+            assert((options.promptResponse !== undefined && wasPrompted) || (options.promptResponse === undefined && !wasPrompted));
+            assert((options.promptResponse === true && wasOpened) || (options.promptResponse !== true && !wasOpened));
+        });
+    }
+
+    buildTest('First activation, no use', { activationDate: '2020-01-24' });
+
+    buildTest('Activation, no use, previous use within limits', { activationDate: '2020-01-24', lastUseDate: '2020-01-03' });
+
+    buildTest('Activation, no use, previous use within limits, with post non-activation events', { activationDate: '2020-01-20', lastUseDate: '2020-01-03', postActivationTelemetry: [{date: '2020-01-21', event: { eventName: 'docker-build' } }, {date: '2020-01-22', event: { eventName: 'docker-build' } }] });
+
+    buildTest('Activation, no use, previous use within limits, with post activation events', { activationDate: '2020-01-20', lastUseDate: '2020-01-03', postActivationTelemetry: [{date: '2020-01-21', event: { eventName: 'docker-build', properties: { 'isActivationEvent': 'true' } } }] });
+
+    buildTest('Activation, no use, previous use outside limits, not candidate', { activationDate: '2020-01-24', lastUseDate: '2020-01-01', isCandidate: false });
+
+    buildTest('Activation, no use, previous use outside limits, candidate, negative response', { activationDate: '2020-01-24', lastUseDate: '2020-01-01', isCandidate: true, promptResponse: false });
+
+    buildTest('Activation, no use, previous use outside limits, candidate, positive response', { activationDate: '2020-01-24', lastUseDate: '2020-01-01', isCandidate: true, promptResponse: true });
+
+    buildTest('Activation, no use, previous use outside limits, unknown candidate, not selected', { activationDate: '2020-01-24', lastUseDate: '2020-01-01', isSelected: false });
+
+    buildTest('Activation, no use, previous use outside limits, unknown candidate, selected, non-native language', { activationDate: '2020-01-24', lastUseDate: '2020-01-01', isSelected: true, isChosenLanguage: false });
+
+    buildTest('Activation, no use, previous use outside limits, unknown candidate, selected, negative response', { activationDate: '2020-01-24', lastUseDate: '2020-01-01', isSelected: true, promptResponse: false });
+
+    buildTest('Activation, no use, previous use outside limits, unknown candidate, selected, positive response', { activationDate: '2020-01-24', lastUseDate: '2020-01-01', isSelected: true, promptResponse: true });
+
+    buildTest('Activation, no use, previous use at limits, unknown candidate, selected, positive response', { activationDate: '2020-01-23', lastUseDate: '2020-01-01', isSelected: true, promptResponse: true });
+});
+


### PR DESCRIPTION
* Sketch hooking telemetry reporting.

* Start listening for events.

* Update global state with last event dates.

* Switch to swappable clock and disable NPS.

* Eliminate specific "clock" interface.

* Add TelemetryReporterProxy test.

* Add TelemetryPublisher tests.

* Sketch test of survey.

* Refactor to allow deterministic testing.

* Continue adding tests.

* Additional test.

* Tweaked selection.

* Add language check.

* Add tests for post-activation events.

* Test ignoring activation events.

* Fixup linter warnings.

* Refactor telemetry events.

* Fixed telemetry reporting.

* Add docs.