### PR TITLE
Make a few more settings machine-scoped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1807,22 +1807,26 @@
                 "docker.host": {
                     "type": "string",
                     "default": "",
-                    "description": "%vscode-docker.config.docker.host%"
+                    "description": "%vscode-docker.config.docker.host%",
+                    "scope": "machine-overridable"
                 },
                 "docker.certPath": {
                     "type": "string",
                     "default": "",
-                    "description": "%vscode-docker.config.docker.certPath%"
+                    "description": "%vscode-docker.config.docker.certPath%",
+                    "scope": "machine-overridable"
                 },
                 "docker.tlsVerify": {
                     "type": "string",
                     "default": "",
-                    "description": "%vscode-docker.config.docker.tlsVerify%"
+                    "description": "%vscode-docker.config.docker.tlsVerify%",
+                    "scope": "machine-overridable"
                 },
                 "docker.machineName": {
                     "type": "string",
                     "default": "",
-                    "description": "%vscode-docker.config.docker.machineName%"
+                    "description": "%vscode-docker.config.docker.machineName%",
+                    "scope": "machine-overridable"
                 },
                 "docker.languageserver.diagnostics.deprecatedMaintainer": {
                     "scope": "resource",


### PR DESCRIPTION
Additional changes for #993. It seems to me that the four settings that control `DOCKER_*` environment variables ought to be machine-scoped. This might also fix #1769.