### PR TITLE
Feature to easily find and remove dependent child images

### DIFF
--- a/src/commands/images/removeImage.ts
+++ b/src/commands/images/removeImage.ts
@@ -21,9 +21,9 @@ export async function removeImage(context: IActionContext, node?: ImageTreeItem,
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = localize('vscode-docker.commands.images.remove.confirmSingle', 'Are you sure you want to remove image "{0}"? This will remove all matching and child images.', nodes[0].label);
+        confirmRemove = localize('vscode-docker.commands.images.remove.confirmSingle', 'Are you sure you want to remove image "{0}"? This will remove all matching images.', nodes[0].fullTag);
     } else {
-        confirmRemove = localize('vscode-docker.commands.images.remove.confirmMulti', 'Are you sure you want to remove selected images? This will remove all matching and child images.');
+        confirmRemove = localize('vscode-docker.commands.images.remove.confirmMulti', 'Are you sure you want to remove selected images? This will remove all matching images.');
     }
 
     // no need to check result - cancel will throw a UserCancelledError

--- a/src/tree/images/ImageTreeItem.ts
+++ b/src/tree/images/ImageTreeItem.ts
@@ -87,7 +87,7 @@ export class ImageTreeItem extends AzExtTreeItem {
         const childTags = await this.getChildImageTags();
 
         if (childTags.length > 0) {
-            const message = localize('vscode-docker.tree.images.dependentImages', 'Image {0} cannot be removed because the following images depend on it and must be removed first: {1}', this.fullTag, childTags.join(', '));
+            const message = localize('vscode-docker.tree.images.dependentImages', 'Image {0} cannot be removed because the following image(s) depend on it and must be removed first: {1}', this.fullTag, childTags.join(', '));
             const removeChildren = localize('vscode-docker.tree.images.removeDependentImages', 'Remove Dependent Images');
 
             const allImageNodes = await ext.imagesRoot.getFlattenedCachedChildren(context);


### PR DESCRIPTION
Fixes #1529. This adds the ability to easily find and remove dependent child images.

![image](https://user-images.githubusercontent.com/36966225/77099353-2b6c4100-69ea-11ea-88f9-ce60d2a3ef3d.png)

![image](https://user-images.githubusercontent.com/36966225/77099363-3030f500-69ea-11ea-9e93-3a0689a84326.png)

Note that the user will need to re-run the removal of the chosen image after executing the above buttons. Additionally, there is a shortcoming where if an image has both tagged _and_ dangling child images, the first prompt will show; removing those will result in the second prompt being shown.