### PR TITLE
Add logic to run with a low-rights user in Python

### DIFF
--- a/src/configureWorkspace/configurePython.ts
+++ b/src/configureWorkspace/configurePython.ts
@@ -67,14 +67,14 @@ const flaskRequirements = `flask==1.1.1
 gunicorn==20.0.4`;
 
 const lowRightsUser = `
-# Switching to a non-root user, please refer to https://aka.ms/vscode-docker-python-user
+# Switching to a non-root user, please refer to https://aka.ms/vscode-docker-python-user-rights
 RUN useradd appuser && chown -R appuser /app
 USER appuser
 `;
 
 const rootUserWarning = `
 # Warning: A port below 1024 has been exposed. This requires the image to run as a root user which is not a best practice.
-# For more information, please refer to https://aka.ms/vscode-docker-python-ports`
+# For more information, please refer to https://aka.ms/vscode-docker-python-user-rights`
 
 async function genDockerFile(serviceName: string, target: PythonTarget, projectType: PythonProjectType, ports: number[], outputFolder: string): Promise<string> {
     const exposeStatements = getExposeStatements(ports);

--- a/src/configureWorkspace/configurePython.ts
+++ b/src/configureWorkspace/configurePython.ts
@@ -30,7 +30,7 @@ const defaultLaunchFile: Map<PythonProjectType, LaunchFilePrompt> = new Map<Pyth
 
 const pythonDockerfile = `# For more information, please refer to https://aka.ms/vscode-docker-python
 FROM python:3.8
-
+$rootUserWarning$
 $expose_statements$
 
 # Keeps Python from generating .pyc files in the container
@@ -45,8 +45,8 @@ RUN python -m pip install -r requirements.txt
 
 WORKDIR /app
 ADD . /app
-
-# During debugging, this entry point will be overridden. For more information, refer to https://aka.ms/vscode-docker-python-debug
+$user$
+# During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
 $cmd$
 `;
 
@@ -65,6 +65,16 @@ gunicorn==20.0.4`;
 
 const flaskRequirements = `flask==1.1.1
 gunicorn==20.0.4`;
+
+const lowRightsUser = `
+# Switching to a low-rights user, please refer to https://aka.ms/vscode-docker-python-user
+RUN useradd appuser && chown -R appuser /app
+USER appuser
+`;
+
+const rootUserWarning = `
+# Warning: A port below 1024 has been exposed. This requires the image to run as a root user which is not a best practice.
+# For more information, please refer to https://aka.ms/vscode-docker-python-ports`
 
 async function genDockerFile(serviceName: string, target: PythonTarget, projectType: PythonProjectType, ports: number[], outputFolder: string): Promise<string> {
     const exposeStatements = getExposeStatements(ports);
@@ -86,8 +96,18 @@ async function genDockerFile(serviceName: string, target: PythonTarget, projectT
         throw new Error(localize('vscode-docker.configurePython.unknownProjectType', 'Unknown project type: {0}', projectType));
     }
 
+    let userSwitchLogic = lowRightsUser;
+    let userWarning = '';
+
+    if (ports?.find(p => p < 1024)) {
+        userSwitchLogic = '';
+        userWarning = rootUserWarning;
+    }
+
     return pythonDockerfile
+        .replace(/\$rootUserWarning\$/g, userWarning)
         .replace(/\$expose_statements\$/g, exposeStatements)
+        .replace(/\$user\$/g, userSwitchLogic)
         .replace(/\$cmd\$/g, command);
 }
 

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -38,9 +38,9 @@ export class PythonTaskHelper implements TaskHelper {
                     tag: getDefaultImageName(context.folder.name),
                     dockerfile: unresolveWorkspaceFolder(context.dockerfile, context.folder),
                     /* eslint-disable no-template-curly-in-string */
-                    context: '${workspaceFolder}'
+                    context: '${workspaceFolder}',
+                    pull: true
                 },
-                pull: true,
             }
         ];
     }


### PR DESCRIPTION
- If there isn't any chosen port that is less than 1024, then scaffold the logic to run as a low-rights user
- Else, show a warning at the top that this will be running as root

Related to #1766