### PR TITLE
telemetry changes for vscodespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -755,14 +755,14 @@
             }
         },
         "applicationinsights": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.4.0.tgz",
-            "integrity": "sha512-TV8MYb0Kw9uE2cdu4V/UvTKdOABkX2+Fga9iDz0zqV7FLrNXfmAugWZmmdTx4JoynYkln3d5CUHY3oVSUEbfFw==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
+            "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
             "requires": {
                 "cls-hooked": "^4.2.2",
                 "continuation-local-storage": "^3.2.1",
                 "diagnostic-channel": "0.2.0",
-                "diagnostic-channel-publishers": "^0.3.2"
+                "diagnostic-channel-publishers": "^0.3.3"
             }
         },
         "aproba": {
@@ -10869,9 +10869,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.29.13",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.29.13.tgz",
-            "integrity": "sha512-Ko3nBlOgtR5xdMTuV+ty0WjZTtC5FaLMvslDSUK4T2FaIRGF6ScEP6UNSz/IdQ588FAgknfXdw4VNlHZCYBsbw==",
+            "version": "0.29.14",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.29.14.tgz",
+            "integrity": "sha512-K6SKlqj489PiN9ZZCPKtN0je3mXETn+jJwUs9AVPZDuu69WjIpXqyN3WkPXR7r1JmhV1PbpRPvtB3VhlcmulLw==",
             "requires": {
                 "azure-arm-resource": "^3.0.0-preview",
                 "azure-arm-storage": "^3.1.0",
@@ -10882,7 +10882,7 @@
                 "ms-rest-azure": "^2.6.0",
                 "opn": "^6.0.0",
                 "semver": "^5.7.1",
-                "vscode-extension-telemetry": "^0.1.2",
+                "vscode-extension-telemetry": "^0.1.3",
                 "vscode-nls": "^4.1.1"
             },
             "dependencies": {
@@ -10903,11 +10903,11 @@
             }
         },
         "vscode-extension-telemetry": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.2.tgz",
-            "integrity": "sha512-FSbaZKlIH3VKvBJsKw7v5bESWHXzltji2rtjaJeJglpQH4tfClzwHMzlMXUZGiblV++djEzb1gW8mb5E+wxFsg==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.4.tgz",
+            "integrity": "sha512-9U2pUZ/YwZBfA8CkBrHwMxjnq9Ab+ng8daJWJzEQ6CAxlZyRhmck23bx2lqqpEwGWJCiuceQy4k0Me6llEB4zw==",
             "requires": {
-                "applicationinsights": "1.4.0"
+                "applicationinsights": "1.7.4"
             }
         },
         "vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -2650,7 +2650,7 @@
         "semver": "^6.3.0",
         "tar": "^6.0.1",
         "vscode-azureappservice": "^0.57.6",
-        "vscode-azureextensionui": "^0.29.13",
+        "vscode-azureextensionui": "^0.29.14",
         "vscode-languageclient": "^6.1.3",
         "vscode-nls": "^4.1.2",
         "xml2js": "^0.4.23"

--- a/src/telemetry/TelemetryReporterProxy.ts
+++ b/src/telemetry/TelemetryReporterProxy.ts
@@ -21,4 +21,15 @@ export class TelemetryReporterProxy implements ITelemetryReporter {
             properties
         });
     }
+
+    public sendTelemetryErrorEvent(eventName: string, properties?: { [key: string]: string; }, measurements?: { [key: string]: number; }): void {
+        // eslint-disable-next-line @typescript-eslint/tslint/config
+        this.wrappedReporter.sendTelemetryErrorEvent(eventName, properties, measurements);
+
+        this.publisher.publishEvent({
+            eventName,
+            measurements,
+            properties
+        });
+    }
 }

--- a/test/telemetry/TelemetryReporterProxy.test.ts
+++ b/test/telemetry/TelemetryReporterProxy.test.ts
@@ -15,8 +15,9 @@ suite('(unit) telemetry/TelemetryReporterProxy', () => {
         const measurements = {};
         const properties = {};
 
-        let eventPublished = false;
+        let publishedCount = 0;
         let eventSent = false;
+        let errorEventSent = false;
 
         const publisher: ITelemetryPublisher = {
             onEvent: undefined,
@@ -25,7 +26,7 @@ suite('(unit) telemetry/TelemetryReporterProxy', () => {
                 assert.equal(e.measurements, measurements);
                 assert.equal(e.properties, properties);
 
-                eventPublished = true;
+                publishedCount++;
             }
         };
 
@@ -36,14 +37,23 @@ suite('(unit) telemetry/TelemetryReporterProxy', () => {
                 assert.equal(p, properties);
 
                 eventSent = true;
+            },
+            sendTelemetryErrorEvent: (e, p, m) => {
+                assert.equal(e, eventName);
+                assert.equal(m, measurements);
+                assert.equal(p, properties);
+
+                errorEventSent = true;
             }
         };
 
         const proxy = new TelemetryReporterProxy(publisher, wrappedReporter);
 
         proxy.sendTelemetryEvent(eventName, properties, measurements);
+        proxy.sendTelemetryErrorEvent(eventName, properties, measurements);
 
-        assert(eventPublished);
+        assert.equal(publishedCount, 2);
         assert(eventSent);
+        assert(errorEventSent);
     });
 });


### PR DESCRIPTION
Consume the latest vscode-azureextensionui that reports the error event using the latest API which filters out PII in the error message/stack.