### PR TITLE
If refresh is manual, reset docker ctx check timer

### DIFF
--- a/src/tree/registerTrees.ts
+++ b/src/tree/registerTrees.ts
@@ -24,7 +24,7 @@ export function registerTrees(): void {
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
     registerCommand(containersLoadMore, (context: IActionContext, node: AzExtTreeItem) => ext.containersTree.loadMore(node, context));
     registerCommand('vscode-docker.containers.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => {
-        dockerContextManager.resetLastCheckedTimestamp();
+        dockerContextManager.expediteContextCheck();
         await ext.containersTree.refresh(node);
     });
 
@@ -37,7 +37,7 @@ export function registerTrees(): void {
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
     registerCommand(networksLoadMore, (context: IActionContext, node: AzExtTreeItem) => ext.networksTree.loadMore(node, context));
     registerCommand('vscode-docker.networks.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => {
-        dockerContextManager.resetLastCheckedTimestamp();
+        dockerContextManager.expediteContextCheck();
         await ext.networksTree.refresh(node);
     });
 
@@ -50,7 +50,7 @@ export function registerTrees(): void {
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
     registerCommand(imagesLoadMore, (context: IActionContext, node: AzExtTreeItem) => ext.imagesTree.loadMore(node, context));
     registerCommand('vscode-docker.images.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => {
-        dockerContextManager.resetLastCheckedTimestamp();
+        dockerContextManager.expediteContextCheck();
         await ext.imagesTree.refresh(node);
     });
 
@@ -72,7 +72,7 @@ export function registerTrees(): void {
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
     registerCommand(volumesLoadMore, (context: IActionContext, node: AzExtTreeItem) => ext.volumesTree.loadMore(node, context));
     registerCommand('vscode-docker.volumes.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => {
-        dockerContextManager.resetLastCheckedTimestamp();
+        dockerContextManager.expediteContextCheck();
         await ext.volumesTree.refresh(node);
     });
 

--- a/src/tree/registerTrees.ts
+++ b/src/tree/registerTrees.ts
@@ -6,6 +6,7 @@
 import { window } from "vscode";
 import { AzExtTreeDataProvider, AzExtTreeItem, IActionContext, registerCommand } from "vscode-azureextensionui";
 import { ext } from '../extensionVariables';
+import { dockerContextManager } from "../utils/dockerContextManager";
 import { ContainersTreeItem } from './containers/ContainersTreeItem';
 import { ImagesTreeItem } from "./images/ImagesTreeItem";
 import { NetworksTreeItem } from "./networks/NetworksTreeItem";
@@ -22,7 +23,10 @@ export function registerTrees(): void {
     ext.containersRoot.registerRefreshEvents(ext.containersTreeView);
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
     registerCommand(containersLoadMore, (context: IActionContext, node: AzExtTreeItem) => ext.containersTree.loadMore(node, context));
-    registerCommand('vscode-docker.containers.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => ext.containersTree.refresh(node));
+    registerCommand('vscode-docker.containers.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => {
+        dockerContextManager.resetLastCheckedTimestamp();
+        await ext.containersTree.refresh(node);
+    });
 
     ext.networksRoot = new NetworksTreeItem(undefined);
     const networksLoadMore = 'vscode-docker.networks.loadMore';
@@ -32,7 +36,10 @@ export function registerTrees(): void {
     ext.networksRoot.registerRefreshEvents(ext.networksTreeView);
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
     registerCommand(networksLoadMore, (context: IActionContext, node: AzExtTreeItem) => ext.networksTree.loadMore(node, context));
-    registerCommand('vscode-docker.networks.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => ext.networksTree.refresh(node));
+    registerCommand('vscode-docker.networks.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => {
+        dockerContextManager.resetLastCheckedTimestamp();
+        await ext.networksTree.refresh(node);
+    });
 
     ext.imagesRoot = new ImagesTreeItem(undefined);
     const imagesLoadMore = 'vscode-docker.images.loadMore';
@@ -42,7 +49,10 @@ export function registerTrees(): void {
     ext.imagesRoot.registerRefreshEvents(ext.imagesTreeView);
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
     registerCommand(imagesLoadMore, (context: IActionContext, node: AzExtTreeItem) => ext.imagesTree.loadMore(node, context));
-    registerCommand('vscode-docker.images.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => ext.imagesTree.refresh(node));
+    registerCommand('vscode-docker.images.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => {
+        dockerContextManager.resetLastCheckedTimestamp();
+        await ext.imagesTree.refresh(node);
+    });
 
     ext.registriesRoot = new RegistriesTreeItem();
     const registriesLoadMore = 'vscode-docker.registries.loadMore';
@@ -61,7 +71,10 @@ export function registerTrees(): void {
     ext.volumesRoot.registerRefreshEvents(ext.volumesTreeView);
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
     registerCommand(volumesLoadMore, (context: IActionContext, node: AzExtTreeItem) => ext.volumesTree.loadMore(node, context));
-    registerCommand('vscode-docker.volumes.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => ext.volumesTree.refresh(node));
+    registerCommand('vscode-docker.volumes.refresh', async (_context: IActionContext, node?: AzExtTreeItem) => {
+        dockerContextManager.resetLastCheckedTimestamp();
+        await ext.volumesTree.refresh(node);
+    });
 
     registerCommand('vscode-docker.openUrl', async (_context: IActionContext, node: OpenUrlTreeItem) => node.openUrl());
 }

--- a/src/utils/dockerContextManager.ts
+++ b/src/utils/dockerContextManager.ts
@@ -107,7 +107,7 @@ export class DockerContextManager {
         };
     }
 
-    public resetLastCheckedTimestamp(): void {
+    public expediteContextCheck(): void {
         this.lastContextCheckTimestamp = 0;
     }
 

--- a/src/utils/dockerContextManager.ts
+++ b/src/utils/dockerContextManager.ts
@@ -107,6 +107,10 @@ export class DockerContextManager {
         };
     }
 
+    public resetLastCheckedTimestamp(): void {
+        this.lastContextCheckTimestamp = 0;
+    }
+
     private async getDockerConfigDigest(): Promise<string> {
         // Note: computing Docker config file digest may fail, typically because Docker is not installed,
         // and there is no config file. We use falsy value (empty string) as a way to indicate that,


### PR DESCRIPTION
If a refresh was manually triggered (the command), then reset the timer on `docker context` checks. This will force a hash-check of the Docker config.json file; if needed then `docker context inspect` will be re-called.

As a result, clicking refresh manually should always show data from the immediately current Docker context.

NOTE: It is not needed for `vscode-docker.registries.refresh` because Dockerode is not involved in the registries.