### PR TITLE
Provide unique id for treeitem

### DIFF
--- a/src/tree/contexts/ContextTreeItem.ts
+++ b/src/tree/contexts/ContextTreeItem.ts
@@ -23,6 +23,10 @@ export class ContextTreeItem extends AzExtTreeItem {
         return this._item.createdTime;
     }
 
+    public get id(): string {
+        return this._item.treeId;
+    }
+
     public get label(): string {
         return ext.contextsRoot.getTreeItemLabel(this._item);
     }


### PR DESCRIPTION
Earlier the context tree item was using the label and when the label had a duplicate value the tree view construction failed. Now using unique id.
Fixes: #1932 