### PR TITLE
Revert "osProvider.Os to include Mac (#1843)"

### DIFF
--- a/src/debugging/coreclr/CommandLineDotNetClient.ts
+++ b/src/debugging/coreclr/CommandLineDotNetClient.ts
@@ -68,7 +68,7 @@ export class CommandLineDotNetClient implements DotNetClient {
     }
 
     public async isCertificateTrusted(): Promise<TrustState> {
-        if (this.osProvider.os === 'Linux') {
+        if (this.osProvider.os !== 'Windows' && !this.osProvider.isMac) {
             // No centralized notion of trust on Linux
             return TrustState.NotApplicable;
         }

--- a/src/debugging/coreclr/LocalAspNetCoreSslManager.ts
+++ b/src/debugging/coreclr/LocalAspNetCoreSslManager.ts
@@ -60,13 +60,13 @@ export class LocalAspNetCoreSslManager implements AspNetCoreSslManager {
                 message,
                 { modal: false, learnMoreLink: 'https://aka.ms/vscode-docker-dev-certs' },
                 trust).then(async selection => {
-                if (selection === trust) {
-                    const trustCommand = `dotnet dev-certs https --trust`;
-                    await this.processProvider.exec(trustCommand, {});
-                    LocalAspNetCoreSslManager._KnownConfiguredProjects.clear(); // Clear the cache so future F5's will not use an untrusted cert
-                }
-            });
-        } else if (this.osProvider.os === 'Mac') {
+                    if (selection === trust) {
+                        const trustCommand = `dotnet dev-certs https --trust`;
+                        await this.processProvider.exec(trustCommand, {});
+                        LocalAspNetCoreSslManager._KnownConfiguredProjects.clear(); // Clear the cache so future F5's will not use an untrusted cert
+                    }
+                });
+        } else if (this.osProvider.isMac) {
             const message = localize('vscode-docker.debug.coreclr.sslManager.notTrustedRunManual', 'The ASP.NET Core HTTPS development certificate is not trusted. To trust the certificate, run \`dotnet dev-certs https --trust\`.');
 
             // Don't wait

--- a/src/debugging/coreclr/dockerManager.ts
+++ b/src/debugging/coreclr/dockerManager.ts
@@ -356,7 +356,7 @@ export class DefaultDockerManager implements DockerManager {
 
         const nugetFallbackVolume: DockerContainerVolume = {
             localPath: this.osProvider.os === 'Windows' ? path.join(programFilesEnvironmentVariable, 'dotnet', 'sdk', 'NuGetFallbackFolder') :
-                (this.osProvider.os === 'Mac' ? MacNuGetPackageFallbackFolderPath : LinuxNuGetPackageFallbackFolderPath),
+                (this.osProvider.isMac ? MacNuGetPackageFallbackFolderPath : LinuxNuGetPackageFallbackFolderPath),
             containerPath: options.os === 'Windows' ? 'C:\\.nuget\\fallbackpackages' : '/root/.nuget/fallbackpackages',
             permissions: 'ro'
         };

--- a/src/debugging/coreclr/prereqManager.ts
+++ b/src/debugging/coreclr/prereqManager.ts
@@ -107,7 +107,7 @@ export class LinuxUserInDockerGroupPrerequisite implements Prerequisite {
     }
 
     public async checkPrerequisite(): Promise<boolean> {
-        if (this.osProvider.os !== 'Linux') {
+        if (this.osProvider.os !== 'Linux' || this.osProvider.isMac) {
             return true;
         }
 
@@ -134,7 +134,7 @@ export class MacNuGetFallbackFolderSharedPrerequisite implements Prerequisite {
     }
 
     public async checkPrerequisite(): Promise<boolean> {
-        if (this.osProvider.os !== 'Mac') {
+        if (!this.osProvider.isMac) {
             // Only Mac requires this folder be specifically shared.
             return true;
         }

--- a/src/utils/LocalOSProvider.ts
+++ b/src/utils/LocalOSProvider.ts
@@ -11,6 +11,7 @@ import { PlatformOS } from './platform';
 
 export interface OSProvider {
     homedir: string;
+    isMac: boolean;
     os: PlatformOS;
     tmpdir: string;
     pathJoin(os: PlatformOS, ...paths: string[]): string;
@@ -23,15 +24,12 @@ export class LocalOSProvider implements OSProvider {
         return os.homedir();
     }
 
+    public get isMac(): boolean {
+        return os.platform() === 'darwin';
+    }
+
     public get os(): PlatformOS {
-        switch (os.platform()) {
-            case 'win32':
-                return 'Windows';
-            case 'darwin':
-                return 'Mac';
-            default:
-                return 'Linux';
-        }
+        return os.platform() === 'win32' ? 'Windows' : 'Linux';
     }
 
     public get tmpdir(): string {

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export type PlatformOS = 'Windows' | 'Linux' | 'Mac';
+export type PlatformOS = 'Windows' | 'Linux';
 export type Platform =
     'Node.js' |
     '.NET: ASP.NET Core' |

--- a/test/debugging/coreclr/prereqManager.test.ts
+++ b/test/debugging/coreclr/prereqManager.test.ts
@@ -94,13 +94,17 @@ suite('(unit) debugging/coreclr/prereqManager', () => {
     });
 
     suite('LinuxUserInDockerGroupPrerequisite', () => {
-        const generateTest = (name: string, result: boolean, os: PlatformOS, inGroup?: boolean) => {
+        const generateTest = (name: string, result: boolean, os: PlatformOS, isMac?: boolean, inGroup?: boolean) => {
             test(name, async () => {
-                const osProvider = <OSProvider>{ os }
+                const osProvider = <OSProvider>{
+                    os,
+                    isMac
+                }
+
                 let processProvider = <ProcessProvider>{};
                 let listed = false;
 
-                if (os === 'Linux') {
+                if (os === 'Linux' && !isMac) {
                     processProvider = <ProcessProvider>{
                         exec: (command: string, _) => {
                             listed = true;
@@ -125,7 +129,7 @@ suite('(unit) debugging/coreclr/prereqManager', () => {
 
                 const prereqResult = await prerequisite.checkPrerequisite();
 
-                if (os === 'Linux') {
+                if (os === 'Linux' && !isMac) {
                     assert.equal(listed, true, 'The user\'s groups should have been listed.');
                 }
 
@@ -135,9 +139,9 @@ suite('(unit) debugging/coreclr/prereqManager', () => {
         };
 
         generateTest('Windows: No-op', true, 'Windows');
-        generateTest('Mac: No-op', true, 'Mac');
-        generateTest('Linux: In group', true, 'Linux', true);
-        generateTest('Linux: Not in group', false, 'Linux', false);
+        generateTest('Mac: No-op', true, 'Linux', true);
+        generateTest('Linux: In group', true, 'Linux', false, true);
+        generateTest('Linux: Not in group', false, 'Linux', false, false);
     });
 
     suite('MacNuGetFallbackFolderSharedPrerequisite', () => {
@@ -164,7 +168,7 @@ suite('(unit) debugging/coreclr/prereqManager', () => {
 
                 const osProvider = <OSProvider>{
                     homedir: '/Users/User',
-                    os: 'Mac'
+                    isMac: true
                 };
 
                 let shown = false;
@@ -190,7 +194,7 @@ suite('(unit) debugging/coreclr/prereqManager', () => {
 
         test('Non-Mac: No-op', async () => {
             const osProvider = <OSProvider>{
-                os: 'Linux'
+                isMac: false
             };
 
             const showErrorMessage = (message: string, ...items: vscode.MessageItem[]): Thenable<vscode.MessageItem | undefined> => {


### PR DESCRIPTION
This reverts commit 9a74120bebaacab239f6644d0d7be9a71c575862. This change is way too high risk this close to locking down for 1.1 release.