### PR TITLE
adjust net core version extraction logic to handle net5.0

### DIFF
--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -191,7 +191,7 @@ $volumes_list$
 
 function extractNetCoreVersion(projFileContent: string): string {
     // Parse version from TargetFramework or TargetFrameworks
-    // Example: netcoreapp1.0 or app5.0
+    // Example: netcoreapp1.0 or net5.0
     let [tfm] = extractRegExGroups(projFileContent, /<TargetFramework>(.+)<\/TargetFramework>/, [undefined]);
     if (!tfm) {
         [tfm] = extractRegExGroups(projFileContent, /<TargetFrameworks>(.+)<\/TargetFrameworks>/, ['']);

--- a/src/configureWorkspace/configureDotNetCore.ts
+++ b/src/configureWorkspace/configureDotNetCore.ts
@@ -189,7 +189,26 @@ $volumes_list$
 `;
 // #endregion
 
-function genDockerFile(serviceNameAndRelativePath: string, platform: Platform, os: PlatformOS | undefined, ports: number[], version: string, artifactName: string, assemblyName: string): string {
+function extractNetCoreVersion(projFileContent: string): string {
+    // Parse version from TargetFramework or TargetFrameworks
+    // Example: netcoreapp1.0 or app5.0
+    let [tfm] = extractRegExGroups(projFileContent, /<TargetFramework>(.+)<\/TargetFramework>/, [undefined]);
+    if (!tfm) {
+        [tfm] = extractRegExGroups(projFileContent, /<TargetFrameworks>(.+)<\/TargetFrameworks>/, ['']);
+    }
+
+    const defaultNetCoreVersion = '2.1';
+    let [netCoreVersion] = extractRegExGroups(tfm, /^netcoreapp([0-9.]+)|net([0-9.]+)$/, [defaultNetCoreVersion]);
+
+    // semver requires a patch in the version, so add it if only major.minor
+    if (netCoreVersion.match(/^[^.]+\.[^.]+$/)) {
+        netCoreVersion += '.0';
+    }
+
+    return netCoreVersion;
+}
+
+function genDockerFile(serviceNameAndRelativePath: string, platform: Platform, os: PlatformOS | undefined, ports: number[], projFileContent: string, artifactName: string, assemblyName: string): string {
     // VS version of this function is in ResolveImageNames (src/Docker/Microsoft.VisualStudio.Docker.DotNetCore/DockerDotNetCoreScaffoldingProvider.cs)
 
     if (os !== 'Windows' && os !== 'Linux') {
@@ -202,19 +221,10 @@ function genDockerFile(serviceNameAndRelativePath: string, platform: Platform, o
     // example: COPY Core2.0ConsoleAppWindows/Core2.0ConsoleAppWindows.csproj Core2.0ConsoleAppWindows/
     let copyProjectCommands = `COPY ["${artifactName}", "${projectDirectory}/"]`
     let exposeStatements = getExposeStatements(ports);
-
-    // Parse version from TargetFramework
-    // Example: netcoreapp1.0
-    const defaultNetCoreVersion = '2.1';
-    let [netCoreAppVersion] = extractRegExGroups(version, /^netcoreapp([0-9.]+)$/, [defaultNetCoreVersion]);
-
-    // semver requires a patch in the version, so add it if only major.minor
-    if (netCoreAppVersion.match(/^[^.]+\.[^.]+$/)) {
-        netCoreAppVersion += '.0';
-    }
-
     let baseImageFormat: string;
     let sdkImageNameFormat: string;
+
+    const netCoreAppVersion = extractNetCoreVersion(projFileContent);
 
     // For .NET Core 2.1+ use mcr.microsoft.com/dotnet/core/[sdk|aspnet|runtime|runtime-deps] repository.
     // See details here: https://devblogs.microsoft.com/dotnet/net-core-container-images-now-published-to-microsoft-container-registry/
@@ -426,10 +436,7 @@ export async function scaffoldNetCore(context: ScaffolderContext): Promise<Scaff
     const workspaceRelativeProjectFileName = path.posix.relative(context.folder.uri.fsPath, projectFilePath);
 
     let serviceNameAndPathRelative = rootRelativeProjectFileName.slice(0, -(path.extname(rootRelativeProjectFileName).length));
-    const projFileContents = (await fse.readFile(path.join(context.rootFolder, rootRelativeProjectFileName))).toString();
-
-    // Extract TargetFramework for version
-    const [version] = extractRegExGroups(projFileContents, /<TargetFramework>(.+)<\/TargetFramework/, ['']);
+    const projFileContent = (await fse.readFile(path.join(context.rootFolder, rootRelativeProjectFileName))).toString();
 
     if (context.outputFolder) {
         // We need paths in the Dockerfile to be relative to the output folder, not the root
@@ -440,7 +447,7 @@ export async function scaffoldNetCore(context: ScaffolderContext): Promise<Scaff
     serviceNameAndPathRelative = serviceNameAndPathRelative.replace(/\\/g, '/');
 
     const assemblyName = await inferOutputAssemblyName(projectFullPath);
-    let dockerFileContents = genDockerFile(serviceNameAndPathRelative, context.platform, os, ports, version, workspaceRelativeProjectFileName, assemblyName);
+    let dockerFileContents = genDockerFile(serviceNameAndPathRelative, context.platform, os, ports, projFileContent, workspaceRelativeProjectFileName, assemblyName);
 
     // Remove multiple empty lines with single empty lines, as might be produced
     // if $expose_statements$ or another template variable is an empty string

--- a/src/utils/extractRegExGroups.ts
+++ b/src/utils/extractRegExGroups.ts
@@ -15,6 +15,9 @@ export function extractRegExGroups(input: string, regex: RegExp, defaults: strin
         // Ignore first item, which is the text of the entire match
         let [, ...groups] = matches;
 
+        // Ignore the undefined matches
+        groups = groups.filter(g => g !== undefined);
+
         assert(groups.length === defaults.length, "extractRegExGroups: length of defaults array does not match length of actual match groups");
         return groups;
     }


### PR DESCRIPTION
.Net 5.0 preview 3 generates the console project with below TFM
`<TargetFramework>net5.0</TargetFramework>`

During scaffolding we were looking for only netcoreapp5.0, hence it fails to identify net5.0. Also added the logic to look for the version in TargetFrameworks. Picks the first one defined in the list.

Fixes: #1856