### PR TITLE
Upgrade language server to 0.0.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2942,40 +2942,40 @@
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.0.22",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.22.tgz",
-            "integrity": "sha512-Vf/Zieb/BBs/VQnaxntshlTExR3FyE6FO1NxS+yO3SVqzcEVHYkHMC8f/+XRRROVHFh41YfzVfPhSxdCxfbviQ==",
+            "version": "0.0.23",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.23.tgz",
+            "integrity": "sha512-cOMMCsZ2hAt68NjLaBMTWHgCZvM5UfnQI25yIAAVJ6o6srqlUcDzl39CmO7OZsDVOtyG7n+T72PelVmQH2ymlw==",
             "requires": {
-                "dockerfile-language-service": "0.0.9",
+                "dockerfile-language-service": "0.0.11",
                 "dockerfile-utils": "0.0.11",
-                "vscode-languageserver": "^6.1.0"
+                "vscode-languageserver": "^6.1.1"
             }
         },
         "dockerfile-language-service": {
-            "version": "0.0.9",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.9.tgz",
-            "integrity": "sha512-g+TFMRG/Vv+yKqYJ2EE5KZlmwbPShWhlGhyG6tFEhUlHUt2Cd3wMr35popmc5Y9ra3OPwR3nY9cQFWIt8OP1Kw==",
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.11.tgz",
+            "integrity": "sha512-fTCa36gGPpveIsdNTa5GkvJzL/j78ga8kZ7pnF/OaJiuXKzphDetVVfeamgtXLsviAwIXyUDmofxaVKCT/XWSw==",
             "requires": {
-                "dockerfile-ast": "0.0.20",
-                "dockerfile-utils": "0.0.14",
-                "vscode-languageserver-protocol": "^3.15.1",
+                "dockerfile-ast": "0.0.25",
+                "dockerfile-utils": "0.0.16",
+                "vscode-languageserver-protocol": "^3.15.3",
                 "vscode-languageserver-types": "^3.15.1"
             },
             "dependencies": {
                 "dockerfile-ast": {
-                    "version": "0.0.20",
-                    "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.20.tgz",
-                    "integrity": "sha512-VGFMBT0Av1Sk4SCjafsv2S/MCVy6+AuhLW+958wS2df86wb90JPl+WJXhTTGHk5DQVwQX0NoQQBzQQP1U7GaWg==",
+                    "version": "0.0.25",
+                    "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.25.tgz",
+                    "integrity": "sha512-Yiolk/ktLUjThacBuIEqyoRYzDdGrp8rjKjcdZA/hhtIUHrU5iVrS1MIm3p3PWKpnD7va4Jlp/FV0ywP3AdKrg==",
                     "requires": {
-                        "vscode-languageserver-types": "^3.5.0"
+                        "vscode-languageserver-types": "^3.15.1"
                     }
                 },
                 "dockerfile-utils": {
-                    "version": "0.0.14",
-                    "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.14.tgz",
-                    "integrity": "sha512-9S77f18SmnI4hJ1Ndv1h1/gPxm74uV/n9E/2JMp6I9D3cSLrNdBZwq3FpNiXX1TRJQAn+Ufl/5b7YzH63NZ6jA==",
+                    "version": "0.0.16",
+                    "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.16.tgz",
+                    "integrity": "sha512-d/XlyVUEs+oGqoffvgYYItbGLNNSz3I2vIwzXxT9Xbx5YHH8WA8dFvTQU21k5j2Z8MoU6OYfyEZpbUqRC9N2fA==",
                     "requires": {
-                        "dockerfile-ast": "0.0.20",
+                        "dockerfile-ast": "0.0.25",
                         "vscode-languageserver-types": "3.6.0"
                     },
                     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2500,7 +2500,7 @@
         "azure-arm-website": "^5.3.0",
         "azure-storage": "^2.10.3",
         "dockerfile-ast": "^0.0.24",
-        "dockerfile-language-server-nodejs": "^0.0.22",
+        "dockerfile-language-server-nodejs": "^0.0.23",
         "dockerode": "^3.1.0",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.6",


### PR DESCRIPTION
This update adds some preliminary support for the `syntax` parser directive that is in place for users to test [experimental features](https://github.com/moby/buildkit/blob/195f9e598cc7ba82aabefe60d564df7329cb38dd/frontend/dockerfile/docs/experimental.md). Also included are a few fixes to improve the parsing of multiline arguments and embedded comments.

If anyone is wondering, this pull request does **not** add semantic highlighting support for Dockerfiles and it also does **not** introduce a dependency to the (at the time of writing) not-yet-released Visual Studio Code 1.44.

As always, please use the Dockerfiles below to test the new features and fixes. 

This first Dockerfile showcases the new improved support for the `syntax` parser directive.
```Dockerfile
#escape=
#syntax=
#

# 1. Look at the "Outline" view below the Explorer in the side panel.
# You should see both the escape and syntax parser directives there.

# 2. Put your cursor after #escape= and invoke context help
# (Command+Shift+Space on Mac), you should no longer see "escape=`\`"
# as an unformatted markdown string. It should now simply show  "escape=`" instead.

# 3. Hover over #syntax to get hover support for the syntax parser directive.

# 4. Invoke code complete (Ctrl+Space) after on the 3rd line (empty
# comment) to get intellisense support. You should see both escape and
# syntax suggested, syntax is the new addition in this release.
FROM alpine
```
This second Dockerfile includes the usual parsing fixes in these language server updates. Some of the examples are very specific (and clearly contrived), so please do not format the file (or save the file, if you have automatic formatting turned on). Formatting the structure of the file will render some of the test cases invalid.
```
FROM alpine

# this should be an error because the RUN instruction has no arguments
RUN --x=y

# this should not be an error
FR\

OM scratch

# should be able to hover over FR and OM to get hover text for
# the keyword, try both
FR\

OM scratch

ENV var=value
# you should be able to hover over $var to get value
RUN a \
    b #c \
    $var

# you should be able to hover over $var to get value
RUN a \
    #c \
    $var

# the build stage should not be flagged as an error
FROM alpine \
    # comment

    # comment
    AS build

# the AS keyword should not be flagged as an error
FROM alpine AS \
    # comment\
    build2

# there should be no error here because the last argument is correctly /dir/
COPY 1.txt 2.txt \
    3.txt #4.txt /dir/
```
Finally, open the Output panel and select the Dockerfile Language Server. Paste the file below in your host Visual Studio Code instance and you should see some error output. With the upgraded version in your debugging instance, you should not see any errors printed.
```Dockerfile
FROM alpine
RUN \
"\
\
"
```
Thank you for reviewing these changes!