### PR TITLE
Add cleanUp option to the docker-run task

### DIFF
--- a/package.json
+++ b/package.json
@@ -1184,9 +1184,9 @@
                                     ]
                                 }
                             },
-                            "cleanUp": {
+                            "remove": {
                                 "type": "boolean",
-                                "description": "%vscode-docker.tasks.docker-run.dockerRun.cleanUp%",
+                                "description": "%vscode-docker.tasks.docker-run.dockerRun.remove%",
                                 "default": false
                             }
                         }

--- a/package.json
+++ b/package.json
@@ -1183,6 +1183,11 @@
                                         "containerPath"
                                     ]
                                 }
+                            },
+                            "cleanUp": {
+                                "type": "boolean",
+                                "description": "%vscode-docker.tasks.docker-run.dockerRun.cleanUp%",
+                                "default": false
                             }
                         }
                     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -71,6 +71,7 @@
     "vscode-docker.tasks.docker-run.dockerRun.ports.containerPort": "Port number of the container to be bound.",
     "vscode-docker.tasks.docker-run.dockerRun.ports.protocol": "Specific protocol for the binding (`tcp | udp`).",
     "vscode-docker.tasks.docker-run.dockerRun.portsPublishAll": "Whether to publish all exposed container ports to random ports on the host.",
+    "vscode-docker.tasks.docker-run.dockerRun.cleanUp": "Whether to clean up the container and remove the file system when the container exits.",
     "vscode-docker.tasks.docker-run.dockerRun.extraHosts.description": "Hosts to be added to the container's `hosts` file for DNS resolution.",
     "vscode-docker.tasks.docker-run.dockerRun.extraHosts.hostname": "Hostname for dns resolution.",
     "vscode-docker.tasks.docker-run.dockerRun.extraHosts.ip": "IP associated to the hostname.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -71,7 +71,7 @@
     "vscode-docker.tasks.docker-run.dockerRun.ports.containerPort": "Port number of the container to be bound.",
     "vscode-docker.tasks.docker-run.dockerRun.ports.protocol": "Specific protocol for the binding (`tcp | udp`).",
     "vscode-docker.tasks.docker-run.dockerRun.portsPublishAll": "Whether to publish all exposed container ports to random ports on the host.",
-    "vscode-docker.tasks.docker-run.dockerRun.cleanUp": "Whether to clean up the container and remove the file system when the container exits.",
+    "vscode-docker.tasks.docker-run.dockerRun.remove": "Whether to clean up the container and remove the file system when the container exits.",
     "vscode-docker.tasks.docker-run.dockerRun.extraHosts.description": "Hosts to be added to the container's `hosts` file for DNS resolution.",
     "vscode-docker.tasks.docker-run.dockerRun.extraHosts.hostname": "Hostname for dns resolution.",
     "vscode-docker.tasks.docker-run.dockerRun.extraHosts.ip": "IP associated to the hostname.",

--- a/src/tasks/DockerRunTaskDefinitionBase.ts
+++ b/src/tasks/DockerRunTaskDefinitionBase.ts
@@ -39,7 +39,7 @@ export interface DockerRunOptions {
     ports?: DockerContainerPort[];
     portsPublishAll?: boolean;
     volumes?: DockerContainerVolume[];
-    cleanUp?: boolean;
+    remove?: boolean;
 }
 
 export interface DockerRunTaskDefinitionBase extends TaskDefinitionBase {

--- a/src/tasks/DockerRunTaskDefinitionBase.ts
+++ b/src/tasks/DockerRunTaskDefinitionBase.ts
@@ -39,6 +39,7 @@ export interface DockerRunOptions {
     ports?: DockerContainerPort[];
     portsPublishAll?: boolean;
     volumes?: DockerContainerVolume[];
+    cleanUp?: boolean;
 }
 
 export interface DockerRunTaskDefinitionBase extends TaskDefinitionBase {

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -93,7 +93,7 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
             .withArrayArgs('-p', runOptions.ports, port => `${port.hostPort ? port.hostPort + ':' : ''}${port.containerPort}${port.protocol ? '/' + port.protocol : ''}`)
             .withArrayArgs('--add-host', runOptions.extraHosts, extraHost => `${extraHost.hostname}:${extraHost.ip}`)
             .withNamedArg('--entrypoint', runOptions.entrypoint)
-            .withFlagArg('--rm', runOptions.cleanUp)
+            .withFlagArg('--rm', runOptions.remove)
             .withQuotedArg(runOptions.image)
             .withArgs(runOptions.command);
     }

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -93,6 +93,7 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
             .withArrayArgs('-p', runOptions.ports, port => `${port.hostPort ? port.hostPort + ':' : ''}${port.containerPort}${port.protocol ? '/' + port.protocol : ''}`)
             .withArrayArgs('--add-host', runOptions.extraHosts, extraHost => `${extraHost.hostname}:${extraHost.ip}`)
             .withNamedArg('--entrypoint', runOptions.entrypoint)
+            .withFlagArg('--rm', runOptions.cleanUp)
             .withQuotedArg(runOptions.image)
             .withArgs(runOptions.command);
     }


### PR DESCRIPTION
This change allows the user to run a "short-term" container.
By setting this value to `true`, the container will be deleted after its use, using the `--rm` flag of the `docker run` command (default to false, current behavior).
It also helps to make the `dockerRun.containerName` parameter more useful, since a second run would block the task with this error:

> docker: Error response from daemon: Conflict. The container name "/`containerName`" is already in use [...]

Reference:
https://docs.docker.com/engine/reference/run/#clean-up---rm

**Note**: a container with the provided name **_must not exist_** to get this parameter to work (`docker run` command limitation).