### PR TITLE
Update osProvider.os to include Mac

### DIFF
--- a/src/debugging/coreclr/CommandLineDotNetClient.ts
+++ b/src/debugging/coreclr/CommandLineDotNetClient.ts
@@ -68,7 +68,7 @@ export class CommandLineDotNetClient implements DotNetClient {
     }
 
     public async isCertificateTrusted(): Promise<TrustState> {
-        if (this.osProvider.os !== 'Windows' && !this.osProvider.isMac) {
+        if (this.osProvider.os === 'Linux') {
             // No centralized notion of trust on Linux
             return TrustState.NotApplicable;
         }

--- a/src/debugging/coreclr/LocalAspNetCoreSslManager.ts
+++ b/src/debugging/coreclr/LocalAspNetCoreSslManager.ts
@@ -60,13 +60,13 @@ export class LocalAspNetCoreSslManager implements AspNetCoreSslManager {
                 message,
                 { modal: false, learnMoreLink: 'https://aka.ms/vscode-docker-dev-certs' },
                 trust).then(async selection => {
-                    if (selection === trust) {
-                        const trustCommand = `dotnet dev-certs https --trust`;
-                        await this.processProvider.exec(trustCommand, {});
-                        LocalAspNetCoreSslManager._KnownConfiguredProjects.clear(); // Clear the cache so future F5's will not use an untrusted cert
-                    }
-                });
-        } else if (this.osProvider.isMac) {
+                if (selection === trust) {
+                    const trustCommand = `dotnet dev-certs https --trust`;
+                    await this.processProvider.exec(trustCommand, {});
+                    LocalAspNetCoreSslManager._KnownConfiguredProjects.clear(); // Clear the cache so future F5's will not use an untrusted cert
+                }
+            });
+        } else if (this.osProvider.os === 'Mac') {
             const message = localize('vscode-docker.debug.coreclr.sslManager.notTrustedRunManual', 'The ASP.NET Core HTTPS development certificate is not trusted. To trust the certificate, run \`dotnet dev-certs https --trust\`.');
 
             // Don't wait

--- a/src/debugging/coreclr/dockerManager.ts
+++ b/src/debugging/coreclr/dockerManager.ts
@@ -356,7 +356,7 @@ export class DefaultDockerManager implements DockerManager {
 
         const nugetFallbackVolume: DockerContainerVolume = {
             localPath: this.osProvider.os === 'Windows' ? path.join(programFilesEnvironmentVariable, 'dotnet', 'sdk', 'NuGetFallbackFolder') :
-                (this.osProvider.isMac ? MacNuGetPackageFallbackFolderPath : LinuxNuGetPackageFallbackFolderPath),
+                (this.osProvider.os === 'Mac' ? MacNuGetPackageFallbackFolderPath : LinuxNuGetPackageFallbackFolderPath),
             containerPath: options.os === 'Windows' ? 'C:\\.nuget\\fallbackpackages' : '/root/.nuget/fallbackpackages',
             permissions: 'ro'
         };

--- a/src/debugging/coreclr/prereqManager.ts
+++ b/src/debugging/coreclr/prereqManager.ts
@@ -107,7 +107,7 @@ export class LinuxUserInDockerGroupPrerequisite implements Prerequisite {
     }
 
     public async checkPrerequisite(): Promise<boolean> {
-        if (this.osProvider.os !== 'Linux' || this.osProvider.isMac) {
+        if (this.osProvider.os !== 'Linux') {
             return true;
         }
 
@@ -134,7 +134,7 @@ export class MacNuGetFallbackFolderSharedPrerequisite implements Prerequisite {
     }
 
     public async checkPrerequisite(): Promise<boolean> {
-        if (!this.osProvider.isMac) {
+        if (this.osProvider.os !== 'Mac') {
             // Only Mac requires this folder be specifically shared.
             return true;
         }

--- a/src/utils/LocalOSProvider.ts
+++ b/src/utils/LocalOSProvider.ts
@@ -11,7 +11,6 @@ import { PlatformOS } from './platform';
 
 export interface OSProvider {
     homedir: string;
-    isMac: boolean;
     os: PlatformOS;
     tmpdir: string;
     pathJoin(os: PlatformOS, ...paths: string[]): string;
@@ -24,12 +23,15 @@ export class LocalOSProvider implements OSProvider {
         return os.homedir();
     }
 
-    public get isMac(): boolean {
-        return os.platform() === 'darwin';
-    }
-
     public get os(): PlatformOS {
-        return os.platform() === 'win32' ? 'Windows' : 'Linux';
+        switch (os.platform()) {
+            case 'win32':
+                return 'Windows';
+            case 'darwin':
+                return 'Mac';
+            default:
+                return 'Linux';
+        }
     }
 
     public get tmpdir(): string {

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export type PlatformOS = 'Windows' | 'Linux';
+export type PlatformOS = 'Windows' | 'Linux' | 'Mac';
 export type Platform =
     'Node.js' |
     '.NET: ASP.NET Core' |

--- a/test/debugging/coreclr/prereqManager.test.ts
+++ b/test/debugging/coreclr/prereqManager.test.ts
@@ -94,17 +94,13 @@ suite('(unit) debugging/coreclr/prereqManager', () => {
     });
 
     suite('LinuxUserInDockerGroupPrerequisite', () => {
-        const generateTest = (name: string, result: boolean, os: PlatformOS, isMac?: boolean, inGroup?: boolean) => {
+        const generateTest = (name: string, result: boolean, os: PlatformOS, inGroup?: boolean) => {
             test(name, async () => {
-                const osProvider = <OSProvider>{
-                    os,
-                    isMac
-                }
-
+                const osProvider = <OSProvider>{ os }
                 let processProvider = <ProcessProvider>{};
                 let listed = false;
 
-                if (os === 'Linux' && !isMac) {
+                if (os === 'Linux') {
                     processProvider = <ProcessProvider>{
                         exec: (command: string, _) => {
                             listed = true;
@@ -129,7 +125,7 @@ suite('(unit) debugging/coreclr/prereqManager', () => {
 
                 const prereqResult = await prerequisite.checkPrerequisite();
 
-                if (os === 'Linux' && !isMac) {
+                if (os === 'Linux') {
                     assert.equal(listed, true, 'The user\'s groups should have been listed.');
                 }
 
@@ -139,9 +135,9 @@ suite('(unit) debugging/coreclr/prereqManager', () => {
         };
 
         generateTest('Windows: No-op', true, 'Windows');
-        generateTest('Mac: No-op', true, 'Linux', true);
-        generateTest('Linux: In group', true, 'Linux', false, true);
-        generateTest('Linux: Not in group', false, 'Linux', false, false);
+        generateTest('Mac: No-op', true, 'Mac');
+        generateTest('Linux: In group', true, 'Linux', true);
+        generateTest('Linux: Not in group', false, 'Linux', false);
     });
 
     suite('MacNuGetFallbackFolderSharedPrerequisite', () => {
@@ -168,7 +164,7 @@ suite('(unit) debugging/coreclr/prereqManager', () => {
 
                 const osProvider = <OSProvider>{
                     homedir: '/Users/User',
-                    isMac: true
+                    os: 'Mac'
                 };
 
                 let shown = false;
@@ -194,7 +190,7 @@ suite('(unit) debugging/coreclr/prereqManager', () => {
 
         test('Non-Mac: No-op', async () => {
             const osProvider = <OSProvider>{
-                isMac: false
+                os: 'Linux'
             };
 
             const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {


### PR DESCRIPTION
Earlier osProvider.os was returning either Windows or Linux. This causes confusion because Linux could also indicate the Mac and callers had additional checks to further narrow down. So including the Mac as one of the values.