### PR TITLE
Validate dependency build task

### DIFF
--- a/src/commands/debugging/initializeForDebugging.ts
+++ b/src/commands/debugging/initializeForDebugging.ts
@@ -5,6 +5,7 @@
 
 import * as os from 'os';
 import { IActionContext } from 'vscode-azureextensionui';
+import { ensureDotNetCoreDependencies } from '../../configureWorkspace/configureDotNetCore';
 import { promptForLaunchFile } from '../../configureWorkspace/configurePython';
 import { quickPickOS, quickPickPlatform } from '../../configureWorkspace/configUtils';
 import { DockerDebugScaffoldContext } from '../../debugging/DebugHelper';
@@ -38,6 +39,9 @@ export async function initializeForDebugging(actionContext: IActionContext): Pro
     }
 
     actionContext.telemetry.properties.platform = debugPlatform;
+    if (debugPlatform === 'netCore') {
+        ensureDotNetCoreDependencies(folder, actionContext);
+    }
 
     const context: DockerDebugScaffoldContext = {
         folder: folder,

--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -20,6 +20,7 @@ import { DockerDebugScaffoldContext } from '../debugging/DebugHelper';
 import { dockerDebugScaffoldingProvider, NetCoreScaffoldingOptions } from '../debugging/DockerDebugScaffoldingProvider';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
+import { hasTask } from '../tasks/TaskHelper';
 import { extractRegExGroups } from '../utils/extractRegExGroups';
 import { getValidImageName } from '../utils/getValidImageName';
 import { globAsync } from '../utils/globAsync';
@@ -396,6 +397,7 @@ async function inferOutputAssemblyName(appProjectFilePath: string): Promise<stri
 
 // tslint:disable-next-line: export-name
 export async function scaffoldNetCore(context: ScaffolderContext): Promise<ScaffoldFile[]> {
+    ensureDotNetCoreDependencies(context.folder, context);
     const os = context.os ?? (context.os = await context.promptForOS());
     const isCompose = await context.promptForCompose();
 
@@ -461,4 +463,12 @@ export async function scaffoldNetCore(context: ScaffolderContext): Promise<Scaff
     }
 
     return files;
+}
+
+export function ensureDotNetCoreDependencies(workspaceFolder: WorkspaceFolder, context: IActionContext): void {
+    if (!hasTask('build', workspaceFolder)) {
+        context.errorHandling.suppressReportIssue = true;
+        const message = localize('vscode-docker.configureDotNetCore.missingDependencies', 'Dependency build task is missing. Please generate build task by running \'.NET: Generate Assets for Build an Debug\' before running this command');
+        throw new Error(message);
+    }
 }

--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -468,7 +468,7 @@ export async function scaffoldNetCore(context: ScaffolderContext): Promise<Scaff
 export function ensureDotNetCoreDependencies(workspaceFolder: WorkspaceFolder, context: IActionContext): void {
     if (!hasTask('build', workspaceFolder)) {
         context.errorHandling.suppressReportIssue = true;
-        const message = localize('vscode-docker.configureDotNetCore.missingDependencies', 'Dependency build task is missing. Please generate build task by running \'.NET: Generate Assets for Build an Debug\' before running this command');
+        const message = localize('vscode-docker.configureDotNetCore.missingDependencies', 'A build task is missing. Please generate build task by running \'.NET: Generate Assets for Build and Debug\' before running this command');
         throw new Error(message);
     }
 }

--- a/src/tasks/TaskHelper.ts
+++ b/src/tasks/TaskHelper.ts
@@ -91,6 +91,12 @@ export function registerTaskProviders(ctx: ExtensionContext): void {
     );
 }
 
