### PR TITLE
.Net Core Attach support for windows container

### DIFF
--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -14,7 +14,7 @@ import { NetCoreTaskHelper, NetCoreTaskOptions } from '../../tasks/netcore/NetCo
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { callDockerodeWithErrorHandling } from '../../utils/callDockerode';
 import { LocalOSProvider } from '../../utils/LocalOSProvider';
-import { ContainerOSType, getContainerOSType } from '../../utils/osUtils';
+import { DockerOSType, getDockerOSType } from '../../utils/osUtils';
 import { pathNormalize } from '../../utils/pathNormalize';
 import { PlatformOS } from '../../utils/platform';
 import { unresolveWorkspaceFolder } from '../../utils/resolveVariables';
@@ -188,7 +188,6 @@ export class NetCoreDebugHelper implements DebugHelper {
     }
 
     public async resolveAttachDebugConfiguration(context: DockerDebugContext, debugConfiguration: DockerAttachConfiguration): Promise<ResolvedDebugConfiguration | undefined> {
-        // TODO: Validate the target container OS and fail debugging
         // Get Container Name if missing
         const containerName: string = debugConfiguration.containerName ?? await this.getContainerNameToAttach();
 
@@ -196,7 +195,7 @@ export class NetCoreDebugHelper implements DebugHelper {
 
         // If debugger path is not specified, then install the debugger if it doesn't exist in the container
         if (!debuggerPath) {
-            const containerOS = await getContainerOSType(containerName, context.actionContext);
+            const containerOS = await getDockerOSType(context.actionContext);
             const osProvider = new LocalOSProvider();
             const debuggerDirectory = containerOS === 'windows' ? 'C:\\remote_debugger' : '/remote_debugger';
             debuggerPath = containerOS === 'windows'
@@ -293,7 +292,7 @@ export class NetCoreDebugHelper implements DebugHelper {
         return pathNormalize(result, platformOS);
     }
 
-    private async copyDebuggerToContainer(context: IActionContext, containerName: string, containerDebuggerDirectory: string, containerOS: ContainerOSType): Promise<void> {
+    private async copyDebuggerToContainer(context: IActionContext, containerName: string, containerDebuggerDirectory: string, containerOS: DockerOSType): Promise<void> {
         const dockerClient = new CliDockerClient(new ChildProcessProvider());
         if (containerOS === 'windows') {
             const containerInfo = await callDockerodeWithErrorHandling(async () => ext.dockerode.getContainer(containerName).inspect(), context);
@@ -331,7 +330,7 @@ export class NetCoreDebugHelper implements DebugHelper {
         );
     }
 
-    private async isDebuggerInstalled(containerName: string, debuggerPath: string, containerOS: ContainerOSType): Promise<boolean> {
+    private async isDebuggerInstalled(containerName: string, debuggerPath: string, containerOS: DockerOSType): Promise<boolean> {
         const dockerClient = new CliDockerClient(new ChildProcessProvider());
         const osProvider = new LocalOSProvider();
         let command: string;

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -298,7 +298,7 @@ export class NetCoreDebugHelper implements DebugHelper {
             const isolation = await dockerClient.inspectObject(containerName, { format: '{{ .HostConfig.Isolation}}' });
             if (isolation && isolation === 'hyperv') {
                 context.actionContext.errorHandling.suppressReportIssue = true;
-                throw new Error(localize('vscode-docker.debug.netcore.isolationNotSupported', 'Unable to copy debugger. This operation is not supported on Hyper-V container.'));
+                throw new Error(localize('vscode-docker.debug.netcore.isolationNotSupported', 'Attaching a debugger to a Hyper-V container is not supported.'));
             }
         }
 

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -13,7 +13,7 @@ import { localize } from '../../localize';
 import { NetCoreTaskHelper, NetCoreTaskOptions } from '../../tasks/netcore/NetCoreTaskHelper';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { LocalOSProvider } from '../../utils/LocalOSProvider';
-import { ContainerOSType, getConatinerOSType } from '../../utils/osUtils';
+import { ContainerOSType, getContainerOSType } from '../../utils/osUtils';
 import { pathNormalize } from '../../utils/pathNormalize';
 import { PlatformOS } from '../../utils/platform';
 import { unresolveWorkspaceFolder } from '../../utils/resolveVariables';
@@ -195,15 +195,15 @@ export class NetCoreDebugHelper implements DebugHelper {
 
         // If debugger path is not specified, then install the debugger if it doesn't exist in the container
         if (!debuggerPath) {
-            const conatinerOS = await getConatinerOSType(containerName);
+            const containerOS = await getContainerOSType(containerName);
             const osProvider = new LocalOSProvider();
-            const debuggerDirectory = conatinerOS === 'windows' ? 'C:\\remote_debugger' : '/remote_debugger';
-            debuggerPath = conatinerOS === 'windows'
+            const debuggerDirectory = containerOS === 'windows' ? 'C:\\remote_debugger' : '/remote_debugger';
+            debuggerPath = containerOS === 'windows'
                 ? osProvider.pathJoin(osProvider.os, debuggerDirectory, 'win7-x64', 'latest', 'vsdbg.exe')
                 : osProvider.pathJoin(osProvider.os, debuggerDirectory, 'vsdbg');
-            const isDebuggerInstalled: boolean = await this.isDebuggerInstalled(containerName, debuggerPath, conatinerOS);
+            const isDebuggerInstalled: boolean = await this.isDebuggerInstalled(containerName, debuggerPath, containerOS);
             if (!isDebuggerInstalled) {
-                await this.copyDebuggerToContainer(context, containerName, debuggerDirectory, conatinerOS);
+                await this.copyDebuggerToContainer(context, containerName, debuggerDirectory, containerOS);
             }
         }
 

--- a/src/utils/osUtils.ts
+++ b/src/utils/osUtils.ts
@@ -7,6 +7,7 @@ import * as semver from 'semver';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { callDockerodeWithErrorHandling } from './callDockerode';
+import { execAsync } from './spawnAsync';
 
 // Minimum Windows RS3 version number
 const windows10RS3MinVersion = '10.0.16299';
@@ -76,6 +77,7 @@ export function isMac(): boolean {
 }
 
 export type DockerOSType = "windows" | "linux";
+export type ContainerOSType = "windows" | "linux";
 
 export async function getDockerOSType(context: IActionContext): Promise<DockerOSType> {
     if (!isWindows()) {
@@ -87,4 +89,10 @@ export async function getDockerOSType(context: IActionContext): Promise<DockerOS
         // eslint-disable-next-line @typescript-eslint/tslint/config
         return info.OSType;
     }
+}
+
+export async function getConatinerOSType(containerId: string): Promise<ContainerOSType> {
+    const inspectCmd: string = `docker inspect --format="{{ .Platform}}" ${containerId}`;
+    const execResult = await execAsync(inspectCmd);
+    return execResult.stdout.trim().toLowerCase() === 'windows' ? 'windows' : 'linux';
 }

--- a/src/utils/osUtils.ts
+++ b/src/utils/osUtils.ts
@@ -76,7 +76,6 @@ export function isMac(): boolean {
 }
 
 export type DockerOSType = "windows" | "linux";
-export type ContainerOSType = "windows" | "linux";
 
 export async function getDockerOSType(context: IActionContext): Promise<DockerOSType> {
     if (!isWindows()) {
@@ -87,17 +86,5 @@ export async function getDockerOSType(context: IActionContext): Promise<DockerOS
         const info = await callDockerodeWithErrorHandling(async () => ext.dockerode.info(), context);
         // eslint-disable-next-line @typescript-eslint/tslint/config
         return info.OSType;
-    }
-}
-
-export async function getContainerOSType(containerId: string, context: IActionContext): Promise<ContainerOSType> {
-    if (!isWindows()) {
-        // On Linux or macOS, this can only ever be linux,
-        // so short-circuit the Docker call entirely.
-        return "linux";
-    } else {
-        const info = await callDockerodeWithErrorHandling(async () => ext.dockerode.getContainer(containerId).inspect(), context);
-        // eslint-disable-next-line @typescript-eslint/tslint/config
-        return info.Platform === 'windows' ? 'windows' : 'linux'
     }
 }

--- a/src/utils/osUtils.ts
+++ b/src/utils/osUtils.ts
@@ -91,7 +91,7 @@ export async function getDockerOSType(context: IActionContext): Promise<DockerOS
     }
 }
 
-export async function getConatinerOSType(containerId: string): Promise<ContainerOSType> {
+export async function getContainerOSType(containerId: string): Promise<ContainerOSType> {
     const inspectCmd: string = `docker inspect --format="{{ .Platform}}" ${containerId}`;
     const execResult = await execAsync(inspectCmd);
     return execResult.stdout.trim().toLowerCase() === 'windows' ? 'windows' : 'linux';


### PR DESCRIPTION
Earlier we were not handling the windows container during attach. Now added support. But `docker cp` command is not supported on hyper-v containers, which is the default in windows 10. So still this doesn't address most of the windows container. At least now this will provide a better error message.
Fixes: #1662 