### PR TITLE
Group containers by compose project name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1572,6 +1572,7 @@
                     "default": "None",
                     "description": "%vscode-docker.config.docker.containers.groupBy%",
                     "enum": [
+                        "Compose Project Name",
                         "ContainerId",
                         "ContainerName",
                         "CreatedTime",
@@ -1599,6 +1600,7 @@
                     "items": {
                         "type": "string",
                         "enum": [
+                            "Compose Project Name",
                             "ContainerId",
                             "ContainerName",
                             "CreatedTime",
@@ -1621,6 +1623,7 @@
                     "default": "FullTag",
                     "description": "%vscode-docker.config.docker.containers.label%",
                     "enum": [
+                        "Compose Project Name",
                         "ContainerId",
                         "ContainerName",
                         "CreatedTime",

--- a/src/tree/LocalRootTreeItemBase.ts
+++ b/src/tree/LocalRootTreeItemBase.ts
@@ -53,10 +53,10 @@ export abstract class LocalRootTreeItemBase<TItem extends ILocalItem, TProperty 
     public sortBySetting: CommonSortBy;
     public labelSetting: TProperty;
     public descriptionSetting: TProperty[];
+    protected failedToConnect: boolean = false;
 
     private _currentItems: TItem[] | undefined;
     private _itemsFromPolling: TItem[] | undefined;
-    private _failedToConnect: boolean = false;
 
     public get contextValue(): string {
         return this.treePrefix;
@@ -103,10 +103,10 @@ export abstract class LocalRootTreeItemBase<TItem extends ILocalItem, TProperty 
         try {
             this._currentItems = this._itemsFromPolling || await this.getSortedItems();
             this._itemsFromPolling = undefined;
-            this._failedToConnect = false;
+            this.failedToConnect = false;
         } catch (error) {
             this._currentItems = undefined;
-            this._failedToConnect = true;
+            this.failedToConnect = true;
             context.telemetry.properties.failedToConnect = 'true';
             return this.getDockerErrorTreeItems(context, error);
         }
@@ -137,7 +137,7 @@ export abstract class LocalRootTreeItemBase<TItem extends ILocalItem, TProperty 
     }
 
     public compareChildrenImpl(ti1: AzExtTreeItem, ti2: AzExtTreeItem): number {
-        if (this._failedToConnect) {
+        if (this.failedToConnect) {
             return 0; // children are already sorted
         } else {
             if (ti1 instanceof this.childGroupType && ti2 instanceof this.childGroupType) {

--- a/src/tree/containers/ContainerGroupTreeItem.ts
+++ b/src/tree/containers/ContainerGroupTreeItem.ts
@@ -25,6 +25,7 @@ export class ContainerGroupTreeItem extends LocalGroupTreeItemBase<ILocalContain
                 break;
             case 'Ports':
             case 'Status':
+            case 'Compose Project Name':
                 icon = 'applicationGroup';
                 break;
             case 'State':

--- a/src/tree/containers/ContainerProperties.ts
+++ b/src/tree/containers/ContainerProperties.ts
@@ -18,7 +18,7 @@ export const containerProperties: ITreePropertyInfo<ContainerProperty>[] = [
     { property: 'Ports', exampleValue: '8080' },
     { property: 'State', exampleValue: 'exited' },
     { property: 'Status', exampleValue: 'Exited (0) 2 hours ago' },
-    { property: 'Compose Project Name', description: localize('vscode-docker.tree.containers.properties.composeProjectName', 'Value used to associate containers launched by a \'compose up\' command') },
+    { property: 'Compose Project Name', description: localize('vscode-docker.tree.containers.properties.composeProjectName', 'Value used to associate containers launched by a \'docker-compose up\' command') },
 ];
 
 export function getContainerStateIcon(state: string): IconPath {

--- a/src/tree/containers/ContainerProperties.ts
+++ b/src/tree/containers/ContainerProperties.ts
@@ -7,7 +7,7 @@ import { getThemedIconPath, IconPath } from "../IconPath";
 import { imageProperties, ImageProperty } from "../images/ImageProperties";
 import { ITreePropertyInfo } from "../settings/ITreeSettingInfo";
 
-export type ContainerProperty = ImageProperty | 'ContainerId' | 'ContainerName' | 'Networks' | 'Ports' | 'State' | 'Status';
+export type ContainerProperty = ImageProperty | 'Compose Project Name' | 'ContainerId' | 'ContainerName' | 'Networks' | 'Ports' | 'State' | 'Status';
 
 export const containerProperties: ITreePropertyInfo<ContainerProperty>[] = [
     ...imageProperties,
@@ -16,7 +16,8 @@ export const containerProperties: ITreePropertyInfo<ContainerProperty>[] = [
     { property: 'Networks', exampleValue: 'mybridge_network' },
     { property: 'Ports', exampleValue: '8080' },
     { property: 'State', exampleValue: 'exited' },
-    { property: 'Status', exampleValue: 'Exited (0) 2 hours ago' }
+    { property: 'Status', exampleValue: 'Exited (0) 2 hours ago' },
+    { property: 'Compose Project Name', description: 'Value used to associate containers launched by a \'compose up\' command' },
 ];
 
 export function getContainerStateIcon(state: string): IconPath {

--- a/src/tree/containers/ContainerProperties.ts
+++ b/src/tree/containers/ContainerProperties.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { localize } from "../../localize";
 import { getThemedIconPath, IconPath } from "../IconPath";
 import { imageProperties, ImageProperty } from "../images/ImageProperties";
 import { ITreePropertyInfo } from "../settings/ITreeSettingInfo";
@@ -17,7 +18,7 @@ export const containerProperties: ITreePropertyInfo<ContainerProperty>[] = [
     { property: 'Ports', exampleValue: '8080' },
     { property: 'State', exampleValue: 'exited' },
     { property: 'Status', exampleValue: 'Exited (0) 2 hours ago' },
-    { property: 'Compose Project Name', description: 'Value used to associate containers launched by a \'compose up\' command' },
+    { property: 'Compose Project Name', description: localize('vscode-docker.tree.containers.properties.composeProjectName', 'Value used to associate containers launched by a \'compose up\' command') },
 ];
 
 export function getContainerStateIcon(state: string): IconPath {

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -13,7 +13,7 @@ import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettin
 import { ContainerGroupTreeItem } from "./ContainerGroupTreeItem";
 import { containerProperties, ContainerProperty } from "./ContainerProperties";
 import { ContainerTreeItem } from "./ContainerTreeItem";
-import { ILocalContainerInfo, LocalContainerInfo } from "./LocalContainerInfo";
+import { ILocalContainerInfo, LocalContainerInfo, NonComposeGroupName } from "./LocalContainerInfo";
 
 export class ContainersTreeItem extends LocalRootTreeItemBase<ILocalContainerInfo, ContainerProperty> {
     public treePrefix: string = 'containers';
@@ -67,8 +67,26 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<ILocalContainerInf
                 return item.state;
             case 'Status':
                 return item.status;
+            case 'Compose Project Name':
+                return item.compose;
             default:
                 return getImagePropertyValue(item, property);
         }
+    }
+
+    public compareChildrenImpl(ti1: ContainerTreeItem, ti2: ContainerTreeItem): number {
+        if (this.failedToConnect) {
+            return 0; // children are already sorted
+        }
+        if (this.groupBySetting === 'Compose Project Name'
+            && ti1 instanceof this.childGroupType && ti2 instanceof this.childGroupType
+            && (ti1.label === NonComposeGroupName || ti2.label === NonComposeGroupName)) {
+            if (ti1.label === ti2.label) {
+                return 0;
+            } else {
+                return ti1.label === NonComposeGroupName ? 1 : -1;
+            }
+        }
+        return super.compareChildrenImpl(ti1, ti2);
     }
 }

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -68,13 +68,15 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<ILocalContainerInf
             case 'Status':
                 return item.status;
             case 'Compose Project Name':
-                return item.compose;
+                return item.composeProjectName;
             default:
                 return getImagePropertyValue(item, property);
         }
     }
 
     public compareChildrenImpl(ti1: ContainerTreeItem, ti2: ContainerTreeItem): number {
+        // Override the sorting behavior to keep the non compose group at the bottom when
+        // grouped by compose project name.
         if (this.failedToConnect) {
             return 0; // children are already sorted
         }

--- a/src/tree/containers/LocalContainerInfo.ts
+++ b/src/tree/containers/LocalContainerInfo.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/tslint/config */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
@@ -18,8 +19,10 @@ export interface ILocalContainerInfo extends ILocalItem {
     ports: number[];
     state: string;
     status: string;
+    compose: string;
 }
 
+export const NonComposeGroupName = 'Other Containers';
 /**
  * Wrapper class for Dockerode item, which has inconsistent names/types
  */
@@ -73,6 +76,18 @@ export class LocalContainerInfo implements ILocalContainerInfo {
 
     public get status(): string {
         return this.data.Status;
+    }
+
+    public get compose(): string {
+        const labels = Object.keys(this.data.Labels)
+            .map(label => ({ label: label, value: this.data.Labels[label] }));
+
+        const composeProject = labels.find(l => l.label === 'com.docker.compose.project');
+        if (composeProject) {
+            return composeProject.value;
+        } else {
+            return NonComposeGroupName;
+        }
     }
 
     public get treeId(): string {

--- a/src/tree/containers/LocalContainerInfo.ts
+++ b/src/tree/containers/LocalContainerInfo.ts
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/tslint/config */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import { ContainerInfo } from "dockerode";
+import { localize } from "../../localize";
 import { ILocalItem } from "../LocalRootTreeItemBase";
 
 /**
@@ -19,10 +19,10 @@ export interface ILocalContainerInfo extends ILocalItem {
     ports: number[];
     state: string;
     status: string;
-    compose: string;
+    composeProjectName: string;
 }
 
-export const NonComposeGroupName = 'Other Containers';
+export const NonComposeGroupName = localize('vscode-docker.tree.containers.otherContainers', 'Other Containers');
 /**
  * Wrapper class for Dockerode item, which has inconsistent names/types
  */
@@ -78,7 +78,7 @@ export class LocalContainerInfo implements ILocalContainerInfo {
         return this.data.Status;
     }
 
-    public get compose(): string {
+    public get composeProjectName(): string {
         const labels = Object.keys(this.data.Labels)
             .map(label => ({ label: label, value: this.data.Labels[label] }));
 


### PR DESCRIPTION
A new property "Compose Project Name" is added to container. This will allow group by compose projects. This will also enable user to choose this new propery to be displayed on tree item label and description.
Fixes: #1846 