### PR TITLE
[Python] Use debugpy launch

### DIFF
--- a/resources/python/launcher.py
+++ b/resources/python/launcher.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+containerId = sys.argv[-1]
+args = sys.argv[1:-1]
+
+print("docker exec -d " + containerId + " python /pydbg/debugpy/launcher " + ' '.join(args))
+os.execvp('docker', ['docker', 'exec', '-d', containerId, 'python', '/pydbg/debugpy/launcher'] + args)

--- a/resources/python/launcher.py
+++ b/resources/python/launcher.py
@@ -1,8 +1,13 @@
-import os
-import sys
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.md in the project root for license information.
 
+# This acts as a simple launcher for debugpy that only redirects the args to the actual launcher inside the container
+import os, sys
+
+# Container id is the last arg
 containerId = sys.argv[-1]
 args = sys.argv[1:-1]
 
 print("docker exec -d " + containerId + " python /pydbg/debugpy/launcher " + ' '.join(args))
+
 os.execvp('docker', ['docker', 'exec', '-d', containerId, 'python', '/pydbg/debugpy/launcher'] + args)

--- a/resources/python/launcher.py
+++ b/resources/python/launcher.py
@@ -8,6 +8,8 @@ import os, sys
 containerId = sys.argv[-1]
 args = sys.argv[1:-1]
 
-print("docker exec -d " + containerId + " python /pydbg/debugpy/launcher " + ' '.join(args))
+launcherPort = args[0]
+args[0] = 'host.docker.internal:' + launcherPort
 
+print("docker exec -d " + containerId + " python /pydbg/debugpy/launcher " + ' '.join(args))
 os.execvp('docker', ['docker', 'exec', '-d', containerId, 'python', '/pydbg/debugpy/launcher'] + args)

--- a/resources/python/launcher.py
+++ b/resources/python/launcher.py
@@ -8,8 +8,10 @@ import os, sys
 containerId = sys.argv[-1]
 args = sys.argv[1:-1]
 
-launcherPort = args[0]
-args[0] = 'host.docker.internal:' + launcherPort
+adapterHost = args[0]
+
+if ':' not in adapterHost:
+    args[0] = 'host.docker.internal:' + adapterHost
 
 print("docker exec -d " + containerId + " python /pydbg/debugpy/launcher " + ' '.join(args))
 os.execvp('docker', ['docker', 'exec', '-d', containerId, 'python', '/pydbg/debugpy/launcher'] + args)

--- a/resources/python/launcher.py
+++ b/resources/python/launcher.py
@@ -8,10 +8,13 @@ import os, sys
 containerId = sys.argv[-1]
 args = sys.argv[1:-1]
 
+# If the adapterHost is only a port number, then append the default DNS name 'host.docker.internal'
 adapterHost = args[0]
 
-if ':' not in adapterHost:
+if adapterHost.isnumeric():
     args[0] = 'host.docker.internal:' + adapterHost
 
-print("docker exec -d " + containerId + " python /pydbg/debugpy/launcher " + ' '.join(args))
-os.execvp('docker', ['docker', 'exec', '-d', containerId, 'python', '/pydbg/debugpy/launcher'] + args)
+dockerExecArgs = ['docker', 'exec', '-d', containerId, 'python', '/pydbg/debugpy/launcher'] + args
+
+print(' '.join(dockerExecArgs))
+os.execvp('docker', dockerExecArgs)

--- a/src/configureWorkspace/configurePython.ts
+++ b/src/configureWorkspace/configurePython.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import vscode = require('vscode');
 import * as fse from 'fs-extra';
 import * as path from "path";
-import vscode = require('vscode');
 import { TelemetryProperties } from 'vscode-azureextensionui';
 import { DockerDebugScaffoldContext } from '../debugging/DebugHelper';
 import { dockerDebugScaffoldingProvider, PythonScaffoldingOptions } from '../debugging/DockerDebugScaffoldingProvider';
 import { ext } from "../extensionVariables";
 import { localize } from '../localize';
 import { getValidImageName } from '../utils/getValidImageName';
