### PR TITLE
Fix filtering for Remove* multi-select commands

### DIFF
--- a/src/commands/images/removeImage.ts
+++ b/src/commands/images/removeImage.ts
@@ -13,7 +13,7 @@ export async function removeImage(context: IActionContext, node?: ImageTreeItem,
     nodes = await multiSelectNodes(
         { ...context, suppressCreatePick: true, noItemFoundErrorMessage: 'No images are available to remove' },
         ext.imagesTree,
-        new RegExp(ImageTreeItem.contextValue, 'i'),
+        ImageTreeItem.contextValue,
         node,
         nodes
     );

--- a/src/commands/networks/removeNetwork.ts
+++ b/src/commands/networks/removeNetwork.ts
@@ -13,7 +13,7 @@ export async function removeNetwork(context: IActionContext, node?: NetworkTreeI
     nodes = await multiSelectNodes(
         { ...context, suppressCreatePick: true, noItemFoundErrorMessage: 'No networks are available to remove' },
         ext.networksTree,
-        new RegExp(NetworkTreeItem.contextValue, 'i'),
+        NetworkTreeItem.contextValue,
         node,
         nodes
     );

--- a/src/commands/volumes/removeVolume.ts
+++ b/src/commands/volumes/removeVolume.ts
@@ -13,7 +13,7 @@ export async function removeVolume(context: IActionContext, node?: VolumeTreeIte
     nodes = await multiSelectNodes(
         { ...context, suppressCreatePick: true, noItemFoundErrorMessage: 'No volumes are available to remove' },
         ext.volumesTree,
-        new RegExp(VolumeTreeItem.contextValue, 'i'),
+        VolumeTreeItem.contextValue,
         node,
         nodes
     );

--- a/src/utils/multiSelectNodes.ts
+++ b/src/utils/multiSelectNodes.ts
@@ -16,7 +16,7 @@ import { AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, ITreeItemPic
 export async function multiSelectNodes<T extends AzExtTreeItem>(
     context: ITreeItemPickerContext,
     tree: AzExtTreeDataProvider,
-    expectedContextValue?: RegExp,
+    expectedContextValue?: string | RegExp,
     node?: T,
     nodes?: T[]): Promise<T[]> {
 
@@ -33,7 +33,11 @@ export async function multiSelectNodes<T extends AzExtTreeItem>(
         nodes = await tree.showTreeItemPicker<T>(expectedContextValue, { ...context, canPickMany: true });
     } else if (expectedContextValue) {
         // Otherwise if there's a filter, need to filter our selection to exclude ineligible nodes
-        nodes = nodes.filter(n => expectedContextValue.test(n.contextValue));
+        // This uses the same logic as AzExtTreeItem.matchesContextValue()
+        nodes = nodes.filter(n => {
+            return expectedContextValue === n.contextValue || // For strings, exact match comparison
+                (expectedContextValue instanceof RegExp && expectedContextValue.test(n.contextValue)); // For regexs, RegExp.test()
+        });
     }
 
     // Filter off parent items (i.e. group items), as it doesn't make sense to perform actions on them, when we don't allow actions to be performed on *only* them


### PR DESCRIPTION
Fixes #1660. Because of the change from string to regexp, it matched parent nodes of the images / networks / etc. tab, in error (the RegExp did not have anchors at start/end of string). The quick pick thus returned the root node as a single object, and calling `.filter()` on the object was invalid.

Changing back to strings, and doing exact string comparison (which is what `AzExtTreeItem` does) in that case fixes it.