### PR TITLE
Set scope to machine for imageBuildContextPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -1798,7 +1798,7 @@
                     "type": "string",
                     "default": "",
                     "description": "%vscode-docker.config.docker.imageBuildContextPath%",
-                    "scope": "machine"
+                    "scope": "machine-overridable"
                 },
                 "docker.truncateLongRegistryPaths": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1797,7 +1797,8 @@
                 "docker.imageBuildContextPath": {
                     "type": "string",
                     "default": "",
-                    "description": "%vscode-docker.config.docker.imageBuildContextPath%"
+                    "description": "%vscode-docker.config.docker.imageBuildContextPath%",
+                    "scope": "machine"
                 },
                 "docker.truncateLongRegistryPaths": {
                     "type": "boolean",


### PR DESCRIPTION
This will essentially avoid reading this setting (if set in the User settings) in remote scenarios, which makes sense since the path might not make sense when running in a container/WSL.