### PR TITLE
Use cmd on Windows containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1929,7 +1929,7 @@
                 },
                 "docker.attachShellCommand.windowsContainer": {
                     "type": "string",
-                    "default": "powershell",
+                    "default": "cmd",
                     "description": "Attach command to use for Windows containers"
                 },
                 "docker.dockerComposeBuild": {


### PR DESCRIPTION
Preparing this in case we decide to fix it in 1.0.0.

This fixes #1728.