### PR TITLE
Look in Docker logs to determine if the server is ready

### DIFF
--- a/src/debugging/DockerServerReadyAction.ts
+++ b/src/debugging/DockerServerReadyAction.ts
@@ -228,7 +228,6 @@ class DockerLogsTracker extends vscode.Disposable {
                 },
                 (err, stream) => {
                     if (err) {
-                        // TODO: Log error. Dispose of ourselves?
                         return;
                     }
 
@@ -238,10 +237,7 @@ class DockerLogsTracker extends vscode.Disposable {
                         detector.detectPattern(data.toString());
                     });
                 });
-        } catch {
-            // Failed to get the container logs.
-            this.disposeStream();
-        }
+        } catch { }
     }
 
     private disposeStream() : void {


### PR DESCRIPTION
- Adds a `DockerLogsTracker` class that looks for the pattern in "docker logs"
- Adds `MultiOutputDockerServerReadyManager` which is essentially a combination of looking in the debug console and docker logs
- Some simple refactoring

For the most (if not all) cases, the pattern will be found in "docker logs" before it ever reaches the debug console. However, it might be safer to keep looking in the debug console just to cover cases that we might not know about.

These are pretty much @philliphoff's changes from that branch: https://github.com/microsoft/vscode-docker/compare/philliphoff-docker-logs