### PR TITLE
use correct volume mount path on windows

### DIFF
--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -302,10 +302,9 @@ function generateComposeFiles(dockerfileName: string, platform: Platform, os: Pl
         }
     }
 
-    let volumesList = '      - ~/.vsdbg:/remote_debugger';
-    if (os === 'Linux') {
-        volumesList += ':rw'
-    }
+    let volumesList = os === 'Windows' ?
+        '      - ~/.vsdbg:c:\\remote_debugger'
+        : '      - ~/.vsdbg:/remote_debugger:rw';
 
     // Ensure the path scaffolded in the Dockerfile uses POSIX separators (which work on both Linux and Windows).
     dockerfileName = dockerfileName.replace(/\\/g, '/');

--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -303,7 +303,7 @@ function generateComposeFiles(dockerfileName: string, platform: Platform, os: Pl
     }
 
     let volumesList = os === 'Windows' ?
-        '      - ~/.vsdbg:c:\\remote_debugger'
+        '      - ~/.vsdbg:c:\\remote_debugger:rw'
         : '      - ~/.vsdbg:/remote_debugger:rw';
 
     // Ensure the path scaffolded in the Dockerfile uses POSIX separators (which work on both Linux and Windows).


### PR DESCRIPTION
Scaffold docker-compose with the right volume mount path for windows container.
Related: #1662 