-import { getPythonProjectType, PythonDefaultPorts, PythonFileExtension, PythonFileTarget, PythonModuleTarget, PythonProjectType, PythonTarget, inferPythonArgs } from "../utils/pythonUtils";
+import { getPythonProjectType, inferPythonArgs, PythonDefaultPorts, PythonFileExtension, PythonFileTarget, PythonModuleTarget, PythonProjectType, PythonTarget } from "../utils/pythonUtils";
 import { getComposePorts, getExposeStatements } from './configure';
 import { ConfigureTelemetryProperties, genCommonDockerIgnoreFile, quickPickGenerateComposeFiles } from './configUtils';
 import { ScaffolderContext, ScaffoldFile } from './scaffolding';

--- a/src/configureWorkspace/configurePython.ts
+++ b/src/configureWorkspace/configurePython.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import vscode = require('vscode');
 import * as fse from 'fs-extra';
 import * as path from "path";
+import vscode = require('vscode');
 import { TelemetryProperties } from 'vscode-azureextensionui';
 import { DockerDebugScaffoldContext } from '../debugging/DebugHelper';
 import { dockerDebugScaffoldingProvider, PythonScaffoldingOptions } from '../debugging/DockerDebugScaffoldingProvider';

--- a/src/debugging/DockerDebugConfigurationProvider.ts
+++ b/src/debugging/DockerDebugConfigurationProvider.ts
@@ -118,16 +118,9 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         if (resolvedConfiguration.dockerOptions
             && (resolvedConfiguration.dockerOptions.removeContainerAfterDebug === undefined || resolvedConfiguration.dockerOptions.removeContainerAfterDebug)
             && resolvedConfiguration.dockerOptions.containerName) {
-
-            // Since Python is a special case as we handle waiting for the debugger to be ready while resolving
-            // the launch configuration, and since this method comes later then we shouldn't remove a container
-            // that we just created.
-            // TODO: this needs to be removed as soon as the Python extension adds a way to retry while connecting to a remote debugger.
-            if (resolvedConfiguration.type !== 'python') {
-                try {
-                    await this.dockerClient.removeContainer(resolvedConfiguration.dockerOptions.containerName, { force: true });
-                } catch { }
-            }
+            try {
+                await this.dockerClient.removeContainer(resolvedConfiguration.dockerOptions.containerName, { force: true });
+            } catch { }
 
             // Now register the container for removal after the debug session ends
             const disposable = debug.onDidTerminateDebugSession(async session => {

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -87,7 +87,7 @@ export class PythonDebugHelper implements DebugHelper {
                 removeContainerAfterDebug: debugConfiguration.removeContainerAfterDebug
             },
             debugLauncherPath: debugConfiguration.debugLauncherPath || launcherPath,
-            debugAdapterHost: debugConfiguration.debugAdapterHost || "host.docker.internal",
+            debugAdapterHost: debugConfiguration.debugAdapterHost || 'localhost',
             console: debugConfiguration.console || "integratedTerminal",
             internalConsoleOptions: debugConfiguration.internalConsoleOptions || "openOnSessionStart",
             module: debugConfiguration.module ||  pythonRunTaskOptions.module,

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -3,14 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fse from 'fs-extra';
-import * as os from 'os';
-import * as vscode from 'vscode';
-import { localize } from '../../localize';
-import { PythonExtensionHelper } from '../../tasks/python/PythonExtensionHelper';
-import { PythonDefaultDebugPort, PythonProjectType } from '../../utils/pythonUtils';
-import ChildProcessProvider from '../coreclr/ChildProcessProvider';
-import CliDockerClient from '../coreclr/CliDockerClient';
+import * as path from 'path';
+import { ext } from '../../extensionVariables';
+import { PythonRunTaskDefinition } from '../../tasks/python/PythonTaskHelper';
+import { PythonProjectType } from '../../utils/pythonUtils';
 import { DebugHelper, DockerDebugContext, DockerDebugScaffoldContext, inferContainerName, ResolvedDebugConfiguration, resolveDockerServerReadyAction } from '../DebugHelper';
 import { DockerDebugConfigurationBase } from '../DockerDebugConfigurationBase';
 import { DockerDebugConfiguration } from '../DockerDebugConfigurationProvider';
@@ -36,10 +32,6 @@ export interface PythonDockerDebugConfiguration extends DockerDebugConfiguration
 }
 
 export class PythonDebugHelper implements DebugHelper {
-    public constructor(
-        private readonly cliDockerClient: CliDockerClient) {
-    }
-
     public async provideDebugConfigurations(context: DockerDebugScaffoldContext, options?: PythonScaffoldingOptions): Promise<DockerDebugConfiguration[]> {
         // Capitalize the first letter.
         const projectType = options.projectType.charAt(0).toUpperCase() + options.projectType.slice(1);
@@ -65,44 +57,12 @@ export class PythonDebugHelper implements DebugHelper {
     public async resolveDebugConfiguration(context: DockerDebugContext, debugConfiguration: PythonDockerDebugConfiguration): Promise<ResolvedDebugConfiguration | undefined> {
         const containerName = inferContainerName(debugConfiguration, context, context.folder.name);
 
-        // Since Python is a special case, we need to ensure the container is removed before attempting to resolve
-        // the debug configuration.
-        try {
-            await this.cliDockerClient.removeContainer(containerName, { force: true });
-        } catch { }
-
-        const debuggerLogFilePath = await PythonExtensionHelper.getDebuggerLogFilePath(context.folder.name);
-        await fse.remove(debuggerLogFilePath);
-
-        let debuggerReadyPromise = Promise.resolve();
-        if (debugConfiguration.preLaunchTask) {
-            // There is this limitation with the Python debugger where we need to ensure it's ready before allowing VSCode to attach,
-            // if attach happens too soon then it will fail silently. The workaround here is to set the preLaunchTask to undefined,
-            // then execute it ourselves with a listener to when it is finished, then wait for the debugger to be ready and return
-            // the resolved launch configuration.
-
-            const task = await this.tryGetPreLaunchTask(debugConfiguration.preLaunchTask);
-
-            if (!task) {
-                throw new Error(localize('vscode-docker.debug.python.noPreLaunch', 'Unable to find the prelaunch task with the name: {0}', debugConfiguration.preLaunchTask));
-            }
-
-            debugConfiguration.preLaunchTask = undefined;
-            context.actionContext.errorHandling.suppressReportIssue = true;
-
-            debuggerReadyPromise = PythonExtensionHelper.ensureDebuggerReady(task, debuggerLogFilePath, containerName, this.cliDockerClient);
-
-            /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
-            vscode.tasks.executeTask(task);
-        }
-
-        return await debuggerReadyPromise.then(() => {
-            return this.resolveDebugConfigurationInternal(debugConfiguration, containerName, context);
-        });
+        return this.resolveDebugConfigurationInternal(debugConfiguration, containerName, context);
     }
 
     private resolveDebugConfigurationInternal(debugConfiguration: PythonDockerDebugConfiguration, containerName: string, context: DockerDebugContext): ResolvedDebugConfiguration {
         const projectType = debugConfiguration.python.projectType;
+        const pythonRunTaskOptions = (context.runDefinition as PythonRunTaskDefinition).python;
 
         const dockerServerReadyAction =
             resolveDockerServerReadyAction(
@@ -114,21 +74,14 @@ export class PythonDebugHelper implements DebugHelper {
                 },
                 true);
 
-        // These properties are required by the old debugger, should be changed to normal properties in the configuration
-        // as soon as the new debugger is released to 100% of the users.
-        const debugOptions = ['FixFilePathCase', 'RedirectOutput', 'ShowReturnValue'];
-
-        if (os.platform() === 'win32') {
-            debugOptions.push('WindowsClient');
-        }
+        const args = [...debugConfiguration.args || pythonRunTaskOptions.args || [], containerName];
+        const launcherPath = path.join(ext.context.asAbsolutePath('resources'), 'python', 'launcher.py');
 
         return {
-            ...debugConfiguration,
+            name: debugConfiguration.name,
+            preLaunchTask: debugConfiguration.preLaunchTask,
             type: 'python',
-            request: 'attach',
-            workspaceFolder: context.folder.uri.fsPath,
-            host: debugConfiguration.python.host || 'localhost',
-            port: debugConfiguration.python.port || PythonDefaultDebugPort,
+            request: 'launch',
             pathMappings: debugConfiguration.python.pathMappings,
             justMyCode: debugConfiguration.python.justMyCode || true,
             django: debugConfiguration.python.django || projectType === 'django',
@@ -138,26 +91,16 @@ export class PythonDebugHelper implements DebugHelper {
                 dockerServerReadyAction: dockerServerReadyAction,
                 removeContainerAfterDebug: debugConfiguration.removeContainerAfterDebug
             },
-            debugOptions: debugOptions
+            debugLauncherPath: debugConfiguration.debugLauncherPath || launcherPath,
+            debugAdapterHost: debugConfiguration.debugAdapterHost || "host.docker.internal",
+            console: debugConfiguration.console || "integratedTerminal",
+            internalConsoleOptions: debugConfiguration.internalConsoleOptions || "openOnSessionStart",
+            module: debugConfiguration.module ||  pythonRunTaskOptions.module,
+            program: debugConfiguration.file || pythonRunTaskOptions.file,
+            redirectOutput: debugConfiguration.redirectOutput || true,
+            args: args,
+            cwd: '.'
         };
-    }
-
-    private async tryGetPreLaunchTask(prelaunchTaskName: string): Promise<vscode.Task> | undefined {
-        if (!prelaunchTaskName) {
-            return undefined;
-        }
-
-        const tasks = await vscode.tasks.fetchTasks();
-
-        if (tasks) {
-            const results = tasks.filter(t => t.name.localeCompare(prelaunchTaskName) === 0);
-
-            if (results.length > 0) {
-                return results[0];
-            }
-        }
-
-        return undefined;
     }
 
     private getServerReadyPattern(projectType: PythonProjectType): string | undefined {
@@ -172,6 +115,4 @@ export class PythonDebugHelper implements DebugHelper {
     }
 }
 
-const dockerClient = new CliDockerClient(new ChildProcessProvider());
-
-export const pythonDebugHelper = new PythonDebugHelper(dockerClient);
+export const pythonDebugHelper = new PythonDebugHelper();

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -56,11 +56,6 @@ export class PythonDebugHelper implements DebugHelper {
 
     public async resolveDebugConfiguration(context: DockerDebugContext, debugConfiguration: PythonDockerDebugConfiguration): Promise<ResolvedDebugConfiguration | undefined> {
         const containerName = inferContainerName(debugConfiguration, context, context.folder.name);
-
-        return this.resolveDebugConfigurationInternal(debugConfiguration, containerName, context);
-    }
-
-    private resolveDebugConfigurationInternal(debugConfiguration: PythonDockerDebugConfiguration, containerName: string, context: DockerDebugContext): ResolvedDebugConfiguration {
         const projectType = debugConfiguration.python.projectType;
         const pythonRunTaskOptions = (context.runDefinition as PythonRunTaskDefinition).python;
 

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -7,6 +7,7 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
+import * as semver from 'semver';
 import * as vscode from "vscode";
 import { localize } from '../../localize';
 
@@ -19,6 +20,8 @@ export namespace PythonExtensionHelper {
 
     export async function getLauncherFolderPath(): Promise<string> {
         const pyExtensionId = 'ms-python.python';
+        const minPyExtensionVersion = new semver.SemVer('2020.5.78807');
+
         const pyExt = vscode.extensions.getExtension(pyExtensionId);
         const button = localize('vscode-docker.tasks.pythonExt.openExtension', 'Open Extension');
 
@@ -29,6 +32,13 @@ export namespace PythonExtensionHelper {
                 await vscode.commands.executeCommand('extension.open', pyExtensionId);
             }
 
+            return undefined;
+        }
+
+        const version = new semver.SemVer(pyExt.packageJSON.version);
+
+        if (version.compare(minPyExtensionVersion) == -1) {
+            await vscode.window.showErrorMessage(localize('vscode-docker.tasks.pythonExt.pythonExtensionNotSupported', 'The installed Python extension does not meet the minimum requirements, please update to the latest version and try again.'));
             return undefined;
         }
 

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -37,7 +37,7 @@ export namespace PythonExtensionHelper {
 
         const version = new semver.SemVer(pyExt.packageJSON.version);
 
-        if (version.compare(minPyExtensionVersion) == -1) {
+        if (version.compare(minPyExtensionVersion) < 0) {
             await vscode.window.showErrorMessage(localize('vscode-docker.tasks.pythonExt.pythonExtensionNotSupported', 'The installed Python extension does not meet the minimum requirements, please update to the latest version and try again.'));
             return undefined;
         }

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -8,109 +8,13 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from "vscode";
-import CliDockerClient from '../../debugging/coreclr/CliDockerClient';
 import { localize } from '../../localize';
-import { delay } from '../../utils/promiseUtils';
-import { getTempDirectoryPath, PythonDefaultDebugPort, PythonTarget } from '../../utils/pythonUtils';
-import { dockerTaskEndEventListener, DockerTaskEvent } from '../DockerTaskEndEventListener';
 
 export namespace PythonExtensionHelper {
     export interface DebugLaunchOptions {
         host?: string;
         port?: number;
         wait?: boolean;
-    }
-
-    export function getDebuggerEnvironmentVars(): { [key: string]: string } {
-        return { 'PTVSD_LOG_DIR': '/dbglogs' };
-    }
-
-    export async function getDebuggerLogFilePath(folderName: string): Promise<string> {
-        // The debugger generates the log file with the name in this format: ptvsd-{pid}.log,
-        // So given that we run the debugger as the entry point, then the PID is guaranteed to be 1.
-        const tempDir = await getTempDirectoryPath();
-        return path.join(tempDir, folderName, 'ptvsd-1.log');
-    }
-
-    export async function ensureDebuggerReady(prelaunchTask: vscode.Task, debuggerSemaphorePath: string, containerName: string, cliDockerClient: CliDockerClient): Promise<void> {
-        // tslint:disable-next-line:promise-must-complete
-        return new Promise((resolve, reject) => {
-            const dockerTaskListener = dockerTaskEndEventListener.event((taskEvent: DockerTaskEvent) => {
-                if (!taskEvent.success) {
-                    cleanupListeners();
-                    reject(localize('vscode-docker.tasks.pythonExt.failedToAttach', 'Failed to attach the debugger, please see the terminal output for more details.'));
-                }
-            });
-
-            const listener = vscode.tasks.onDidEndTask(async e => {
-                if (e.execution.task.name === prelaunchTask.name) {
-                    try {
-                        // There is no way to know the result of the completed task, so a best guess is to check if the container is running.
-                        const containerRunning = await cliDockerClient.inspectObject(containerName, { format: '{{.State.Running}}' });
-
-                        if (containerRunning === 'false') {
-                            reject(localize('vscode-docker.tasks.pythonExt.failedToAttach', 'Failed to attach the debugger, please see the terminal output for more details.'));
-                        }
-
-                        const maxRetriesCount = 20;
-                        let retries = 0;
-                        let created = false;
-
-                        // Look for the magic string below in the log file with a retry every 0.5 second for a maximum of 10 seconds.
-                        // TODO: Should be gone as soon as the retry logic is part of the Python debugger/extension.
-                        while (++retries < maxRetriesCount && !created) {
-                            if (await fse.pathExists(debuggerSemaphorePath)) {
-                                const contents = await fse.readFile(debuggerSemaphorePath);
-
-                                created = contents.toString().indexOf('Starting server daemon on') >= 0;
-                                if (created) {
-                                    break;
-                                }
-                            }
-
-                            await delay(500);
-                        }
-
-                        if (created) {
-                            resolve();
-                        } else {
-                            reject(localize('vscode-docker.tasks.pythonExt.attachTimeout', 'Failed to attach the debugger within the alotted timeout.'));
-                        }
-                    } catch {
-                        reject(localize('vscode-docker.tasks.pythonExt.unexpectedAttachError', 'An unexpected error occurred while attempting to attach the debugger.'));
-                    } finally {
-                        cleanupListeners();
-                    }
-                }
-            });
-
-            const cleanupListeners = () => {
-                /* eslint-disable no-unused-expressions */
-                listener?.dispose();
-                dockerTaskListener?.dispose();
-                /* eslint-enable no-unused-expressions */
-            };
-        });
-    }
-
-    export function getRemotePtvsdCommand(target: PythonTarget, args?: string[], options?: DebugLaunchOptions): string {
-        let fullTarget: string;
-
-        if ('file' in target) {
-            fullTarget = target.file;
-        } else if ('module' in target) {
-            fullTarget = `-m ${target.module}`;
-        } else {
-            throw new Error(localize('vscode-docker.tasks.pythonExt.moduleOrFile', 'One of either module or file must be provided.'));
-        }
-
-        options = options ?? {};
-        options.host = options.host || '0.0.0.0';
-        options.port = options.port || PythonDefaultDebugPort;
-        options.wait = !!options.wait;
-        args = args ?? [];
-
-        return `/pydbg/ptvsd --host ${options.host} --port ${options.port} ${options.wait ? '--wait' : ''} ${fullTarget} ${args.join(' ')}`;
     }
 
     export async function getLauncherFolderPath(): Promise<string> {
@@ -128,18 +32,12 @@ export namespace PythonExtensionHelper {
             return undefined;
         }
 
-        const debuggerPath = path.join(pyExt.extensionPath, 'pythonFiles', 'lib', 'python');
-        const oldDebugger = path.join(debuggerPath, 'old_ptvsd');
-        const newDebugger = path.join(debuggerPath, 'new_ptvsd');
+        await pyExt.activate();
 
-        // Always favor the old_ptvsd debugger since it will work in all cases.
-        // If it is not found, then look for the new instead.
-        // TODO: This should be revisited when the Python extension releases the new debugger since it might have a different name.
+        const debuggerPath = path.join(pyExt.extensionPath, 'pythonFiles', 'lib', 'python', 'debugpy', 'no_wheels');
 
-        if ((await fse.pathExists(oldDebugger))) {
-            return oldDebugger;
-        } else if ((await fse.pathExists(newDebugger))) {
-            return newDebugger;
+        if ((await fse.pathExists(debuggerPath))) {
+            return debuggerPath;
         }
 
         throw new Error(localize('vscode-docker.tasks.pythonExt.noDebugger', 'Unable to find the debugger in the Python extension.'));

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -103,7 +103,7 @@ export class PythonTaskHelper implements TaskHelper {
 
         // User input is honored in all of the below.
         runOptions.volumes = this.inferVolumes(runOptions, launcherFolder);
-        runOptions.entrypoint = runOptions.entrypoint || 'bash';
+        runOptions.entrypoint = runOptions.entrypoint || 'python';
         runOptions.portsPublishAll = runOptions.portsPublishAll || true;
 
         return runOptions;

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -3,7 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as os from 'os';
+import { DockerContainerExtraHost } from '../../debugging/coreclr/CliDockerClient';
 import { PythonScaffoldingOptions } from '../../debugging/DockerDebugScaffoldingProvider';
+import LocalOSProvider from '../../utils/LocalOSProvider';
 import { inferPythonArgs } from '../../utils/pythonUtils';
 import { unresolveWorkspaceFolder } from "../../utils/resolveVariables";
 import { DockerBuildOptions } from "../DockerBuildTaskDefinitionBase";
@@ -105,6 +108,7 @@ export class PythonTaskHelper implements TaskHelper {
         runOptions.volumes = this.inferVolumes(runOptions, launcherFolder);
         runOptions.entrypoint = runOptions.entrypoint || 'python';
         runOptions.portsPublishAll = runOptions.portsPublishAll || true;
+        runOptions.extraHosts = this.addInternalHostForLinuxHosts(runOptions.extraHosts);
 
         return runOptions;
     }
@@ -125,6 +129,28 @@ export class PythonTaskHelper implements TaskHelper {
         dbgVolumes.map(dbgVol => { addVolumeWithoutConflicts(volumes, dbgVol) });
 
         return volumes;
+    }
+
+    private addInternalHostForLinuxHosts(extraHosts: DockerContainerExtraHost[]) : DockerContainerExtraHost[] {
+        const osProvider = new LocalOSProvider();
+
+        if (osProvider.os != 'Linux') return [];
+
+        const hosts = extraHosts ? [...extraHosts] : [];
+        if (!hosts.find(h => h.hostname == 'host.docker.internal')) {
+            const interfaces = os.networkInterfaces() || [];
+            const dockerBridgeIp = 'docker0' in interfaces &&
+                                   interfaces['docker0'].length > 0 ? interfaces['docker0'][0].address : undefined;
+
+            if (dockerBridgeIp) {
+                hosts.push({
+                    hostname: 'host.docker.internal',
+                    ip: dockerBridgeIp
+                });
+            }
+        }
+
+        return hosts;
     }
 }
 

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -115,14 +115,13 @@ export class PythonTaskHelper implements TaskHelper {
         }
 
         const volumes = runOptions?.volumes ? [...runOptions.volumes] : [];
-        const dbgVolumes: DockerContainerVolume[] = [
-            {
+        const dbgVolume: DockerContainerVolume = {
                 localPath: launcherFolder,
                 containerPath: '/pydbg',
                 permissions: 'ro'
-            }];
+        };
 
-        dbgVolumes.map(dbgVol => { addVolumeWithoutConflicts(volumes, dbgVol) });
+        addVolumeWithoutConflicts(volumes, dbgVolume);
 
         return volumes;
     }

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -3,14 +3,12 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fse from 'fs-extra';
-import * as path from 'path';
 import { PythonScaffoldingOptions } from '../../debugging/DockerDebugScaffoldingProvider';
-import { getTempDirectoryPath, inferPythonArgs, PythonDefaultDebugPort, PythonTarget } from '../../utils/pythonUtils';
+import { inferPythonArgs } from '../../utils/pythonUtils';
 import { unresolveWorkspaceFolder } from "../../utils/resolveVariables";
 import { DockerBuildOptions } from "../DockerBuildTaskDefinitionBase";
 import { DockerBuildTaskDefinition } from "../DockerBuildTaskProvider";
-import { DockerContainerPort, DockerContainerVolume, DockerRunOptions, DockerRunTaskDefinitionBase } from "../DockerRunTaskDefinitionBase";
+import { DockerContainerVolume, DockerRunOptions, DockerRunTaskDefinitionBase } from "../DockerRunTaskDefinitionBase";
 import { DockerRunTaskDefinition } from "../DockerRunTaskProvider";
 import { addVolumeWithoutConflicts, DockerBuildTaskContext, DockerRunTaskContext, DockerTaskScaffoldContext, getDefaultContainerName, getDefaultImageName, inferImageName, TaskHelper } from "../TaskHelper";
 import { PythonExtensionHelper } from "./PythonExtensionHelper";
@@ -92,23 +90,7 @@ export class PythonTaskHelper implements TaskHelper {
 
     public async getDockerRunOptions(context: DockerRunTaskContext, runDefinition: DockerRunTaskDefinition): Promise<DockerRunOptions> {
         // tslint:disable no-unsafe-any
-        const helperOptions: PythonTaskRunOptions = runDefinition.python || {};
         const runOptions: DockerRunOptions = runDefinition.dockerRun;
-
-        const target: PythonTarget = helperOptions.file
-            ? { file: helperOptions.file, }
-            : { module: helperOptions.module };
-
-        const launcherCommand: string = PythonExtensionHelper.getRemotePtvsdCommand(
-            target,
-            helperOptions.args,
-            {
-                host: '0.0.0.0',
-                port: helperOptions.debugPort || PythonDefaultDebugPort,
-                wait: helperOptions.wait === undefined ? true : helperOptions.wait
-            }
-        );
-
         const launcherFolder: string = await PythonExtensionHelper.getLauncherFolderPath();
 
         runOptions.image = inferImageName(
@@ -119,28 +101,16 @@ export class PythonTaskHelper implements TaskHelper {
 
         runOptions.containerName = runOptions.containerName || getDefaultContainerName(context.folder.name);
 
-        const tempDir = await getTempDirectoryPath();
-        const dbgLogsFolder = path.join(tempDir, context.folder.name);
-
-        // The debugger will complain if the logs directory does not exist.
-        if (!(await fse.pathExists(dbgLogsFolder))) {
-            await fse.emptyDir(dbgLogsFolder);
-        }
-
         // User input is honored in all of the below.
-        runOptions.volumes = this.inferVolumes(runOptions, launcherFolder, dbgLogsFolder);
-        runOptions.ports = this.inferPorts(runOptions, helperOptions);
-        runOptions.entrypoint = runOptions.entrypoint || 'python';
-        runOptions.command = runOptions.command || launcherCommand;
-
-        runOptions.env = this.addDebuggerEnvironmentVars(runOptions.env);
+        runOptions.volumes = this.inferVolumes(runOptions, launcherFolder);
+        runOptions.entrypoint = runOptions.entrypoint || 'bash';
         runOptions.portsPublishAll = runOptions.portsPublishAll || true;
 
         return runOptions;
     }
 
-    private inferVolumes(runOptions: DockerRunOptions, launcherFolder: string, dbgLogsFolder: string): DockerContainerVolume[] {
-        if (!launcherFolder || !dbgLogsFolder) {
+    private inferVolumes(runOptions: DockerRunOptions, launcherFolder: string): DockerContainerVolume[] {
+        if (!launcherFolder) {
             return;
         }
 
@@ -150,41 +120,11 @@ export class PythonTaskHelper implements TaskHelper {
                 localPath: launcherFolder,
                 containerPath: '/pydbg',
                 permissions: 'ro'
-            },
-            {
-                localPath: dbgLogsFolder,
-                containerPath: '/dbglogs',
-                permissions: 'rw'
             }];
 
         dbgVolumes.map(dbgVol => { addVolumeWithoutConflicts(volumes, dbgVol) });
 
         return volumes;
-    }
-
-    private inferPorts(runOptions: DockerRunOptions, pythonOptions: PythonTaskRunOptions): DockerContainerPort[] {
-        const ports: DockerContainerPort[] = runOptions?.ports ? [...runOptions.ports] : [];
-        const debugPort = pythonOptions.debugPort || PythonDefaultDebugPort;
-
-        if (ports.find(port => port.containerPort === debugPort) === undefined) {
-            ports.push({
-                containerPort: debugPort,
-                hostPort: debugPort
-            });
-        }
-
-        return ports;
-    }
-
-    private addDebuggerEnvironmentVars(env: { [key: string]: string }): { [key: string]: string } {
-        env = env ?? {};
-        const debuggerVars = PythonExtensionHelper.getDebuggerEnvironmentVars();
-
-        Object.keys(debuggerVars).map(varName => {
-            env[varName] = debuggerVars[varName];
-        });
-
-        return env;
     }
 }
 


### PR DESCRIPTION
Here is how the flow of the launch request works:
_(host) [VSCode] -> (host) [Debug Adapter] -> (host) [Custom launcher] -> (container) [Debugpy launcher] -> (container) [debugpy]_

We added our own custom launcher which doesn't do much but pass the call to the real launcher in the container using a `docker exec` command.

When debugpy gets the request, it connects back to VSCode on the specified host:port. For Windows/Mac, we use `host.docker.internal:{randomPort}`, however this doesn't work for Linux. So we use the ip address from Docker's predefined network "bridge" and it works in all of the cases I tried (we might need to check with Docker so that we're not basing off wrong assumptions).

The rest of the changes get rid of the attach logic we have.