### PR TITLE
Ensure stdErr is written to telemetry

### DIFF
--- a/src/tasks/DockerBuildTaskProvider.ts
+++ b/src/tasks/DockerBuildTaskProvider.ts
@@ -58,7 +58,7 @@ export class DockerBuildTaskProvider extends DockerTaskProvider {
             context.folder,
             false, // rejectOnStderr
             undefined, // stdoutBuffer
-            undefined, // stderrBuffer
+            Buffer.alloc(10 * 1024), // stderrBuffer
             context.cancellationToken
         );
         throwIfCancellationRequested(context);

--- a/src/tasks/DockerPseudoterminal.ts
+++ b/src/tasks/DockerPseudoterminal.ts
@@ -11,7 +11,6 @@ import { DockerBuildTask } from './DockerBuildTaskProvider';
 import { DockerRunTask } from './DockerRunTaskProvider';
 import { DockerTaskProvider } from './DockerTaskProvider';
 import { DockerTaskExecutionContext } from './TaskHelper';
-import { ChildProcess } from 'child_process';
 
 const DEFAULT = '0m';
 const DEFAULTBOLD = '0;1m';
@@ -72,12 +71,8 @@ export class DockerPseudoterminal implements Pseudoterminal {
                 this.writeOutput(stdout);
             },
             stdoutBuffer,
-            (stderr: string, process: ChildProcess) => {
-                // Only write stdErr if the process is alive.
-                // If the process is closed, then the error will be thrown in spawnAsync.
-                if (process.connected) {
-                    this.writeError(stderr);
-                }
+            (stderr: string) => {
+                this.writeError(stderr);
 
                 if (rejectOnStderr) {
                     throw new Error(stderr);

--- a/src/tasks/DockerPseudoterminal.ts
+++ b/src/tasks/DockerPseudoterminal.ts
@@ -11,6 +11,7 @@ import { DockerBuildTask } from './DockerBuildTaskProvider';
 import { DockerRunTask } from './DockerRunTaskProvider';
 import { DockerTaskProvider } from './DockerTaskProvider';
 import { DockerTaskExecutionContext } from './TaskHelper';
+import { ChildProcess } from 'child_process';
 
 const DEFAULT = '0m';
 const DEFAULTBOLD = '0;1m';
@@ -71,8 +72,12 @@ export class DockerPseudoterminal implements Pseudoterminal {
                 this.writeOutput(stdout);
             },
             stdoutBuffer,
-            (stderr: string) => {
-                this.writeError(stderr);
+            (stderr: string, process: ChildProcess) => {
+                // Only write stdErr if the process is alive.
+                // If the process is closed, then the error will be thrown in spawnAsync.
+                if (process.connected) {
+                    this.writeError(stderr);
+                }
 
                 if (rejectOnStderr) {
                     throw new Error(stderr);

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -54,14 +54,14 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
         const commandLine = await this.resolveCommandLine(definition.dockerRun);
 
         const stdoutBuffer = Buffer.alloc(4 * 1024); // Any output beyond 4K is not a container ID and we won't deal with it
-        const stdrrrBuffer = Buffer.alloc(4 * 1024)
+        const stderrBuffer = Buffer.alloc(10 * 1024);
 
         await context.terminal.executeCommandInTerminal(
             commandLine,
             context.folder,
             true, // rejectOnStderr
             stdoutBuffer,
-            stdrrrBuffer,
+            stderrBuffer,
             context.cancellationToken
         );
         throwIfCancellationRequested(context);

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -54,12 +54,14 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
         const commandLine = await this.resolveCommandLine(definition.dockerRun);
 
         const stdoutBuffer = Buffer.alloc(4 * 1024); // Any output beyond 4K is not a container ID and we won't deal with it
+        const stdrrrBuffer = Buffer.alloc(4 * 1024)
+
         await context.terminal.executeCommandInTerminal(
             commandLine,
             context.folder,
             true, // rejectOnStderr
             stdoutBuffer,
-            undefined, // stderrBuffer
+            stdrrrBuffer,
             context.cancellationToken
         );
         throwIfCancellationRequested(context);

--- a/src/tasks/DockerTaskProvider.ts
+++ b/src/tasks/DockerTaskProvider.ts
@@ -8,6 +8,7 @@ import { callWithTelemetryAndErrorHandling, IActionContext, parseError } from 'v
 import { DockerOrchestration } from '../constants';
 import { DockerPlatform, getPlatform } from '../debugging/DockerPlatformHelper';
 import { localize } from '../localize';
+import { ExecError } from '../utils/spawnAsync';
 import { DockerBuildTask } from './DockerBuildTaskProvider';
 import { DockerPseudoterminal } from './DockerPseudoterminal';
 import { DockerRunTask } from './DockerRunTaskProvider';
@@ -53,7 +54,11 @@ export abstract class DockerTaskProvider implements TaskProvider {
         } catch (err) {
             // Errors will not be rethrown, rather it will simply return an error code or 1
             const error = parseError(err);
-            context.terminal.writeErrorLine(error.message);
+
+            if (!(err as ExecError)?.stdErrHandled) {
+                context.terminal.writeErrorLine(error.message);
+            }
+
             return parseInt(error.errorType, 10) || 1;
         }
 

--- a/src/utils/spawnAsync.ts
+++ b/src/utils/spawnAsync.ts
@@ -13,7 +13,7 @@ const DEFAULT_BUFFER_SIZE = 10 * 1024; // The default Node.js `exec` buffer size
 export type Progress = (content: string, process: cp.ChildProcess) => void;
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-type ExecError = Error & { code: any, signal: any };
+export type ExecError = Error & { code: any, signal: any, stdErrHandled: boolean };
 
 export async function spawnAsync(
     command: string,
@@ -57,7 +57,6 @@ export async function spawnAsync(
                 let errorMessage = localize('vscode-docker.utils.spawn.exited', 'Process \'{0}\' exited with code {1}', command.length > 50 ? `${command.substring(0, 50)}...` : command, code);
 
                 if (stderrBuffer) {
-                    // If there was no progress handler for stderr, then the error output would be lost, so help mitigate that by putting the error output into the Error we throw
                     errorMessage += localize('vscode-docker.utils.spawn.exitedError', '\nError: {0}', bufferToString(stderrBuffer));
                 }
 
@@ -65,6 +64,8 @@ export async function spawnAsync(
 
                 error.code = code;
                 error.signal = signal;
+                error.stdErrHandled = onStderr != null;
+
                 return reject(error);
             }
 

--- a/src/utils/spawnAsync.ts
+++ b/src/utils/spawnAsync.ts
@@ -56,7 +56,7 @@ export async function spawnAsync(
             } else if (code) {
                 let errorMessage = localize('vscode-docker.utils.spawn.exited', 'Process \'{0}\' exited with code {1}', command.length > 50 ? `${command.substring(0, 50)}...` : command, code);
 
-                if (!onStderr && stderrBuffer) {
+                if (stderrBuffer) {
                     // If there was no progress handler for stderr, then the error output would be lost, so help mitigate that by putting the error output into the Error we throw
                     errorMessage += localize('vscode-docker.utils.spawn.exitedError', '\nError: {0}', bufferToString(stderrBuffer));
                 }


### PR DESCRIPTION
- Pass the stdErr buffer for both docker-build and docker-run task providers to ensure the error message makes its way to telemetry
- Add a new flag to the error from spawnAsync the determines if the error is already written through the handler to avoid duplication