### PR TITLE
Provider better error message for Docker Desktop installer download failure

### DIFF
--- a/src/commands/dockerInstaller.ts
+++ b/src/commands/dockerInstaller.ts
@@ -49,7 +49,11 @@ export abstract class DockerInstallerBase {
             const command = this.getInstallCommand(downloadedFileName);
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             vscode.window.showInformationMessage(installationMessage);
-            await this.install(downloadedFileName, command);
+            try {
+                await this.install(downloadedFileName, command);
+            } catch {
+                context.errorHandling.suppressReportIssue = true;
+            }
         }
     }
 

--- a/src/commands/installDocker.ts
+++ b/src/commands/installDocker.ts
@@ -12,9 +12,9 @@ export async function installDocker(context: IActionContext): Promise<void> {
     const osProvider = new LocalOSProvider();
 
     if (osProvider.os === 'Windows') {
-        await (new WindowsDockerInstaller()).downloadAndInstallDocker();
+        await (new WindowsDockerInstaller()).downloadAndInstallDocker(context);
     } else if (osProvider.os === 'Mac') {
-        await (new MacDockerInstaller()).downloadAndInstallDocker();
+        await (new MacDockerInstaller()).downloadAndInstallDocker(context);
     } else {
         await openExternal('https://aka.ms/download-docker-linux-vscode');
     }


### PR DESCRIPTION
Docker Desktop installer sometimes failed due to connection issue or proxy settings. Now we provider a better error message and also offer to manually download and install like below
![image](https://user-images.githubusercontent.com/1775825/80548203-331af000-896f-11ea-9452-6f5a5c717bb7.png)

Fixes: #1913 , #1926 