### PR TITLE
Rename platform to dockerPlatform

### DIFF
--- a/src/commands/debugging/initializeForDebugging.ts
+++ b/src/commands/debugging/initializeForDebugging.ts
@@ -38,7 +38,7 @@ export async function initializeForDebugging(actionContext: IActionContext): Pro
             throw new Error(localize('vscode-docker.commands.debugging.initialize.platformNotSupported', 'The selected platform is not yet supported for debugging.'));
     }
 
-    actionContext.telemetry.properties.platform = debugPlatform;
+    actionContext.telemetry.properties.dockerPlatform = debugPlatform;
     if (debugPlatform === 'netCore') {
         ensureDotNetCoreDependencies(folder, actionContext);
     }

--- a/src/debugging/DockerDebugConfigurationProvider.ts
+++ b/src/debugging/DockerDebugConfigurationProvider.ts
@@ -71,7 +71,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
                 }
 
                 const debugPlatform = getPlatform(debugConfiguration);
-                actionContext.telemetry.properties.platform = debugPlatform;
+                actionContext.telemetry.properties.dockerPlatform = debugPlatform;
                 actionContext.telemetry.properties.orchestration = 'single' as DockerOrchestration; // TODO: docker-compose, when support is added
 
                 return await this.resolveDebugConfigurationInternal(

--- a/src/tasks/DockerTaskProvider.ts
+++ b/src/tasks/DockerTaskProvider.ts
@@ -46,7 +46,7 @@ export abstract class DockerTaskProvider implements TaskProvider {
                 context.actionContext = actionContext;
                 context.platform = getPlatform(task.definition);
 
-                context.actionContext.telemetry.properties.platform = context.platform;
+                context.actionContext.telemetry.properties.dockerPlatform = context.platform;
                 context.actionContext.telemetry.properties.orchestration = 'single' as DockerOrchestration; // TODO: docker-compose, when support is added
                 await this.executeTaskInternal(context, task);
             });


### PR DESCRIPTION
In order to avoid conflicts with other properties named "platform".