### PR TITLE
Create Attach config for dotnet core compose

### DIFF
--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -361,7 +361,7 @@ async function findCSProjOrFSProjFile(folderPath?: string): Promise<string> {
     }
 }
 
-async function initializeForDebugging(context: IActionContext, folder: WorkspaceFolder, platformOS: PlatformOS, workspaceRelativeDockerfileName: string, workspaceRelativeProjectFileName: string): Promise<void> {
+async function initializeForDebugging(context: IActionContext, folder: WorkspaceFolder, platformOS: PlatformOS, isCompose: boolean, workspaceRelativeDockerfileName: string, workspaceRelativeProjectFileName: string): Promise<void> {
     const scaffoldContext: DockerDebugScaffoldContext = {
         folder: folder,
         platform: 'netCore',
@@ -369,6 +369,7 @@ async function initializeForDebugging(context: IActionContext, folder: Workspace
         // always use posix for debug config because it's committed to source control and works on all OS's
         /* eslint-disable-next-line no-template-curly-in-string */
         dockerfile: path.posix.join('${workspaceFolder}', workspaceRelativeDockerfileName),
+        isCompose: isCompose
     }
 
     const options: NetCoreScaffoldingOptions = {
@@ -442,7 +443,7 @@ export async function scaffoldNetCore(context: ScaffolderContext): Promise<Scaff
         const dockerFilePath = path.resolve(context.rootFolder, dockerFileName);
         const workspaceRelativeDockerfileName = path.relative(context.folder.uri.fsPath, dockerFilePath);
 
-        await initializeForDebugging(context, context.folder, context.os, workspaceRelativeDockerfileName, workspaceRelativeProjectFileName);
+        await initializeForDebugging(context, context.folder, context.os, isCompose, workspaceRelativeDockerfileName, workspaceRelativeProjectFileName);
     }
 
     return files;

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -88,18 +88,32 @@ export class NetCoreDebugHelper implements DebugHelper {
     public async provideDebugConfigurations(context: DockerDebugScaffoldContext, options?: NetCoreDebugScaffoldingOptions): Promise<DockerDebugConfiguration[]> {
         options = options || {};
         options.appProject = options.appProject || await NetCoreTaskHelper.inferAppProject(context.folder); // This method internally checks the user-defined input first
-
-        return [
-            {
-                name: 'Docker .NET Core Launch',
-                type: 'docker',
-                request: 'launch',
-                preLaunchTask: 'docker-run: debug',
-                netCore: {
-                    appProject: unresolveWorkspaceFolder(options.appProject, context.folder)
-                }
+        let debugConfigurations : DockerDebugConfiguration[] = [{
+            name: 'Docker .NET Core Launch',
+            type: 'docker',
+            request: 'launch',
+            preLaunchTask: 'docker-run: debug',
+            netCore: {
+                appProject: unresolveWorkspaceFolder(options.appProject, context.folder)
             }
-        ];
+        }];
+
+        if (context.isCompose) {
+            debugConfigurations.push(
+                {
+                    name: 'Docker .NET Core Attach (Preview)',
+                    type: 'docker',
+                    request: 'attach',
+                    platform: 'netCore',
+                    sourceFileMap: {
+                        // eslint-disable-next-line no-template-curly-in-string
+                        '/src': '${workspaceFolder}'
+                    }
+                }
+            );
+        }
+
+        return debugConfigurations;
     }
 
     public async resolveDebugConfiguration(context: DockerDebugContext, debugConfiguration: DockerDebugConfiguration): Promise<ResolvedDebugConfiguration | undefined> {

--- a/src/tasks/TaskHelper.ts
+++ b/src/tasks/TaskHelper.ts
@@ -41,6 +41,7 @@ export function throwIfCancellationRequested(context: DockerTaskContext): void {
 export interface DockerTaskScaffoldContext extends DockerTaskContext {
     dockerfile: string;
     ports?: number[];
+    isCompose?: boolean;
 }
 
 export interface DockerTaskExecutionContext extends DockerTaskContext {


### PR DESCRIPTION
When compose is selected during scaffolding, the 'Docker .NET Core Attach (Preview)' debug config is added automatically.

fixes #1543