### PR TITLE
[Python] Remove compose-debug + a couple of minor updates

### DIFF
--- a/src/commands/containers/browseContainer.ts
+++ b/src/commands/containers/browseContainer.ts
@@ -26,7 +26,8 @@ const commonWebPorts = [
     3000,   // (Node.js) Express.js
     3001,   // (Node.js) Sails.js
     5001,   // (.NET Core) ASP.NET SSL
-    5000,   // (.NET Core) ASP.NET HTTP
+    5000,   // (.NET Core) ASP.NET HTTP and (Python) Flask
+    8000,   // (Python) Django
     8080,   // (Node.js)
     8081    // (Node.js)
 ];

--- a/src/configureWorkspace/configurePython.ts
+++ b/src/configureWorkspace/configurePython.ts
@@ -177,7 +177,7 @@ export async function scaffoldPython(context: ScaffolderContext): Promise<Scaffo
     }
 
     const dockerFileContents = genDockerFile(serviceName, launchFile, projectType, ports);
-    const dockerIgnoreContents = `**/__pycache__\n${genCommonDockerIgnoreFile(context.platform)}`;
+    const dockerIgnoreContents = '**/__pycache__\n'.concat(genCommonDockerIgnoreFile(context.platform));
 
     const files: ScaffoldFile[] = [
         { fileName: 'Dockerfile', contents: dockerFileContents, open: true },

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -5,14 +5,14 @@
 
 import * as fse from 'fs-extra';
 import * as os from 'os';
-import * as vscode from "vscode";
-import { PythonExtensionHelper } from "../../tasks/python/PythonExtensionHelper";
+import * as vscode from 'vscode';
+import { PythonExtensionHelper } from '../../tasks/python/PythonExtensionHelper';
 import { PythonDefaultDebugPort, PythonProjectType } from '../../utils/pythonUtils';
-import ChildProcessProvider from "../coreclr/ChildProcessProvider";
-import CliDockerClient from "../coreclr/CliDockerClient";
+import ChildProcessProvider from '../coreclr/ChildProcessProvider';
+import CliDockerClient from '../coreclr/CliDockerClient';
 import { DebugHelper, DockerDebugContext, DockerDebugScaffoldContext, inferContainerName, ResolvedDebugConfiguration, resolveDockerServerReadyAction } from '../DebugHelper';
-import { DockerDebugConfigurationBase } from "../DockerDebugConfigurationBase";
-import { DockerDebugConfiguration } from "../DockerDebugConfigurationProvider";
+import { DockerDebugConfigurationBase } from '../DockerDebugConfigurationBase';
+import { DockerDebugConfiguration } from '../DockerDebugConfigurationProvider';
 import { PythonScaffoldingOptions } from '../DockerDebugScaffoldingProvider';
 
 export interface PythonPathMapping {
@@ -40,9 +40,11 @@ export class PythonDebugHelper implements DebugHelper {
     }
 
     public async provideDebugConfigurations(context: DockerDebugScaffoldContext, options?: PythonScaffoldingOptions): Promise<DockerDebugConfiguration[]> {
-        const configs : DockerDebugConfiguration[] =
-        [{
-            name: 'Docker Python Launch',
+        // Capitalize the first letter.
+        const projectType = options.projectType.charAt(0).toUpperCase() + options.projectType.slice(1);
+
+        return [{
+            name: `Docker: Python - ${projectType}`,
             type: 'docker',
             request: 'launch',
             preLaunchTask: 'docker-run: debug',
@@ -57,27 +59,6 @@ export class PythonDebugHelper implements DebugHelper {
                 projectType: options.projectType
             }
         }];
-
-        // If we generated compose files, then we should generate a Python attach configuration.
-        if (context.generateComposeTask) {
-            configs.push(
-                {
-                    name: 'Python Remote Attach',
-                    type: 'python',
-                    request: 'attach',
-                    host: 'localhost',
-                    port: PythonDefaultDebugPort,
-                    pathMappings: [
-                        {
-                            /* eslint-disable-next-line no-template-curly-in-string */
-                            localRoot: '${workspaceFolder}',
-                            remoteRoot: '/app'
-                        }
-                    ]
-                });
-        }
-
-        return configs;
     }
 
     public async resolveDebugConfiguration(context: DockerDebugContext, debugConfiguration: PythonDockerDebugConfiguration): Promise<ResolvedDebugConfiguration | undefined> {

--- a/src/tasks/TaskHelper.ts
+++ b/src/tasks/TaskHelper.ts
@@ -41,7 +41,6 @@ export function throwIfCancellationRequested(context: DockerTaskContext): void {
 export interface DockerTaskScaffoldContext extends DockerTaskContext {
     dockerfile: string;
     ports?: number[];
-    generateComposeTask?: boolean;
 }
 
 export interface DockerTaskExecutionContext extends DockerTaskContext {

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -1217,7 +1217,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     packageFileType: undefined,
                     packageFileSubfolderDepth: undefined
                 },
-                ['No', '8000', 'manage.py'],
+                ['No', 'manage.py', '8000'],
                 ['Dockerfile', '.dockerignore', 'requirements.txt']
             );
 
@@ -1241,7 +1241,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     packageFileType: undefined,
                     packageFileSubfolderDepth: undefined
                 },
-                ['No', '5000', 'flask_app.py'],
+                ['No', 'flask_app.py', '5000'],
                 ['Dockerfile', '.dockerignore', 'requirements.txt']
             );
 


### PR DESCRIPTION
Changes:
- Launch tasks renamed to Docker: Python - Django, Docker: Python - Flask, Docker: Python – General
- Add "**/__pycache__" to .dockerignore
- Add a comment at the top of the requirements.txt file
- Handle executing "folders" as an app path
- Change wording for the "launchFile" prompt
- Move the "ports" prompt to be the last