### PR TITLE
Fix login to Azure

### DIFF
--- a/src/tree/registries/auth/AzureOAuthProvider.ts
+++ b/src/tree/registries/auth/AzureOAuthProvider.ts
@@ -24,7 +24,7 @@ class AzureOAuthProvider implements IAuthProvider {
 
     public async getDockerCliCredentials(cachedProvider: ICachedRegistryProvider, authContext?: IAzureOAuthContext): Promise<IDockerCliCredentials> {
         return {
-            registryPath: cachedProvider.url,
+            registryPath: `https://${authContext.service}`,
             auth: {
                 token: await acquireAcrRefreshToken(authContext.realm.host, authContext.subscriptionContext),
             },


### PR DESCRIPTION
Fixes #1776.

`cachedProvider.url` was empty because for Azure, that `cachedProvider` is shared across all registries in the entire Azure account. `authContext` however is specific to each ACR.