### PR TITLE
[Cherry-pick] Switch to using the Flask CLI as the entrypoint for flask apps (#1690)

### DIFF
--- a/src/configureWorkspace/configurePython.ts
+++ b/src/configureWorkspace/configurePython.ts
@@ -44,6 +44,7 @@ RUN python -m pip install -r requirements.txt
 WORKDIR /app
 ADD . /app
 
+# During debugging, this entry point will be overridden. For more information, refer to https://aka.ms/vscode-docker-python-debug
 $cmd$
 `;
 

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -50,17 +50,32 @@ export class PythonTaskHelper implements TaskHelper {
             args: inferPythonArgs(options.projectType, context.ports)
         };
 
+        let dockerRunOptions: DockerRunOptions | undefined;
+
         if ('file' in options.target) {
             runOptions.file = options.target.file;
         } else {
             runOptions.module = options.target.module;
         }
 
+        // If the projectType is flask, then we set the module to 'flask' and
+        // set whatever the user entered in an env variable named "FLASK_APP".
+        if (options.projectType === 'flask') {
+            dockerRunOptions = {
+                env: {
+                    "FLASK_APP": runOptions.file || runOptions.module
+                }
+            }
+            runOptions.module = 'flask';
+            runOptions.file = undefined;
+        }
+
         return [{
             type: 'docker-run',
             label: 'docker-run: debug',
             dependsOn: ['docker-build'],
-            python: runOptions
+            dockerRun: dockerRunOptions,
+            python: runOptions,
         }];
     }
 

--- a/src/utils/pythonUtils.ts
+++ b/src/utils/pythonUtils.ts
@@ -32,6 +32,14 @@ export function inferPythonArgs(projectType: PythonProjectType, ports: number[])
                 '--nothreading',
                 '--noreload'
             ];
+        case 'flask':
+            return [
+                'run',
+                '--no-debugger',
+                '--no-reload',
+                '--host 0.0.0.0',
+                `--port ${ports !== undefined ? ports[0] : PythonDefaultPorts[projectType]}`,
+            ]
         default:
             return undefined;
     }


### PR DESCRIPTION
* Switch to using the Flask CLI as the entrypoint for flask apps

* Add comment explaining we override the entrypoint in debugging