### PR TITLE
Change to removing images by name

### DIFF
--- a/src/commands/images/removeImage.ts
+++ b/src/commands/images/removeImage.ts
@@ -23,7 +23,7 @@ export async function removeImage(context: IActionContext, node?: ImageTreeItem,
     if (nodes.length === 1) {
         confirmRemove = localize('vscode-docker.commands.images.remove.confirmSingle', 'Are you sure you want to remove image "{0}"? If there are other tags or child images for this image, only the tag will be removed.', nodes[0].fullTag);
     } else {
-        confirmRemove = localize('vscode-docker.commands.images.remove.confirmMulti', 'Are you sure you want to remove the selected images? If there are other tags or child images for this image, only the tag will be removed.');
+        confirmRemove = localize('vscode-docker.commands.images.remove.confirmMulti', 'Are you sure you want to remove the selected images? If there are other tags or child images for these images, only the tag will be removed.');
     }
 
     // no need to check result - cancel will throw a UserCancelledError

--- a/src/commands/images/removeImage.ts
+++ b/src/commands/images/removeImage.ts
@@ -21,9 +21,9 @@ export async function removeImage(context: IActionContext, node?: ImageTreeItem,
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = localize('vscode-docker.commands.images.remove.confirmSingle', 'Are you sure you want to remove image "{0}"? If there are other tags or child images, only the tag will be removed.', nodes[0].fullTag);
+        confirmRemove = localize('vscode-docker.commands.images.remove.confirmSingle', 'Are you sure you want to remove image "{0}"? If there are other tags or child images for this image, only the tag will be removed.', nodes[0].fullTag);
     } else {
-        confirmRemove = localize('vscode-docker.commands.images.remove.confirmMulti', 'Are you sure you want to remove the selected images? If there are other tags or child images, only the tag will be removed.');
+        confirmRemove = localize('vscode-docker.commands.images.remove.confirmMulti', 'Are you sure you want to remove the selected images? If there are other tags or child images for this image, only the tag will be removed.');
     }
 
     // no need to check result - cancel will throw a UserCancelledError

--- a/src/commands/images/removeImage.ts
+++ b/src/commands/images/removeImage.ts
@@ -21,9 +21,9 @@ export async function removeImage(context: IActionContext, node?: ImageTreeItem,
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = localize('vscode-docker.commands.images.remove.confirmSingle', 'Are you sure you want to remove image "{0}"? This will remove all matching and child images.', nodes[0].label);
+        confirmRemove = localize('vscode-docker.commands.images.remove.confirmSingle', 'Are you sure you want to remove image "{0}"? If there are other tags or child images, only the tag will be removed.', nodes[0].fullTag);
     } else {
-        confirmRemove = localize('vscode-docker.commands.images.remove.confirmMulti', 'Are you sure you want to remove selected images? This will remove all matching and child images.');
+        confirmRemove = localize('vscode-docker.commands.images.remove.confirmMulti', 'Are you sure you want to remove the selected images? If there are other tags or child images, only the tag will be removed.');
     }
 
     // no need to check result - cancel will throw a UserCancelledError

--- a/src/commands/images/runImage.ts
+++ b/src/commands/images/runImage.ts
@@ -7,6 +7,7 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
+import { callDockerode } from '../../utils/callDockerode';
 import { selectRunCommand } from '../selectCommandTemplate';
 
 export async function runImage(context: IActionContext, node?: ImageTreeItem): Promise<void> {
@@ -26,7 +27,7 @@ async function runImageCore(context: IActionContext, node: ImageTreeItem | undef
     }
 
     const image = await node.getImage();
-    const inspectInfo = await image.inspect();
+    const inspectInfo = await callDockerode(async () => image.inspect());
 
     const terminalCommand = await selectRunCommand(
         context,

--- a/src/tree/containers/ContainerGroupTreeItem.ts
+++ b/src/tree/containers/ContainerGroupTreeItem.ts
@@ -8,9 +8,9 @@ import { getThemedIconPath, IconPath } from "../IconPath";
 import { getImageGroupIcon } from "../images/ImageProperties";
 import { LocalGroupTreeItemBase } from "../LocalGroupTreeItemBase";
 import { ContainerProperty, getContainerStateIcon } from "./ContainerProperties";
-import { LocalContainerInfo } from "./LocalContainerInfo";
+import { ILocalContainerInfo } from "./LocalContainerInfo";
 
-export class ContainerGroupTreeItem extends LocalGroupTreeItemBase<LocalContainerInfo, ContainerProperty> {
+export class ContainerGroupTreeItem extends LocalGroupTreeItemBase<ILocalContainerInfo, ContainerProperty> {
     public static readonly contextValue: string = 'containerGroup';
     public readonly contextValue: string = ContainerGroupTreeItem.contextValue;
     public childTypeLabel: string = 'container';

--- a/src/tree/containers/ContainerTreeItem.ts
+++ b/src/tree/containers/ContainerTreeItem.ts
@@ -9,14 +9,14 @@ import { ext } from "../../extensionVariables";
 import { callDockerode, callDockerodeWithErrorHandling } from "../../utils/callDockerode";
 import { getThemedIconPath, IconPath } from '../IconPath';
 import { getContainerStateIcon } from "./ContainerProperties";
-import { LocalContainerInfo } from "./LocalContainerInfo";
+import { ILocalContainerInfo } from "./LocalContainerInfo";
 
 export class ContainerTreeItem extends AzExtTreeItem {
     public static allContextRegExp: RegExp = /Container$/;
     public static runningContainerRegExp: RegExp = /^runningContainer$/i;
-    private readonly _item: LocalContainerInfo;
+    private readonly _item: ILocalContainerInfo;
 
-    public constructor(parent: AzExtParentTreeItem, itemInfo: LocalContainerInfo) {
+    public constructor(parent: AzExtParentTreeItem, itemInfo: ILocalContainerInfo) {
         super(parent);
         this._item = itemInfo;
     }

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -13,15 +13,15 @@ import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettin
 import { ContainerGroupTreeItem } from "./ContainerGroupTreeItem";
 import { containerProperties, ContainerProperty } from "./ContainerProperties";
 import { ContainerTreeItem } from "./ContainerTreeItem";
-import { LocalContainerInfo } from "./LocalContainerInfo";
+import { ILocalContainerInfo, LocalContainerInfo } from "./LocalContainerInfo";
 
-export class ContainersTreeItem extends LocalRootTreeItemBase<LocalContainerInfo, ContainerProperty> {
+export class ContainersTreeItem extends LocalRootTreeItemBase<ILocalContainerInfo, ContainerProperty> {
     public treePrefix: string = 'containers';
     public label: string = localize('vscode-docker.tree.containers.label', 'Containers');
     public configureExplorerTitle: string = localize('vscode-docker.tree.containers.configure', 'Configure containers explorer');
 
-    public childType: LocalChildType<LocalContainerInfo> = ContainerTreeItem;
-    public childGroupType: LocalChildGroupType<LocalContainerInfo, ContainerProperty> = ContainerGroupTreeItem;
+    public childType: LocalChildType<ILocalContainerInfo> = ContainerTreeItem;
+    public childGroupType: LocalChildGroupType<ILocalContainerInfo, ContainerProperty> = ContainerGroupTreeItem;
 
     public labelSettingInfo: ITreeSettingInfo<ContainerProperty> = {
         properties: containerProperties,
@@ -42,7 +42,7 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<LocalContainerInfo
         return this.groupBySetting === 'None' ? 'container' : 'container group';
     }
 
-    public async getItems(): Promise<LocalContainerInfo[]> {
+    public async getItems(): Promise<ILocalContainerInfo[]> {
         const options = {
             "filters": {
                 "status": ["created", "restarting", "running", "paused", "exited", "dead"]
@@ -53,7 +53,7 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<LocalContainerInfo
         return items.map(c => new LocalContainerInfo(c));
     }
 
-    public getPropertyValue(item: LocalContainerInfo, property: ContainerProperty): string {
+    public getPropertyValue(item: ILocalContainerInfo, property: ContainerProperty): string {
         switch (property) {
             case 'ContainerId':
                 return item.containerId.slice(0, 12);

--- a/src/tree/containers/LocalContainerInfo.ts
+++ b/src/tree/containers/LocalContainerInfo.ts
@@ -4,12 +4,26 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ContainerInfo } from "dockerode";
-import { ILocalImageInfo } from "../images/LocalImageInfo";
+import { ILocalItem } from "../LocalRootTreeItemBase";
+
+/**
+ * Interface implemented by `LocalContainerInfo`
+ */
+export interface ILocalContainerInfo extends ILocalItem {
+    fullTag: string;
+    imageId: string;
+    containerId: string;
+    containerName: string;
+    networks: string[];
+    ports: number[];
+    state: string;
+    status: string;
+}
 
 /**
  * Wrapper class for Dockerode item, which has inconsistent names/types
  */
-export class LocalContainerInfo implements ILocalImageInfo {
+export class LocalContainerInfo implements ILocalContainerInfo {
     private _containerName: string;
     public data: ContainerInfo;
     public constructor(data: ContainerInfo) {

--- a/src/tree/images/ImageTreeItem.ts
+++ b/src/tree/images/ImageTreeItem.ts
@@ -66,10 +66,11 @@ export class ImageTreeItem extends AzExtTreeItem {
         let image: Image;
 
         // Dangling images are not shown in the explorer. However, an image can end up with <none> tag, if a new version of that particular tag is pulled.
-        // For such cases, we need to delete by digest, not by tag.
         if (this.fullTag.endsWith(':<none>') && this._item.repoDigests && this._item.repoDigests.length > 0) {
+            // Image is tagged <none>. Need to delete by digest.
             image = await callDockerode(() => ext.dockerode.getImage(this._item.repoDigests[0]));
         } else {
+            // Image is normal. Delete by name.
             image = await callDockerode(() => ext.dockerode.getImage(this.fullTag));
         }
 

--- a/src/tree/images/ImageTreeItem.ts
+++ b/src/tree/images/ImageTreeItem.ts
@@ -4,10 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Image } from 'dockerode';
-import { window } from 'vscode';
-import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, IParsedError, parseError } from "vscode-azureextensionui";
+import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
 import { callDockerode, callDockerodeWithErrorHandling } from '../../utils/callDockerode';
 import { getThemedIconPath, IconPath } from '../IconPath';
 import { ILocalImageInfo } from './LocalImageInfo';
@@ -59,25 +57,11 @@ export class ImageTreeItem extends AzExtTreeItem {
     }
 
     public async getImage(): Promise<Image> {
-        return callDockerode(() => ext.dockerode.getImage(this.imageId));
+        return callDockerode(() => ext.dockerode.getImage(this.fullTag));
     }
 
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {
         const image: Image = await this.getImage();
-        try {
-            await callDockerodeWithErrorHandling(async () => image.remove({ force: true }), context);
-        } catch (error) {
-            const parsedError: IParsedError = parseError(error);
-
-            // error code 409 is returned for conflicts like the image is used by a running container or another image.
-            // Such errors are not really an error, it should be treated as warning.
-            if (parsedError.errorType === '409') {
-                ext.outputChannel.appendLog(localize('vscode-docker.tree.images.warning', 'Warning: {0}', parsedError.message));
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                window.showWarningMessage(parsedError.message);
-            } else {
-                throw error;
-            }
-        }
+        await callDockerodeWithErrorHandling(async () => image.remove({ force: true }), context);
     }
 }

--- a/src/tree/images/ImageTreeItem.ts
+++ b/src/tree/images/ImageTreeItem.ts
@@ -4,10 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Image } from 'dockerode';
-import { window } from 'vscode';
-import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, IParsedError, parseError } from "vscode-azureextensionui";
+import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
 import { callDockerode, callDockerodeWithErrorHandling } from '../../utils/callDockerode';
 import { getThemedIconPath, IconPath } from '../IconPath';
 import { ILocalImageInfo } from './LocalImageInfo';
@@ -74,20 +72,6 @@ export class ImageTreeItem extends AzExtTreeItem {
             image = await callDockerode(() => ext.dockerode.getImage(this.fullTag));
         }
 
-        try {
-            await callDockerodeWithErrorHandling(async () => image.remove({ force: true }), context);
-        } catch (error) {
-            const parsedError: IParsedError = parseError(error);
-
-            // error code 409 is returned for conflicts like the image is used by a running container or another image.
-            // Such errors are not really an error, it should be treated as warning.
-            if (parsedError.errorType === '409') {
-                ext.outputChannel.appendLog(localize('vscode-docker.tree.images.warning', 'Warning: {0}', parsedError.message));
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                window.showWarningMessage(parsedError.message);
-            } else {
-                throw error;
-            }
-        }
+        await callDockerodeWithErrorHandling(async () => image.remove({ force: true }), context);
     }
 }

--- a/src/tree/images/LocalImageInfo.ts
+++ b/src/tree/images/LocalImageInfo.ts
@@ -7,11 +7,12 @@ import { ImageInfo } from "dockerode";
 import { ILocalItem } from "../LocalRootTreeItemBase";
 
 /**
- * Common interface that both `LocalImageInfo` and `LocalContainerInfo` implement
+ * Interface implemented by `LocalImageInfo`
  */
 export interface ILocalImageInfo extends ILocalItem {
     fullTag: string;
     imageId: string;
+    repoDigests?: string[];
 }
 
 /**
@@ -35,5 +36,9 @@ export class LocalImageInfo implements ILocalImageInfo {
 
     public get treeId(): string {
         return this.fullTag + this.imageId;
+    }
+
+    public get repoDigests(): string[] {
+        return this.data.RepoDigests;
     }
 }


### PR DESCRIPTION
Fixes #1529, #333 (both indirectly).

If we remove by name instead of by ID, then the 409 conflict error won't happen anymore. If there are child images, then this will simply remove the tag of the parent image; later on if the child is removed it will also remove this parent image (assuming there aren't any other tags).