### PR TITLE
Convert the platform to a string in tasks telemetry

### DIFF
--- a/src/tasks/DockerTaskProvider.ts
+++ b/src/tasks/DockerTaskProvider.ts
@@ -47,7 +47,7 @@ export abstract class DockerTaskProvider implements TaskProvider {
                 context.actionContext = actionContext;
                 context.platform = getPlatform(task.definition);
 
-                context.actionContext.telemetry.properties.platform = context.platform;
+                context.actionContext.telemetry.properties.platform = context.platform.toString();
                 context.actionContext.telemetry.properties.orchestration = 'single' as DockerOrchestration; // TODO: docker-compose, when support is added
                 await this.executeTaskInternal(context, task);
             });


### PR DESCRIPTION
An attempt to fix the "platform" not showing up in the tasks telemetry.