### PR TITLE
Do not add https port to ASPNETCORE_URLS

### DIFF
--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -286,14 +286,11 @@ function generateComposeFiles(dockerfileName: string, platform: Platform, os: Pl
     if (platform === '.NET: ASP.NET Core') {
         environmentVariables = `\n    environment:
       - ASPNETCORE_ENVIRONMENT=Development`;
-        // For now assume the first port is http and the second is https. (default scaffolding behavior)
+        // For now assume the first port is http. (default scaffolding behavior)
         // TODO: This is not the perfect logic, this should be improved later.
         if (ports && ports.length > 0) {
             // eslint-disable-next-line @typescript-eslint/tslint/config
             let aspNetCoreUrl: string = `      - ASPNETCORE_URLS=http://+:${ports[0]}`;
-            if (ports.length >= 2) {
-                aspNetCoreUrl += `;https://+:${ports[1]}`;
-            }
             environmentVariables += `\n${aspNetCoreUrl}`
         }
     }


### PR DESCRIPTION
Do not add https port to ASPNETCORE_URLS in docker-compose.debug.yml. This results into failure to bring up a container. Not adding just the first port as http.

Fixes: #1695 