### PR TITLE
Call `docker context inspect` only when needed

### DIFF
--- a/src/utils/dockerContextManager.ts
+++ b/src/utils/dockerContextManager.ts
@@ -99,14 +99,8 @@ export class DockerContextManager {
         if (Date.now() - this.lastContextCheckTimestamp > this.contextRefreshIntervalMs) {
             try {
                 if (!(await fse.pathExists(DockerContextMetasPath)) || (await fse.readdir(DockerContextMetasPath)).length === 0) {
-                    return {
-                        Changed: false,
-                        Context: undefined,
-                    };
-                } else if (!this.cachedContext) {
-                    // First-time check
-                    this.lastDockerConfigDigest = await this.getDockerConfigDigest();
-                    contextChanged = await this.refreshCachedDockerContext();
+                    this.cachedContext = undefined;
+                    contextChanged = false;
                 } else {
                     const dockerConfigDigest: string = await this.getDockerConfigDigest();
 

--- a/src/utils/dockerContextManager.ts
+++ b/src/utils/dockerContextManager.ts
@@ -95,16 +95,15 @@ export class DockerContextManager {
     public async getCurrentContext(): Promise<IDockerContextCheckResult> {
         let contextChanged: boolean = false;
 
+        // The first time this is called, this.lastContextCheckTimestamp will be 0 so this check will certainly pass
         if (Date.now() - this.lastContextCheckTimestamp > this.contextRefreshIntervalMs) {
-            if (!(await fse.pathExists(DockerContextMetasPath)) || (await fse.readdir(DockerContextMetasPath)).length === 0) {
-                return {
-                    Changed: false,
-                    Context: undefined,
-                };
-            }
-
             try {
-                if (!this.cachedContext) {
+                if (!(await fse.pathExists(DockerContextMetasPath)) || (await fse.readdir(DockerContextMetasPath)).length === 0) {
+                    return {
+                        Changed: false,
+                        Context: undefined,
+                    };
+                } else if (!this.cachedContext) {
                     // First-time check
                     this.lastDockerConfigDigest = await this.getDockerConfigDigest();
                     contextChanged = await this.refreshCachedDockerContext();

--- a/src/utils/refreshDockerode.ts
+++ b/src/utils/refreshDockerode.ts
@@ -48,10 +48,10 @@ async function addDockerHostToEnv(newEnv: NodeJS.ProcessEnv): Promise<void> {
         ({ Context: dockerContext } = await dockerContextManager.getCurrentContext());
 
         if (!newEnv.DOCKER_HOST) {
-            newEnv.DOCKER_HOST = dockerContext.Endpoints.docker.Host;
+            newEnv.DOCKER_HOST = dockerContext?.Endpoints.docker.Host;
         }
 
-        if (!newEnv.DOCKER_TLS_VERIFY && dockerContext.Endpoints.docker.SkipTLSVerify) {
+        if (!newEnv.DOCKER_TLS_VERIFY && dockerContext?.Endpoints.docker.SkipTLSVerify) {
             // https://docs.docker.com/compose/reference/envvars/#docker_tls_verify
             newEnv.DOCKER_TLS_VERIFY = "";
         }


### PR DESCRIPTION
Fixes #1818, and along with PR #1816 gets us close enough to fix #1804.

If `~/.docker/contexts/meta` is empty then only the default, non-modifiable `DOCKER_HOST`-based context is available. Since we already handle setting `DOCKER_HOST` based on environment + VSCode setting, it is not necessary to call `docker context inspect` in this case.

I expect that for the majority of users, only the default context will be present.