### PR TITLE
Pull by default whenever possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1364,7 +1364,7 @@
                             "type": "string"
                         }
                     ],
-                    "default": "docker build --rm -f \"${dockerfile}\" -t ${tag} \"${context}\"",
+                    "default": "docker build --pull --rm -f \"${dockerfile}\" -t ${tag} \"${context}\"",
                     "description": "%vscode-docker.config.template.build.description%"
                 },
                 "docker.commands.run": {

--- a/src/commands/selectCommandTemplate.ts
+++ b/src/commands/selectCommandTemplate.ts
@@ -21,7 +21,7 @@ type CommandTemplate = {
 // So, when modifying them here, be sure to modify them there as well!
 const defaults: { [key in TemplateCommand]: CommandTemplate } = {
     /* eslint-disable no-template-curly-in-string */
-    'build': { label: 'Docker Build', template: 'docker build --rm -f "${dockerfile}" -t ${tag} "${context}"' },
+    'build': { label: 'Docker Build', template: 'docker build --pull --rm -f "${dockerfile}" -t ${tag} "${context}"' },
     'run': { label: 'Docker Run', template: 'docker run --rm -d ${exposedPorts} ${tag}' },
     'runInteractive': { label: 'Docker Run (Interactive)', template: 'docker run --rm -it ${exposedPorts} ${tag}' },
     'attach': { label: 'Docker Attach', template: 'docker exec -it ${containerId} ${shellCommand}' },

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -39,7 +39,8 @@ export class PythonTaskHelper implements TaskHelper {
                     dockerfile: unresolveWorkspaceFolder(context.dockerfile, context.folder),
                     /* eslint-disable no-template-curly-in-string */
                     context: '${workspaceFolder}'
-                }
+                },
+                pull: true,
             }
         ];
     }
@@ -91,14 +92,14 @@ export class PythonTaskHelper implements TaskHelper {
 
     public async getDockerRunOptions(context: DockerRunTaskContext, runDefinition: DockerRunTaskDefinition): Promise<DockerRunOptions> {
         // tslint:disable no-unsafe-any
-        const helperOptions : PythonTaskRunOptions = runDefinition.python || {};
-        const runOptions : DockerRunOptions = runDefinition.dockerRun;
+        const helperOptions: PythonTaskRunOptions = runDefinition.python || {};
+        const runOptions: DockerRunOptions = runDefinition.dockerRun;
 
         const target: PythonTarget = helperOptions.file
             ? { file: helperOptions.file, }
             : { module: helperOptions.module };
 
-        const launcherCommand : string = PythonExtensionHelper.getRemotePtvsdCommand(
+        const launcherCommand: string = PythonExtensionHelper.getRemotePtvsdCommand(
             target,
             helperOptions.args,
             {


### PR DESCRIPTION
I added `--pull` to all of our `docker build` commands.

I'd like to do something for `docker-compose up`, but the [maintainers have spent years resisting adding such a feature](https://github.com/docker/compose/issues/3574). There _is_ the `docker-compose pull` command, however, the command lines would be ugly, and maybe incorrect because `docker-compose pull` does not allow for specifying compose files.