+export function hasTask(taskLabel: string, folder: WorkspaceFolder): boolean {
+    const workspaceTasks = workspace.getConfiguration('tasks', folder.uri);
+    const allTasks = workspaceTasks && workspaceTasks.tasks as TaskDefinitionBase[] || [];
+    return allTasks.findIndex(t => t.label === taskLabel) > -1;
+}
+
 export async function addTask(newTask: DockerBuildTaskDefinition | DockerRunTaskDefinition, folder: WorkspaceFolder, overwrite?: boolean): Promise<boolean> {
     // Using config API instead of tasks API means no wasted perf on re-resolving the tasks, and avoids confusion on resolved type !== true type
     const workspaceTasks = workspace.getConfiguration('tasks', folder.uri);

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -1403,7 +1403,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                 assertFileContains('Dockerfile', 'EXPOSE 555');
             });
 
-            testInEmptyFolder("Only platform/OS specified, others come from user", async () => {
+            testInEmptyFolderWithBuildTask("Only platform/OS specified, others come from user", async () => {
                 await writeFile('projectFolder1', 'aspnetapp.csproj', dotNetCoreConsole_21_ProjectFileContents);
                 await writeFile('projectFolder2', 'aspnetapp.csproj', dotNetCoreConsole_21_ProjectFileContents);
 
@@ -1446,7 +1446,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                 // The service folder will only have 0 or 1 csproj within them. So even though there are multiple service directories within the root, we will only be passed 1 service directory at a time, so that only 1 dockerFile generation happens at a time.
                 // So the command which is "Add DockerFile to this Workspace" now extends to "Add DockerFile to the directory", and we would do all the searching and processing only within the passed directory path.
 
-                testInEmptyFolder("All files in service folder, output to service folder", async () => {
+                testInEmptyFolderWithBuildTask("All files in service folder, output to service folder", async () => {
                     let rootFolder = 'serviceFolder';
                     await writeFile(rootFolder, 'somefile1.cs', "// Some file");
                     await writeFile(rootFolder, 'aspnetapp.csproj', dotNetCoreConsole_21_ProjectFileContents);
@@ -1465,7 +1465,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                 });
 
 
-                testInEmptyFolder(".csproj file in subfolder, output to service folder", async () => {
+                testInEmptyFolderWithBuildTask(".csproj file in subfolder, output to service folder", async () => {
                     let rootFolder = 'serviceFolder';
                     await writeFile(path.join(rootFolder, 'subfolder1'), 'somefile1.cs', "// Some file");
                     await writeFile(path.join(rootFolder, 'subfolder1'), 'aspnetapp.csproj', dotNetCoreConsole_21_ProjectFileContents);
@@ -1483,7 +1483,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                     assertFileContains('serviceFolder/Dockerfile', 'ENTRYPOINT ["dotnet", "aspnetapp.dll"]');
                 });
 
-                testInEmptyFolder(".csproj file in subfolder, output to subfolder", async () => {
+                testInEmptyFolderWithBuildTask(".csproj file in subfolder, output to subfolder", async () => {
                     let rootFolder = 'serviceFolder';
                     await writeFile(path.join(rootFolder, 'subfolder1'), 'somefile1.cs', "// Some file");
                     await writeFile(path.join(rootFolder, 'subfolder1'), 'aspnetapp.csproj', aspNet_21_ProjectFileContents);

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import { Suite } from 'mocha';
 import { PlatformOS, Platform, ext, configure, ConfigureApiOptions, globAsync } from '../extension.bundle';
 import { IActionContext, TelemetryProperties, IAzExtOutputChannel, createAzExtOutputChannel } from 'vscode-azureextensionui';
-import { getTestRootFolder, testInEmptyFolder, testUserInput } from './global.test';
+import { getTestRootFolder, testInEmptyFolder, testUserInput, testInEmptyFolderWithBuildTask } from './global.test';
 import { TestInput } from 'vscode-azureextensiondev';
 import { ConfigureTelemetryProperties } from '../src/configureWorkspace/configUtils';
 
@@ -623,7 +623,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
     // .NET Core Console
 
     suite(".NET Core General", () => {
-        testInEmptyFolder("No project file", async () => {
+        testInEmptyFolderWithBuildTask("No project file", async () => {
             await assertEx.throwsOrRejectsAsync(async () =>
                 testConfigureDocker(
                     '.NET: Core Console',
@@ -639,13 +639,13 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             );
         });
 
-        testInEmptyFolder("ASP.NET Core no project file", async () => {
+        testInEmptyFolderWithBuildTask("ASP.NET Core no project file", async () => {
             await assertEx.throwsOrRejectsAsync(async () => testConfigureDocker('.NET: ASP.NET Core', {}, ['Windows', 'No', '1234']),
                 { message: "No .csproj or .fsproj file could be found. You need a C# or F# project file in the workspace to generate Docker files for the selected platform." }
             );
         });
 
-        testInEmptyFolder("Multiple project files", async () => {
+        testInEmptyFolderWithBuildTask("Multiple project files", async () => {
             await writeFile('projectFolder1', 'aspnetapp.csproj', dotNetCoreConsole_21_ProjectFileContents);
             await writeFile('projectFolder2', 'aspnetapp.csproj', dotNetCoreConsole_21_ProjectFileContents);
             await testConfigureDocker(
@@ -668,7 +668,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
     });
 
     suite(".NET Core Console 2.1", async () => {
-        testInEmptyFolder("Windows", async () => {
+        testInEmptyFolderWithBuildTask("Windows", async () => {
             await testDotNetCoreConsole(
                 'Windows',
                 'Windows',
@@ -703,7 +703,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertNotFileContains('ConsoleApp1Folder/Dockerfile', 'EXPOSE');
         });
 
-        testInEmptyFolder("Linux", async () => {
+        testInEmptyFolderWithBuildTask("Linux", async () => {
             await testDotNetCoreConsole(
                 'Linux',
                 'Linux',
@@ -737,7 +737,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
     });
 
     suite(".NET Core Console 2.0", async () => {
-        testInEmptyFolder("Windows", async () => {
+        testInEmptyFolderWithBuildTask("Windows", async () => {
             await testDotNetCoreConsole(
                 'Windows',
                 'Windows',
@@ -772,7 +772,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertNotFileContains('subfolder/projectFolder/Dockerfile', 'EXPOSE');
         });
 
-        testInEmptyFolder("Linux", async () => {
+        testInEmptyFolderWithBuildTask("Linux", async () => {
             await testDotNetCoreConsole(
                 'Linux',
                 'Linux',
@@ -806,7 +806,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
     });
 
     suite(".NET Core Console 1.1", async () => {
-        testInEmptyFolder("Windows", async () => {
+        testInEmptyFolderWithBuildTask("Windows", async () => {
             await testDotNetCoreConsole(
                 'Windows',
                 'Windows',
@@ -820,7 +820,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('subfolder/projectFolder/Dockerfile', 'FROM microsoft/dotnet:1.1-sdk AS build');
         });
 
-        testInEmptyFolder("Linux", async () => {
+        testInEmptyFolderWithBuildTask("Linux", async () => {
             await testDotNetCoreConsole(
                 'Linux',
                 'Linux',
@@ -836,7 +836,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
     });
 
     suite(".NET Core Console 2.2", async () => {
-        testInEmptyFolder("Windows", async () => {
+        testInEmptyFolderWithBuildTask("Windows", async () => {
             await testDotNetCoreConsole(
                 'Windows',
                 'Windows',
@@ -850,7 +850,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('subfolder/projectFolder/Dockerfile', 'FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1809 AS build');
         });
 
-        testInEmptyFolder("Linux", async () => {
+        testInEmptyFolderWithBuildTask("Linux", async () => {
             await testDotNetCoreConsole(
                 'Linux',
                 'Linux',
@@ -868,7 +868,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
     // ASP.NET Core
 
     suite("ASP.NET Core 2.2", async () => {
-        testInEmptyFolder("Default port (80)", async () => {
+        testInEmptyFolderWithBuildTask("Default port (80)", async () => {
             await writeFile('projectFolder1', 'aspnetapp.csproj', dotNetCoreConsole_21_ProjectFileContents);
             await testConfigureDocker(
                 '.NET: ASP.NET Core',
@@ -879,7 +879,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('projectFolder1/Dockerfile', 'EXPOSE 80');
         });
 
-        testInEmptyFolder("No port", async () => {
+        testInEmptyFolderWithBuildTask("No port", async () => {
             await writeFile('projectFolder1', 'aspnetapp.csproj', dotNetCoreConsole_21_ProjectFileContents);
             await testConfigureDocker(
                 '.NET: ASP.NET Core',
@@ -890,7 +890,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertNotFileContains('projectFolder1/Dockerfile', 'EXPOSE');
         });
 
-        testInEmptyFolder("Windows 10 RS5", async () => {
+        testInEmptyFolderWithBuildTask("Windows 10 RS5", async () => {
             await testAspNetCore(
                 'Windows',
                 'Windows',
@@ -924,7 +924,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                 `));
         });
 
-        testInEmptyFolder("Linux", async () => {
+        testInEmptyFolderWithBuildTask("Linux", async () => {
             await testAspNetCore(
                 'Linux',
                 'Linux',
@@ -955,7 +955,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                 `));
         });
 
-        testInEmptyFolder("Windows 10 RS4", async () => {
+        testInEmptyFolderWithBuildTask("Windows 10 RS4", async () => {
             await testAspNetCore(
                 'Windows',
                 'Windows',
@@ -968,7 +968,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('AspNetApp1/Dockerfile', 'FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1803 AS build');
         });
 
-        testInEmptyFolder("Windows 10 RS3", async () => {
+        testInEmptyFolderWithBuildTask("Windows 10 RS3", async () => {
             await testAspNetCore(
                 'Windows',
                 'Windows',
@@ -981,7 +981,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('AspNetApp1/Dockerfile', 'FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-1709 AS build');
         });
 
-        testInEmptyFolder("Windows Server 2016", async () => {
+        testInEmptyFolderWithBuildTask("Windows Server 2016", async () => {
             await testAspNetCore(
                 'Windows',
                 'Windows',
@@ -994,7 +994,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('AspNetApp1/Dockerfile', 'FROM mcr.microsoft.com/dotnet/core/sdk:2.2-nanoserver-sac2016 AS build');
         });
 
-        testInEmptyFolder("Host=Linux", async () => {
+        testInEmptyFolderWithBuildTask("Host=Linux", async () => {
             await testAspNetCore(
                 'Windows',
                 'Linux',
@@ -1009,7 +1009,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
     });
 
     suite("ASP.NET Core 1.1", async () => {
-        testInEmptyFolder("Windows", async () => {
+        testInEmptyFolderWithBuildTask("Windows", async () => {
             await testAspNetCore(
                 'Windows',
                 'Windows',
@@ -1024,7 +1024,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
     });
 
     suite("ASP.NET Core 2.0", async () => {
-        testInEmptyFolder("Linux", async () => {
+        testInEmptyFolderWithBuildTask("Linux", async () => {
             await testAspNetCore(
                 'Linux',
                 'Linux',

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -8,7 +8,7 @@ import * as fse from "fs-extra";
 import * as mocha from 'mocha';
 import * as path from "path";
 import * as vscode from "vscode";
-import { ext } from "../extension.bundle";
+import { ext, TaskDefinitionBase } from "../extension.bundle";
 import { TestKeytar } from "../test/testKeytar";
 import { TestUserInput } from 'vscode-azureextensiondev';
 
@@ -54,6 +54,18 @@ export function getTestRootFolder(): string {
  * Run a test with an empty root testing folder (i.e. delete everything out of it before running the test).
  * This is important since we can't open new folders in vscode while tests are running
  */
+export function testInEmptyFolderWithBuildTask(name: string, func?: mocha.AsyncFunc): void {
+    // Ensure build task is created which is required for NetCore scaffolding.
+    const workspacefolder = vscode.workspace.workspaceFolders[0];
+    createBuildTask(workspacefolder);
+
+    testInEmptyFolder(name, func);
+}
+
+/**
+ * Run a test with an empty root testing folder (i.e. delete everything out of it before running the test).
+ * This is important since we can't open new folders in vscode while tests are running
+ */
 export function testInEmptyFolder(name: string, func?: mocha.AsyncFunc): void {
     test(name, !func ? undefined : async function (this: mocha.Context) {
         // Delete everything in the root testing folder
@@ -61,6 +73,23 @@ export function testInEmptyFolder(name: string, func?: mocha.AsyncFunc): void {
         await fse.emptyDir(testRootFolder);
         await func.apply(this);
     });
+}
+
+export async function createBuildTask(folder: vscode.WorkspaceFolder): Promise<void> {
+    const workspaceTasks = vscode.workspace.getConfiguration('tasks', folder.uri);
+    const allTasks = workspaceTasks && workspaceTasks.tasks as TaskDefinitionBase[] || [];
+    const existingTaskIndex = allTasks.findIndex(t => t.label === 'build');
+
+    if (existingTaskIndex == -1) {
+        var buildTask = {
+            label: 'build',
+            command: 'dotnet',
+            type: 'process'
+        };
+
+        allTasks.push(buildTask);
+        await workspaceTasks.update('tasks', allTasks, vscode.ConfigurationTarget.WorkspaceFolder);
+    }
 }
 
 // Runs before all tests

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -57,6 +57,8 @@ export function getTestRootFolder(): string {
 export function testInEmptyFolderWithBuildTask(name: string, func?: mocha.AsyncFunc): void {
     // Ensure build task is created which is required for NetCore scaffolding.
     const workspacefolder = vscode.workspace.workspaceFolders[0];
+    console.log(`workspacefolder length=${vscode.workspace.workspaceFolders.length}`);
+    console.log(`Creating build task in workspace folder ${workspacefolder}`);
     createBuildTask(workspacefolder);
 
     testInEmptyFolder(name, func);

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -58,7 +58,6 @@ export function testInEmptyFolderWithBuildTask(name: string, func?: mocha.AsyncF
     test(name, !func ? undefined : async function (this: mocha.Context) {
         // Ensure build task is created which is required for NetCore scaffolding.
         const workspacefolder = vscode.workspace.workspaceFolders[0];
-        console.log(`Creating build task in workspace folder ${workspacefolder.uri}`);
         await createBuildTask(workspacefolder);
 
         // Delete everything in the root testing folder
@@ -84,9 +83,7 @@ export function testInEmptyFolder(name: string, func?: mocha.AsyncFunc): void {
 export async function createBuildTask(folder: vscode.WorkspaceFolder): Promise<void> {
     const workspaceTasks = vscode.workspace.getConfiguration('tasks', folder.uri);
     const allTasks = workspaceTasks && workspaceTasks.tasks as TaskDefinitionBase[] || [];
-    console.log(`allTasks length=${allTasks.length}`);
     const existingTaskIndex = allTasks.findIndex(t => t.label === 'build');
-    console.log(`existing build task index=${existingTaskIndex}`);
     if (existingTaskIndex == -1) {
         var buildTask = {
             label: 'build',
@@ -95,7 +92,6 @@ export async function createBuildTask(folder: vscode.WorkspaceFolder): Promise<v
         };
 
         allTasks.push(buildTask);
-        console.log(`allTasks length after update=${allTasks.length}`);
         await workspaceTasks.update('tasks', allTasks, vscode.ConfigurationTarget.WorkspaceFolder);
     }
 }


### PR DESCRIPTION
This change will prevent user from creating docker specific tasks and config without the net core tasks.
During Net Core scaffolding, validate if the dotnet core build task is present or not and block scaffolding the docker specific tasks.

Fixes #1423, #1300 