### PR TITLE
Allow unit tests to run independently

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -64,6 +64,30 @@
 			}
 		},
 		{
+			"name": "Launch Tests (unit)",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"${workspaceFolder}/test/test.code-workspace",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test"
+			],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "npm: compile",
+			"env": {
+				"AZCODE_DOCKER_IGNORE_BUNDLE": "1",
+				"MOCHA_grep": "\\(unit\\)", // RegExp of tests to run (empty means all)
+				"MOCHA_enableTimeouts": "0", // Disable time-outs
+				"DEBUGTELEMETRY": "1",
+				"NODE_DEBUG": ""
+			}
+		},
+		{
 			"name": "Launch Tests (webpack)",
 			"type": "extensionHost",
 			"request": "launch",

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -12,12 +12,21 @@ import { gulp_installAzureAccount, gulp_webpack } from 'vscode-azureextensiondev
 
 const env = process.env;
 
-function test(): cp.ChildProcess {
+function test(mochaGrep: string = ''): cp.ChildProcess {
     env.DEBUGTELEMETRY = '1';
     env.CODE_TESTS_WORKSPACE = path.join(__dirname, 'test/test.code-workspace');
+    env.MOCHA_grep = mochaGrep;
     env.MOCHA_timeout = String(10 * 1000);
     env.CODE_TESTS_PATH = path.join(__dirname, 'dist/test');
     return spawn('node', ['./node_modules/vscode/bin/test'], { stdio: 'inherit', env });
+}
+
+function allTest(): cp.ChildProcess {
+    return test();
+}
+
+function unitTest(): cp.ChildProcess {
+    return test('\\(unit\\)');
 }
 
 function spawn(command: string, args: string[], options: {}): cp.ChildProcess {
@@ -53,4 +62,5 @@ async function sortPackageJson(): Promise<void> {
 exports.sortPackageJson = sortPackageJson;
 exports['webpack-dev'] = () => gulp_webpack('development');
 exports['webpack-prod'] = () => gulp_webpack('production');
-exports.test = gulp.series(gulp_installAzureAccount, test);
+exports.test = gulp.series(gulp_installAzureAccount, allTest);
+exports['unit-test'] = gulp.series(gulp_installAzureAccount, unitTest);

--- a/test/assertEx.test.ts
+++ b/test/assertEx.test.ts
@@ -6,7 +6,7 @@
 import { unorderedArraysEqual, notUnorderedArraysEqual, throwsOrRejectsAsync } from "./assertEx";
 import * as assert from "assert";
 
-suite("assertEx", () => {
+suite("(unit) assertEx", () => {
     test("areUnorderedArraysEqual", () => {
         unorderedArraysEqual([], []);
         notUnorderedArraysEqual([], [1]);

--- a/test/configureWorkspace/configUtils.test.ts
+++ b/test/configureWorkspace/configUtils.test.ts
@@ -6,7 +6,7 @@
 import { splitPorts } from "../../extension.bundle";
 import * as assert from 'assert';
 
-suite('configureWorkspace/configUtils', () => {
+suite('(unit) configureWorkspace/configUtils', () => {
     suite('splitPorts', () => {
         function genTest(s: string, expected: number[]): void {
             test(`${String(s)}`, () => {

--- a/test/debugging/coreclr/commandLineBuilder.test.ts
+++ b/test/debugging/coreclr/commandLineBuilder.test.ts
@@ -6,7 +6,7 @@ import * as assert from 'assert';
 import { CommandLineBuilder } from '../../../extension.bundle';
 import { ShellQuoting } from 'vscode';
 
-suite('debugging/coreclr/CommandLineBuilder', () => {
+suite('(unit) debugging/coreclr/CommandLineBuilder', () => {
     function testBuilder(name: string, builderInitializer: (CommandLineBuilder) => CommandLineBuilder, expected: string, message: string) {
         test(name, () => {
             let builder = CommandLineBuilder.create();

--- a/test/debugging/coreclr/dockerManager.test.ts
+++ b/test/debugging/coreclr/dockerManager.test.ts
@@ -6,7 +6,7 @@ import assert = require("assert");
 import { DockerBuildImageOptions } from "../../../extension.bundle";
 import { compareBuildImageOptions } from "../../../extension.bundle";
 
-suite('debugging/coreclr/dockerManager', () => {
+suite('(unit) debugging/coreclr/dockerManager', () => {
     suite('compareBuildImageOptions', () => {
         function testComparison(name: string, options1: DockerBuildImageOptions | undefined, options2: DockerBuildImageOptions | undefined, expected: boolean, message: string) {
             test(name, () => assert.equal(compareBuildImageOptions(options1, options2), expected, message));

--- a/test/debugging/coreclr/lineSplitter.test.ts
+++ b/test/debugging/coreclr/lineSplitter.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import { LineSplitter } from '../../../extension.bundle';
 
-suite('debugging/coreclr/LineSplitter', () => {
+suite('(unit) debugging/coreclr/LineSplitter', () => {
     const testCase = (name: string, input: string | string[], output: string[]) => {
         test(name, () => {
             const splitter = new LineSplitter();

--- a/test/debugging/coreclr/prereqManager.test.ts
+++ b/test/debugging/coreclr/prereqManager.test.ts
@@ -13,7 +13,7 @@ import { DockerClient } from '../../../extension.bundle';
 import { DotNetClient } from '../../../extension.bundle';
 import { LaunchOptions } from '../../../extension.bundle';
 
-suite('debugging/coreclr/prereqManager', () => {
+suite('(unit) debugging/coreclr/prereqManager', () => {
     suite('DockerDaemonIsLinuxPrerequisite', () => {
         const generateTest = (name: string, result: boolean, os: PlatformOS) => {
             test(name, async () => {

--- a/test/nonNull.test.ts
+++ b/test/nonNull.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import { Suite } from 'mocha';
 import { nonNullProp } from '../extension.bundle';
 
-suite("nonNull", async function (this: Suite): Promise<void> {
+suite("(unit) nonNull", async function (this: Suite): Promise<void> {
     type TestSubscription = {
         stringOrUndefined?: string;
         arrayOrUndefined?: number[];

--- a/test/tasks/TaskHelper.test.ts
+++ b/test/tasks/TaskHelper.test.ts
@@ -8,7 +8,7 @@ import { recursiveFindTaskByType } from '../../extension.bundle';
 import { TaskDefinitionBase } from '../../extension.bundle';
 import { DebugConfigurationBase } from '../../extension.bundle';
 
-suite('tasks/TaskHelper/recursiveFindTaskByType', async () => {
+suite('(unit) tasks/TaskHelper/recursiveFindTaskByType', async () => {
 
     const simple: TaskDefinitionBase[] = [
         {

--- a/test/telemetry/TelemetryPublisher.test.ts
+++ b/test/telemetry/TelemetryPublisher.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 
 import { TelemetryPublisher } from '../../extension.bundle';
 
-suite('telemetry/TelemetryPublisher', () => {
+suite('(unit) telemetry/TelemetryPublisher', () => {
     test('Listeners are notified of published events', () => {
         const eventName = 'event';
         const measurements = {};

--- a/test/telemetry/TelemetryReporterProxy.test.ts
+++ b/test/telemetry/TelemetryReporterProxy.test.ts
@@ -9,7 +9,7 @@ import { TelemetryReporterProxy } from '../../extension.bundle';
 import { ITelemetryReporter } from 'vscode-azureextensionui';
 import { ITelemetryPublisher } from '../../extension.bundle';
 
-suite('telemetry/TelemetryReporterProxy', () => {
+suite('(unit) telemetry/TelemetryReporterProxy', () => {
     test('Events sent to both reporter and publisher', () => {
         const eventName = 'event';
         const measurements = {};

--- a/test/telemetry/surveys/activeUseSurvey.test.ts
+++ b/test/telemetry/surveys/activeUseSurvey.test.ts
@@ -25,7 +25,7 @@ interface TestOptions {
     postActivationTelemetry?: TelemetryEventData[];
 }
 
-suite('telemetry/surveys/activeUseSurvey', () => {
+suite('(unit) telemetry/surveys/activeUseSurvey', () => {
     const lastUseDateKey = 'telemetry.surveys.activeUseSurvey.lastUseDate';
     const isCandidateKey = 'telemetry.surveys.activeUseSurvey.isCandidate';
 

--- a/test/trimWithElipsis.test.ts
+++ b/test/trimWithElipsis.test.ts
@@ -6,7 +6,7 @@
 import { trimWithElipsis } from "../extension.bundle";
 import * as assert from 'assert';
 
-suite('trimWithElipsis', () => {
+suite('(unit) trimWithElipsis', () => {
     function genTest(s: string, max: number, expected: string): void {
         test(`${String(s)}: ${max}`, () => {
             let s2 = trimWithElipsis(s, max);

--- a/test/utils/nodeUtils.test.ts
+++ b/test/utils/nodeUtils.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { inferPackageName, inferCommand, InspectMode, NodePackage } from "../../extension.bundle";
 
- suite('utils/nodeUtils', () => {
+ suite('(unit) utils/nodeUtils', () => {
     suite('inferPackageName', () => {
         test('No package', async () => {
             const packageName = await inferPackageName(undefined, '/Users/user/app/package.json');

--- a/test/windowsVersion.test.ts
+++ b/test/windowsVersion.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { ext, isWindows10RS3OrNewer, isWindows10RS4OrNewer, isWindows10RS5OrNewer, isWindows1019H1OrNewer } from '../extension.bundle';
 
-suite("windowsVersion", () => {
+suite("(unit) windowsVersion", () => {
     function testIsWindows1019H1OrNewer(release: string, expectedResult: boolean): void {
         test(`isWindows1019H1OrNewer: ${release}`, () => {
             let previousOs = ext.os;


### PR DESCRIPTION
Updates the VS Code launch configuration and Gulp tasks to allow running *only* the "unit" tests rather than *all* the tests. By not having to run the "integration" (i.e. automation) tests, the edit/build/test loop is much faster, ~10-15s instead of nearly 1 minute.

Unit tests are designated with a `(unit)` tag somewhere in the suite/test name.  Note, the test name tag was used rather than, say, re-arranging the file hierarchy to group unit/integration files as that better fits the existing build/test infrastructure.

Resolves #1640.