### PR TITLE
Take readme images back out of VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,6 +13,7 @@ docs/**
 gulp*
 node_modules/**
 out/**
+resources/readme/**
 src/**
 stats.json
 test-results.xml


### PR DESCRIPTION
I talked with @EricJizbaMSFT, the marketplace actually directly references the master branch for the images. When the old images were removed during restructuring of the README, the marketplace images quit working. If we wanted to fix it immediately we could just add those images back (and eventually, remove them again), but since we're planning to release soon it's probably not worth doing so.

Taking the images back out of the VSIX saves a little size (240KB), so it's worth doing.