### PR TITLE
allow to specify the running user to make sure we can write to debug logs dir

### DIFF
--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -85,6 +85,7 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
             .withFlagArg('-P', runOptions.portsPublishAll || (runOptions.portsPublishAll === undefined && (runOptions.ports === undefined || runOptions.ports.length < 1)))
             .withNamedArg('--name', runOptions.containerName)
             .withNamedArg('--network', runOptions.network)
+            .withNamedArg('--user', runOptions.user)
             .withNamedArg('--network-alias', runOptions.networkAlias)
             .withKeyValueArgs('-e', runOptions.env)
             .withArrayArgs('--env-file', runOptions.envFiles)


### PR DESCRIPTION
This PR is rather cargo cult, but i want to suggest a solution to the issue I am hereby reporting. Typically, dockerized python code is run by vscode like so:

```sh
docker run -dt -P --name "...-dev" -e "PTVSD_LOG_DIR=/dbglogs" --label "com.microsoft.created-by=visual-studio-code" -v "/home/.../.vscode-server/extensions/ms-python.python-2020.5.80290/pythonFiles/lib/python/old_ptvsd:/pydbg:ro" -v "/tmp/...:/dbglogs:rw" -p "5678:5678" --entrypoint "python" "image:latest" /pydbg/ptvsd --host 0.0.0.0 --port 5678 --wait .../manage.py test --noinput
```

The important part is binding the debugger's log dir with `-v "/tmp/...:/dbglogs:rw"` without knowing which user is actually running stuff inside the container. In our use case we are creating the user in our `Dockerfile` like so: `RUN useradd -g 9000 --uid 9000 --create-home servant`. But my docker host user has `UID` 1000.

so what I get in the container run by vscode is

```python
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/pydbg/ptvsd/__main__.py", line 446, in <module>
    main(sys.argv)
  File "/pydbg/ptvsd/__main__.py", line 421, in main
    ptvsd.log.to_file()
  File "/pydbg/ptvsd/log.py", line 124, in to_file
    file = io.open(filename, 'w', encoding='utf-8')
PermissionError: [Errno 13] Permission denied: '/dbglogs/ptvsd-1.log'
```

If I were able to specify the user to run the container, i.e. `1000:1000`, the python process would be allowed to write into `/dbglogs/ptvsd-1.log` inside the container.