### PR TITLE
Refactor Docker context some

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,9 +115,9 @@
             "dev": true
         },
         "@types/dockerode": {
-            "version": "2.5.26",
-            "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-2.5.26.tgz",
-            "integrity": "sha512-1OVF2rHRtn3ue4+aMdmql2TyUUdEFvWU3sg0rvQxO3jasvNokDx3G5xXzucFFgSWMA3OFIJ9yseW3BNU1XgktQ==",
+            "version": "2.5.27",
+            "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-2.5.27.tgz",
+            "integrity": "sha512-22qr8hE+WlSOfOWGyusv5KJSw/HyJXvFesWgi+FG9v/8OMjZ/G0QADffcrJyGILnHmiLta/blJzs+kE7JUw+3w==",
             "dev": true,
             "requires": {
                 "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -1818,6 +1818,10 @@
                     "default": 10,
                     "description": "%vscode-docker.config.docker.truncateMaxLength%"
                 },
+                "docker.dockerodeOptions": {
+                    "type": "object",
+                    "description": "%vscode-docker.config.docker.dockerodeOptions%"
+                },
                 "docker.host": {
                     "type": "string",
                     "default": "",

--- a/package.json
+++ b/package.json
@@ -2460,7 +2460,7 @@
     "devDependencies": {
         "@types/adm-zip": "^0.4.32",
         "@types/deep-equal": "^1.0.1",
-        "@types/dockerode": "^2.5.26",
+        "@types/dockerode": "^2.5.27",
         "@types/fs-extra": "^8.1.0",
         "@types/glob": "^7.1.1",
         "@types/keytar": "^4.4.2",

--- a/package.nls.json
+++ b/package.nls.json
@@ -146,6 +146,7 @@
     "vscode-docker.config.docker.imageBuildContextPath": "Build context PATH to pass to Docker build command.",
     "vscode-docker.config.docker.truncateLongRegistryPaths": "Set to true to truncate long image and container registry paths in Docker view",
     "vscode-docker.config.docker.truncateMaxLength": "Maximum length of a registry paths displayed in Docker view, including elipsis. The truncateLongRegistryPaths setting must be set to true for truncateMaxLength setting to be effective.",
+    "vscode-docker.config.docker.dockerodeOptions": "If specified, this object will be passed to the Dockerode constructor. Takes precedence over DOCKER_HOST, the Docker Host setting, and any existing Docker contexts.",
     "vscode-docker.config.docker.host": "Equivalent to setting the DOCKER_HOST environment variable.",
     "vscode-docker.config.docker.certPath": "Equivalent to setting the DOCKER_CERT_PATH environment variable.",
     "vscode-docker.config.docker.tlsVerify": "Equivalent to setting the DOCKER_TLS_VERIFY environment variable.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,7 +216,8 @@ namespace Configuration {
                 if (e.affectsConfiguration('docker.host') ||
                     e.affectsConfiguration('docker.certPath') ||
                     e.affectsConfiguration('docker.tlsVerify') ||
-                    e.affectsConfiguration('docker.machineName')) {
+                    e.affectsConfiguration('docker.machineName') ||
+                    e.affectsConfiguration('docker.dockerodeOptions')) {
                     await refreshDockerode();
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
+import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzureUserInput, callWithTelemetryAndErrorHandling, createAzExtOutputChannel, createTelemetryReporter, IActionContext, registerUIExtensionVariables, UserCancelledError } from 'vscode-azureextensionui';
@@ -30,6 +31,7 @@ import { registerTrees } from './tree/registerTrees';
 import { AzureAccountExtensionListener } from './utils/AzureAccountExtensionListener';
 import { Keytar } from './utils/keytar';
 import { refreshDockerode } from './utils/refreshDockerode';
+import { bufferToString } from './utils/spawnAsync';
 import { DefaultTerminalProvider } from './utils/TerminalProvider';
 
 export type KeyInfo = { [keyName: string]: string };
@@ -80,6 +82,7 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
     await callWithTelemetryAndErrorHandling('docker.activate', async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';
         activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
+        activateContext.telemetry.properties.dockerInstallationID = await getDockerInstallationID();
 
         validateOldPublisher(activateContext);
 
@@ -143,6 +146,22 @@ export async function deactivateInternal(ctx: vscode.ExtensionContext): Promise<
         activateContext.telemetry.properties.isActivationEvent = 'true';
         AzureAccountExtensionListener.dispose();
     });
+}
+
+async function getDockerInstallationID(): Promise<string> {
+    let result: string = 'unknown';
+    let installIdFilePath: string | undefined;
+    if (os.platform() === 'win32' && process.env.APPDATA) {
+        installIdFilePath = path.join(process.env.APPDATA, 'Docker', '.trackid');
+    } else if (os.platform() === 'darwin') {
+        installIdFilePath = path.join(os.homedir(), 'Library', 'Group Containers', 'group.com.docker', 'userId');
+    }
+
+    if (installIdFilePath && await fse.pathExists(installIdFilePath)) {
+        result = bufferToString(await fse.readFile(installIdFilePath));
+    }
+
+    return result;
 }
 
 /**

--- a/src/utils/refreshDockerode.ts
+++ b/src/utils/refreshDockerode.ts
@@ -65,6 +65,10 @@ export async function refreshDockerode(): Promise<void> {
                         /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
                         ext.ui.showWarningMessage(localize('vscode-docker.utils.dockerode.sshAgent', 'In order to use an SSH DOCKER_HOST, you must configure an ssh-agent.'), { learnMoreLink: 'https://aka.ms/AA7assy' });
                     }
+
+                    if (dockerodeOptions) {
+                        dockerodeOptions.sshAuthAgent = newEnv.SSH_AUTH_SOCK;
+                    }
                 }
 
                 try {
@@ -108,7 +112,7 @@ async function getDockerOptionsFromDockerContext(actionContext: IActionContext, 
 
         options.host = host; // Intentionally the full URL (docker-modem can figure out the protocol and hostname from it)
         options.port = parsed.port; // docker-modem can figure out the port if it is not explicit in the URL
-        // TODO dockerodeOptions.username = parsed.username;
+        options.username = parsed.username;
 
         actionContext.telemetry.properties.hostProtocol = parsed.protocol;
     } else {

--- a/src/utils/refreshDockerode.ts
+++ b/src/utils/refreshDockerode.ts
@@ -34,6 +34,8 @@ export async function refreshDockerode(): Promise<void> {
                 const config = workspace.getConfiguration('docker');
                 const overrideDockerodeOptions = config.get<{}>('dockerodeOptions');
                 if (overrideDockerodeOptions) {
+                    actionContext.telemetry.properties.hostSource = 'docker.dockerodeOptions';
+                    actionContext.telemetry.measurements.retrievalTimeMs = 0;
                     ext.dockerodeInitError = undefined;
                     ext.dockerode = new Dockerode(<Dockerode.DockerOptions>overrideDockerodeOptions);
                     return;
@@ -55,7 +57,7 @@ export async function refreshDockerode(): Promise<void> {
 
                 // If the old value is different from the new value, then the setting overrode it
                 if ((oldEnv.DOCKER_HOST ?? '') !== (newEnv.DOCKER_HOST ?? '')) {
-                    actionContext.telemetry.properties.hostSource = 'setting';
+                    actionContext.telemetry.properties.hostSource = 'docker.host';
                 }
 
                 // If DOCKER_HOST is set, do not use docker context (same behavior as the CLI)
@@ -107,11 +109,11 @@ async function getDockerOptionsFromDockerContext(actionContext: IActionContext, 
     ({ DurationMs: actionContext.telemetry.measurements.contextRetrievalTimeMs, Result: { Context: dockerContext } } = await timeUtils.timeIt(async () => dockerContextManager.getCurrentContext()));
 
     if (dockerContext === undefined) { // Undefined context means there's only the default context
-        actionContext.telemetry.properties.hostSource = 'defaultOnly';
+        actionContext.telemetry.properties.hostSource = 'defaultContextOnly';
     } else if (/^default$/i.test(dockerContext.Name)) {
-        actionContext.telemetry.properties.hostSource = 'defaultSelected';
+        actionContext.telemetry.properties.hostSource = 'defaultContextSelected';
     } else {
-        actionContext.telemetry.properties.hostSource = 'customSelected';
+        actionContext.telemetry.properties.hostSource = 'customContextSelected';
     }
 
     const host = dockerContext?.Endpoints?.docker?.Host;

--- a/src/utils/refreshDockerode.ts
+++ b/src/utils/refreshDockerode.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as url from 'url';
 import Dockerode = require('dockerode');
 import { Socket } from 'net';
+import * as url from 'url';
 import { CancellationTokenSource } from 'vscode';
 import { parseError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
@@ -46,23 +46,18 @@ export async function refreshDockerode(): Promise<void> {
             const host = dockerContext?.Endpoints?.docker.Host;
 
             if (host) {
-                const parsed = url.parse(host);
+                const parsed = new url.URL(host);
 
-                dockerodeOptions.host = parsed?.hostname;
-                dockerodeOptions.port = parsed?.port;
-                dockerodeOptions.protocol = parsed?.protocol;
+                dockerodeOptions.host = host; // Intentionally the full URL (docker-modem can figure out the protocol and hostname from it)
+                dockerodeOptions.port = parsed.port;
+                dockerodeOptions.username = parsed.username;
             }
-
-            dockerodeOptions.host = dockerContext?.Endpoints?.docker.Host;
-            dockerodeOptions.
         }
-
-        await addDockerHostToEnv(newEnv);
 
         ext.dockerodeInitError = undefined;
         process.env = newEnv;
         try {
-            ext.dockerode = new Dockerode();
+            ext.dockerode = new Dockerode(dockerodeOptions);
         } finally {
             process.env = oldEnv;
         }

--- a/src/utils/refreshDockerode.ts
+++ b/src/utils/refreshDockerode.ts
@@ -133,6 +133,8 @@ async function getDockerOptionsFromDockerContext(actionContext: IActionContext, 
 
     // Currently the environment variable is the only way to configure this in docker-modem
     if (dockerContext?.Endpoints?.docker?.SkipTLSVerify) {
+        // Disabling TLS specifically requires the value to be an empty string
+        // https://docs.docker.com/compose/reference/envvars/#docker_tls_verify
         newEnv.DOCKER_TLS_VERIFY = '';
     } else {
         newEnv.DOCKER_TLS_VERIFY = '1';

--- a/src/utils/refreshDockerode.ts
+++ b/src/utils/refreshDockerode.ts
@@ -7,7 +7,7 @@ import Dockerode = require('dockerode');
 import { Socket } from 'net';
 import * as os from 'os';
 import * as url from 'url';
-import { CancellationTokenSource } from 'vscode';
+import { CancellationTokenSource, workspace } from 'vscode';
 import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
@@ -30,6 +30,15 @@ export async function refreshDockerode(): Promise<void> {
         async (actionContext: IActionContext) => {
 
             try {
+                // If the docker.dockerodeOptions setting is present, use it only
+                const config = workspace.getConfiguration('docker');
+                const overrideDockerodeOptions = config.get<{}>('dockerodeOptions');
+                if (overrideDockerodeOptions) {
+                    ext.dockerodeInitError = undefined;
+                    ext.dockerode = new Dockerode(<Dockerode.DockerOptions>overrideDockerodeOptions);
+                    return;
+                }
+
                 // Set up environment variables
                 const oldEnv = process.env;
                 const newEnv: NodeJS.ProcessEnv = cloneObject(process.env); // make a clone before we change anything

--- a/src/utils/spawnAsync.ts
+++ b/src/utils/spawnAsync.ts
@@ -120,7 +120,7 @@ export async function execAsync(command: string, options?: cp.ExecOptions, progr
     }
 }
 
-function bufferToString(buffer: Buffer): string {
+export function bufferToString(buffer: Buffer): string {
     // Node.js treats null bytes as part of the length, which makes everything mad
     // There's also a trailing newline everything hates, so we'll remove
     return buffer.toString().replace(/\0/g, '').replace(/\r?\n$/g, '');


### PR DESCRIPTION
This PR does several things:
- Adds Docker Desktop installation ID to telemetry
- Captures the protocol (local pipe, TCP, SSH, HTTP(S), etc.) in more cases than just Docker context
- Captures the source of the ultimate Dockerode host choice (environment vs. VSCode setting vs. there's-only-one-Docker-context vs. default Docker context vs. custom Docker context)
- Offers a way to do totally bring-your-own-settings to Dockerode (related to #1459 or maybe fixes it)

Resolves #1819.