### PR TITLE
Add an async lazy class and lazy lifetimes

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -28,6 +28,8 @@ export { DotNetClient } from './src/debugging/coreclr/CommandLineDotNetClient';
 export { compareBuildImageOptions, LaunchOptions } from './src/debugging/coreclr/dockerManager';
 export { FileSystemProvider } from './src/debugging/coreclr/fsProvider';
 export { LineSplitter } from './src/debugging/coreclr/lineSplitter';
+export { delay } from './src/utils/delay';
+export { Lazy, AsyncLazy } from './src/utils/lazy';
 export { OSProvider } from './src/utils/LocalOSProvider';
 export { DockerDaemonIsLinuxPrerequisite, DockerfileExistsPrerequisite, DotNetSdkInstalledPrerequisite, LinuxUserInDockerGroupPrerequisite, MacNuGetFallbackFolderSharedPrerequisite } from './src/debugging/coreclr/prereqManager';
 export { ext } from './src/extensionVariables';

--- a/src/tasks/node/NodeTaskHelper.ts
+++ b/src/tasks/node/NodeTaskHelper.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import { WorkspaceFolder } from 'vscode';
-import Lazy from '../../utils/lazy';
+import { Lazy } from '../../utils/lazy';
 import { inferCommand, inferPackageName, InspectMode, NodePackage, readPackage } from '../../utils/nodeUtils';
 import { resolveVariables, unresolveWorkspaceFolder } from '../../utils/resolveVariables';
 import { DockerBuildOptions, DockerBuildTaskDefinitionBase } from '../DockerBuildTaskDefinitionBase';

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -7,7 +7,7 @@ export class Lazy<T> {
     private _isValueCreated: boolean = false;
     private _value: T | undefined;
 
-    public constructor(private readonly valueFactory: () => T) {
+    public constructor(private readonly valueFactory: () => T, private readonly _valueLifetime?: number) {
     }
 
     public get isValueCreated(): boolean {
@@ -15,13 +15,60 @@ export class Lazy<T> {
     }
 
     public get value(): T {
-        if (!this._isValueCreated) {
-            this._value = this.valueFactory();
-            this._isValueCreated = true;
+        if (this._isValueCreated) {
+            return this._value;
+        }
+
+        this._value = this.valueFactory();
+        this._isValueCreated = true;
+
+        if (this._valueLifetime) {
+            const reset = setTimeout(() => {
+                this._isValueCreated = false;
+                this._value = undefined;
+                clearTimeout(reset);
+            }, this._valueLifetime);
         }
 
         return this._value;
     }
 }
 
-export default Lazy;
+export class AsyncLazy<T> {
+    private _isValueCreated: boolean = false;
+    private _value: T | undefined;
+    private _valuePromise: Promise<T> | undefined;
+
+    public constructor(private readonly valueFactory: () => Promise<T>, private readonly _valueLifetime?: number) {
+    }
+
+    public async getValue(): Promise<T> {
+        if (this._isValueCreated) {
+            return this._value;
+        }
+
+        this._isValueCreated = false;
+
+        const isPrimaryPromise = this._valuePromise === undefined; // The first caller is "primary"
+        const fnLocalPromiseRef = this._valuePromise = this._valuePromise ?? this.valueFactory(); // Await any currently-running Promise if there is one
+        this._value = await fnLocalPromiseRef;
+        this._valuePromise = undefined;
+
+        this._isValueCreated = true;
+
+        if (this._valueLifetime && isPrimaryPromise) {
+            const reset = setTimeout(() => {
+                // Will only clear out values if there isn't a currently-running Promise
+                // If there is, this timer will skip, but when that Promise finishes it will go through this code and register a new timer
+                if (this._valuePromise === undefined) {
+                    this._isValueCreated = false;
+                    this._value = undefined;
+                }
+
+                clearTimeout(reset);
+            }, this._valueLifetime);
+        }
+
+        return this._value;
+    }
+}

--- a/test/utils/lazy.test.ts
+++ b/test/utils/lazy.test.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Lazy, AsyncLazy } from "../../extension.bundle";
+import { delay } from '../../src/utils/delay';
+
+suite('(unit) Lazy tests', () => {
+    suite('Lazy<T>', () => {
+        test('Normal', async () => {
+            let factoryCallCount = 0;
+            const lazy: Lazy<boolean> = new Lazy(() => {
+                factoryCallCount++;
+                return true;
+            });
+
+            lazy.value;
+            lazy.value;
+
+            assert.equal(factoryCallCount, 1, 'Incorrect number of value factory calls.');
+        });
+
+        test('With lifetime', async () => {
+            let factoryCallCount = 0;
+            const lazy: Lazy<boolean> = new Lazy(() => {
+                factoryCallCount++;
+                return true;
+            }, 5);
+
+            lazy.value;
+            lazy.value;
+
+            assert.equal(factoryCallCount, 1, 'Incorrect number of value factory calls.');
+
+            await delay(10);
+            lazy.value;
+            lazy.value;
+
+            assert.equal(factoryCallCount, 2, 'Incorrect number of value factory calls.');
+        });
+    });
+
+    suite('AsyncLazy<T>', () => {
+        test('Normal', async () => {
+            let factoryCallCount = 0;
+            const lazy: AsyncLazy<boolean> = new AsyncLazy(async () => {
+                factoryCallCount++;
+                await delay(5);
+                return true;
+            });
+
+            await lazy.getValue();
+            await lazy.getValue();
+
+            assert.equal(factoryCallCount, 1, 'Incorrect number of value factory calls.');
+        });
+
+        test('Simultaneous callers', async () => {
+            let factoryCallCount = 0;
+            const lazy: AsyncLazy<boolean> = new AsyncLazy(async () => {
+                factoryCallCount++;
+                await delay(5);
+                return true;
+            });
+
+            const p1 = lazy.getValue();
+            const p2 = lazy.getValue();
+            await Promise.all([p1, p2]);
+
+            assert.equal(factoryCallCount, 1, 'Incorrect number of value factory calls.');
+        });
+
+        test('With lifetime', async () => {
+            let factoryCallCount = 0;
+            const lazy: AsyncLazy<boolean> = new AsyncLazy(async () => {
+                factoryCallCount++;
+                await delay(5);
+                return true;
+            }, 10);
+
+            await lazy.getValue();
+            await lazy.getValue();
+
+            assert.equal(factoryCallCount, 1, 'Incorrect number of value factory calls.');
+
+            await delay(15);
+            await lazy.getValue();
+            await lazy.getValue();
+
+            assert.equal(factoryCallCount, 2, 'Incorrect number of value factory calls.');
+        });
+
+        test('Simultaneous callers with lifetime', async () => {
+            let factoryCallCount = 0;
+            const lazy: AsyncLazy<boolean> = new AsyncLazy(async () => {
+                factoryCallCount++;
+                await delay(5);
+                return true;
+            }, 10);
+
+            const p1 = lazy.getValue();
+            const p2 = lazy.getValue();
+            await Promise.all([p1, p2]);
+
+            assert.equal(factoryCallCount, 1, 'Incorrect number of value factory calls.');
+
+            await delay(15);
+            const p3 = lazy.getValue();
+            const p4 = lazy.getValue();
+            await Promise.all([p3, p4]);
+
+            assert.equal(factoryCallCount, 2, 'Incorrect number of value factory calls.');
+        });
+    });
+});

--- a/test/utils/lazy.test.ts
+++ b/test/utils/lazy.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import { Lazy, AsyncLazy } from "../../extension.bundle";
-import { delay } from '../../src/utils/delay';
+import { delay } from '../../extension.bundle';
 
 suite('(unit) Lazy tests', () => {
     suite('Lazy<T>', () => {


### PR DESCRIPTION
(Not for 1.1)

Adds an `AsyncLazy` class that is smart enough to not re-run the task if it's currently running. Also adds lifetimes to force `Lazy`s to re-evaluate, if the caller so specifies.

One scenario where this would be useful is in places where we know we are going to query something several times in rapid succession--maybe `docker info`, as an example--and we expect no changes to occur in some time span (e.g. 1 second), but want to share the result across each of these queries to avoid re-running code unnecessarily.