### PR TITLE
Open a registry specific help topic from reqistry view

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
         "onCommand:vscode-docker.registries.deployImageToAzure",
         "onCommand:vscode-docker.registries.disconnectRegistry",
         "onCommand:vscode-docker.registries.dockerHub.openInBrowser",
+        "onCommand:vscode-docker.registries.help",
         "onCommand:vscode-docker.registries.logInToDockerCli",
         "onCommand:vscode-docker.registries.logOutOfDockerCli",
         "onCommand:vscode-docker.registries.pullImage",
@@ -278,6 +279,11 @@
                     "group": "navigation@1"
                 },
                 {
+                    "command": "vscode-docker.registries.help",
+                    "when": "view == dockerRegistries",
+                    "group": "navigation@10"
+                },
+                {
                     "command": "vscode-docker.volumes.prune",
                     "when": "view == dockerVolumes",
                     "group": "navigation@1"
@@ -294,7 +300,7 @@
                 },
                 {
                     "command": "vscode-docker.help",
-                    "when": "view == dockerContainers || view == dockerImages || view == dockerVolumes || view == dockerRegistries || view == dockerNetworks",
+                    "when": "view == dockerContainers || view == dockerImages || view == dockerVolumes || view == dockerNetworks",
                     "group": "navigation@10"
                 }
             ],
@@ -2331,6 +2337,12 @@
                 "command": "vscode-docker.registries.dockerHub.openInBrowser",
                 "title": "%vscode-docker.commands.registries.dockerHub.openInBrowser%",
                 "category": "%vscode-docker.commands.category.dockerHub%"
+            },
+            {
+                "command": "vscode-docker.registries.help",
+                "title": "%vscode-docker.commands.registries.help%",
+                "category": "%vscode-docker.commands.category.dockerRegistries%",
+                "icon": "$(question)"
             },
             {
                 "command": "vscode-docker.registries.logInToDockerCli",

--- a/package.nls.json
+++ b/package.nls.json
@@ -224,6 +224,7 @@
     "vscode-docker.commands.registries.deployImageToAzure": "Deploy Image to Azure App Service...",
     "vscode-docker.commands.registries.disconnectRegistry": "Disconnect",
     "vscode-docker.commands.registries.dockerHub.openInBrowser": "Open in Browser",
+    "vscode-docker.commands.registries.help": "Registries Help...",
     "vscode-docker.commands.registries.logInToDockerCli": "Log In to Docker CLI",
     "vscode-docker.commands.registries.logOutOfDockerCli": "Log Out of Docker CLI",
     "vscode-docker.commands.registries.pullImage": "Pull Image",

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -63,6 +63,7 @@ import { logInToDockerCli } from "./registries/logInToDockerCli";
 import { logOutOfDockerCli } from "./registries/logOutOfDockerCli";
 import { pullImageFromRepository, pullRepository } from "./registries/pullImages";
 import { reconnectRegistry } from "./registries/reconnectRegistry";
+import { registryHelp } from "./registries/registryHelp";
 import { reportIssue } from "./reportIssue";
 import { configureVolumesExplorer } from "./volumes/configureVolumesExplorer";
 import { inspectVolume } from "./volumes/inspectVolume";
@@ -114,6 +115,7 @@ export function registerCommands(): void {
     registerCommand('vscode-docker.registries.deleteImage', deleteRemoteImage);
     registerCommand('vscode-docker.registries.deployImageToAzure', deployImageToAzure);
     registerCommand('vscode-docker.registries.disconnectRegistry', disconnectRegistry);
+    registerCommand('vscode-docker.registries.help', registryHelp);
     registerWorkspaceCommand('vscode-docker.registries.logInToDockerCli', logInToDockerCli);
     registerWorkspaceCommand('vscode-docker.registries.logOutOfDockerCli', logOutOfDockerCli);
     registerWorkspaceCommand('vscode-docker.registries.pullImage', pullImageFromRepository);

--- a/src/commands/registries/registryHelp.ts
+++ b/src/commands/registries/registryHelp.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from "vscode-azureextensionui";
+import { openExternal } from "../../utils/openExternal";
+
+export async function registryHelp(context: IActionContext): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    openExternal('https://aka.ms/helpicon_containerregistries');
+}


### PR DESCRIPTION
Earlier the ? command on registries view was using generic help command. Now this is updated to open a registry specific help page.
Fixes #1894