### PR TITLE
Open docker install instruction page for linux

### DIFF
--- a/src/commands/dockerInstaller.ts
+++ b/src/commands/dockerInstaller.ts
@@ -16,13 +16,13 @@ import { execAsync } from '../utils/spawnAsync';
 export abstract class DockerInstallerBase {
     protected abstract downloadUrl: string;
     protected abstract fileExtension: string;
-    protected abstract installationMessage: string;
     protected abstract getInstallCommand(fileName: string): string;
 
     public async downloadAndInstallDocker(): Promise<void> {
         const confirmInstall: string = localize('vscode-docker.commands.DockerInstallerBase.confirm', 'Are you sure you want to install Docker on this machine?');
         const installTitle: string = localize('vscode-docker.commands.DockerInstallerBase.install', 'Install');
         const downloadingMessage: string = localize('vscode-docker.commands.DockerInstallerBase.downloading', 'Downloading Docker installer...');
+        const installationMessage: string = localize('vscode-docker.commands.DockerInstallerBase.installationMessage', 'Opening the Docker Desktop installer...');
 
         // no need to check result - cancel will throw a UserCancelledError
         await ext.ui.showWarningMessage(confirmInstall, { modal: true }, { title: installTitle });
@@ -31,10 +31,9 @@ export abstract class DockerInstallerBase {
             { location: vscode.ProgressLocation.Notification, title: downloadingMessage },
             async () => this.downloadInstaller());
 
-
         const command = this.getInstallCommand(downloadedFileName);
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        vscode.window.showInformationMessage(this.installationMessage);
+        vscode.window.showInformationMessage(installationMessage);
         await this.install(downloadedFileName, command);
     }
 
@@ -53,7 +52,6 @@ export abstract class DockerInstallerBase {
 export class WindowsDockerInstaller extends DockerInstallerBase {
     protected downloadUrl: string = 'https://aka.ms/download-docker-windows-vscode';
     protected fileExtension: string = 'exe';
-    protected installationMessage: string = localize('vscode-docker.commands.WindowsDockerInstaller.installationMessage', 'Opening the Docker Desktop installer...');
     protected getInstallCommand(fileName: string): string {
         // Windows require double quote.
         return `"${fileName}"`;
@@ -75,7 +73,6 @@ export class WindowsDockerInstaller extends DockerInstallerBase {
 export class MacDockerInstaller extends DockerInstallerBase {
     protected downloadUrl: string = 'https://aka.ms/download-docker-mac-vscode';
     protected fileExtension: string = 'dmg';
-    protected installationMessage: string = localize('vscode-docker.commands.MacDockerInstaller.installationMessage', 'Opening the Docker Desktop installer...');
     protected getInstallCommand(fileName: string): string {
         return `chmod +x '${fileName}' && open '${fileName}'`;
     }

--- a/src/commands/dockerInstaller.ts
+++ b/src/commands/dockerInstaller.ts
@@ -72,29 +72,18 @@ export class WindowsDockerInstaller extends DockerInstallerBase {
     }
 }
 
-abstract class UnixDockerInstaller extends DockerInstallerBase {
-    protected async install(fileName: string): Promise<void> {
-        const terminal = ext.terminalProvider.createTerminal(localize('vscode-docker.commands.UnixDockerInstaller.terminalTitle', 'Docker Install'));
-        const command = this.getInstallCommand(fileName);
-        terminal.sendText(command);
-        terminal.show();
-    }
-}
-
-export class MacDockerInstaller extends UnixDockerInstaller {
+export class MacDockerInstaller extends DockerInstallerBase {
     protected downloadUrl: string = 'https://aka.ms/download-docker-mac-vscode';
     protected fileExtension: string = 'dmg';
     protected installationMessage: string = localize('vscode-docker.commands.MacDockerInstaller.installationMessage', 'Opening the Docker Desktop installer...');
     protected getInstallCommand(fileName: string): string {
         return `chmod +x '${fileName}' && open '${fileName}'`;
     }
-}
 
-export class LinuxDockerInstaller extends UnixDockerInstaller {
-    protected downloadUrl: string = 'https://aka.ms/download-docker-linux-vscode';
-    protected fileExtension: string = 'sh';
-    protected installationMessage: string = localize('vscode-docker.commands.LinuxDockerInstaller.installationMessage', 'Opening the Docker installer...');
-    protected getInstallCommand(fileName: string): string {
-        return `chmod +x '${fileName}' && sh '${fileName}'`;
+    protected async install(fileName: string): Promise<void> {
+        const terminal = ext.terminalProvider.createTerminal(localize('vscode-docker.commands.UnixDockerInstaller.terminalTitle', 'Docker Install'));
+        const command = this.getInstallCommand(fileName);
+        terminal.sendText(command);
+        terminal.show();
     }
 }

--- a/src/commands/dockerInstaller.ts
+++ b/src/commands/dockerInstaller.ts
@@ -78,7 +78,7 @@ export class MacDockerInstaller extends DockerInstallerBase {
     }
 
     protected async install(fileName: string): Promise<void> {
-        const terminal = ext.terminalProvider.createTerminal(localize('vscode-docker.commands.UnixDockerInstaller.terminalTitle', 'Docker Install'));
+        const terminal = ext.terminalProvider.createTerminal(localize('vscode-docker.commands.MacDockerInstaller.terminalTitle', 'Docker Install'));
         const command = this.getInstallCommand(fileName);
         terminal.sendText(command);
         terminal.show();

--- a/src/commands/installDocker.ts
+++ b/src/commands/installDocker.ts
@@ -5,14 +5,18 @@
 
 import { IActionContext } from 'vscode-azureextensionui';
 import LocalOSProvider from '../utils/LocalOSProvider';
-import { LinuxDockerInstaller, MacDockerInstaller, WindowsDockerInstaller } from './dockerInstaller';
+import { openExternal } from '../utils/openExternal';
+import { MacDockerInstaller, WindowsDockerInstaller } from './dockerInstaller';
 
 export async function installDocker(context: IActionContext): Promise<void> {
     const osProvider = new LocalOSProvider();
-    const dockerInstaller = osProvider.isMac
-        ? new MacDockerInstaller()
-        : osProvider.os === 'Windows'
-            ? new WindowsDockerInstaller()
-            : new LinuxDockerInstaller();
-    await dockerInstaller.downloadAndInstallDocker();
+    if (osProvider.os === 'Linux') {
+        // eslint-disable-next-line @typescript-eslint/tslint/config
+        await openExternal('https://aka.ms/download-docker-linux-vscode');
+    } else {
+        const dockerInstaller = osProvider.isMac
+            ? new MacDockerInstaller()
+            : new WindowsDockerInstaller();
+        await dockerInstaller.downloadAndInstallDocker();
+    }
 }


### PR DESCRIPTION
There are several ways to get docker on Linux. So instead of trying to install using a generic script, we let the user install the docker.