### PR TITLE
don't install unzip

### DIFF
--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -295,9 +295,11 @@ export class NetCoreDebugHelper implements DebugHelper {
         }
         // Windows require double quotes and Mac and Linux require single quote.
         const osProvider = new LocalOSProvider();
+        const installDebuggerOnAlpine = `apk --no-cache add curl && curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${installPath}`;
+        const installDebuggerOnNonAlpine = `curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${installPath}`;
         const installDebugger: string = osProvider.os === 'Windows' ?
-            `/bin/sh -c "ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID; if [ $ID == alpine ]; then apk --no-cache add curl && curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${installPath} ; else apt-get update && apt-get install unzip && curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${installPath}; fi"`
-            : `/bin/sh -c 'ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID; if [ $ID == alpine ]; then apk --no-cache add curl && curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${installPath} ; else apt-get update && apt-get install unzip && curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${installPath}; fi'`
+            `/bin/sh -c "ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID; if [ $ID == alpine ]; then ${installDebuggerOnAlpine}; else ${installDebuggerOnNonAlpine}; fi"`
+            : `/bin/sh -c 'ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID; if [ $ID == alpine ]; then ${installDebuggerOnAlpine}; else ${installDebuggerOnNonAlpine}; fi'`
 
         const outputManager = new DefaultOutputManager(ext.outputChannel);
         const dockerClient = new CliDockerClient(new ChildProcessProvider());

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -293,13 +293,15 @@ export class NetCoreDebugHelper implements DebugHelper {
         if (!install) {
             throw new UserCancelledError();
         }
-        // Windows require double quotes and Mac and Linux require single quote.
+
         const osProvider = new LocalOSProvider();
         const installDebuggerOnAlpine = `apk --no-cache add curl && curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${installPath}`;
         const installDebuggerOnNonAlpine = `curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ${installPath}`;
+        const installDebuggerCmd = `ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID; if [ $ID == alpine ]; then ${installDebuggerOnAlpine}; else ${installDebuggerOnNonAlpine}; fi`
+        // Windows require double quotes and Mac and Linux require single quote.
         const installDebugger: string = osProvider.os === 'Windows' ?
-            `/bin/sh -c "ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID; if [ $ID == alpine ]; then ${installDebuggerOnAlpine}; else ${installDebuggerOnNonAlpine}; fi"`
-            : `/bin/sh -c 'ID=default; if [ -e /etc/os-release ]; then . /etc/os-release; fi; echo $ID; if [ $ID == alpine ]; then ${installDebuggerOnAlpine}; else ${installDebuggerOnNonAlpine}; fi'`
+            `/bin/sh -c "${installDebuggerCmd}"`
+            : `/bin/sh -c '${installDebuggerCmd}'`
 
         const outputManager = new DefaultOutputManager(ext.outputChannel);
         const dockerClient = new CliDockerClient(new ChildProcessProvider());


### PR DESCRIPTION
The latest version of GetVsDbg.sh doesn't require unzip. So not installing unzip in non-alpine flavor OS

Fixes: #1727 