### PR TITLE
Refresh before running tree item picker

### DIFF
--- a/src/commands/containers/attachShellContainer.ts
+++ b/src/commands/containers/attachShellContainer.ts
@@ -13,6 +13,7 @@ import { selectAttachCommand } from '../selectCommandTemplate';
 
 export async function attachShellContainer(context: IActionContext, node?: ContainerTreeItem): Promise<void> {
     if (!node) {
+        await ext.containersTree.refresh();
         node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.runningContainerRegExp, {
             ...context,
             noItemFoundErrorMessage: localize('vscode-docker.commands.containers.attachShellContainer.noContainers', 'No running containers are available to attach')

--- a/src/commands/containers/browseContainer.ts
+++ b/src/commands/containers/browseContainer.ts
@@ -59,6 +59,7 @@ export async function browseContainer(context: IActionContext, node?: ContainerT
     const telemetryProperties = <BrowseTelemetryProperties>context.telemetry.properties;
 
     if (!node) {
+        await ext.containersTree.refresh();
         node = await captureBrowseCancelStep('node', telemetryProperties, async () =>
             ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.runningContainerRegExp, {
                 ...context,

--- a/src/commands/containers/inspectContainer.ts
+++ b/src/commands/containers/inspectContainer.ts
@@ -12,6 +12,7 @@ import { callDockerodeWithErrorHandling } from "../../utils/callDockerode";
 
 export async function inspectContainer(context: IActionContext, node?: ContainerTreeItem): Promise<void> {
     if (!node) {
+        await ext.containersTree.refresh();
         node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.allContextRegExp, {
             ...context,
             noItemFoundErrorMessage: localize('vscode-docker.commands.containers.inspect.noContainers', 'No containers are available to inspect')

--- a/src/commands/containers/viewContainerLogs.ts
+++ b/src/commands/containers/viewContainerLogs.ts
@@ -11,6 +11,7 @@ import { selectLogsCommand } from '../selectCommandTemplate';
 
 export async function viewContainerLogs(context: IActionContext, node?: ContainerTreeItem): Promise<void> {
     if (!node) {
+        await ext.containersTree.refresh();
         node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.allContextRegExp, {
             ...context,
             noItemFoundErrorMessage: localize('vscode-docker.commands.containers.viewLogs.noContainers', 'No containers are available to view logs')

--- a/src/commands/images/copyFullTag.ts
+++ b/src/commands/images/copyFullTag.ts
@@ -11,6 +11,7 @@ import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 
 export async function copyFullTag(context: IActionContext, node: ImageTreeItem | undefined): Promise<string> {
     if (!node) {
+        await ext.imagesTree.refresh();
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
             noItemFoundErrorMessage: localize('vscode-docker.commands.images.copyFullTag.noImages', 'No images are available to copy tag')

--- a/src/commands/images/inspectImage.ts
+++ b/src/commands/images/inspectImage.ts
@@ -12,6 +12,7 @@ import { callDockerodeWithErrorHandling } from "../../utils/callDockerode";
 
 export async function inspectImage(context: IActionContext, node?: ImageTreeItem): Promise<void> {
     if (!node) {
+        await ext.imagesTree.refresh();
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
             noItemFoundErrorMessage: localize('vscode-docker.commands.images.inspect.noImages', 'No images are available to inspect')

--- a/src/commands/images/pushImage.ts
+++ b/src/commands/images/pushImage.ts
@@ -14,6 +14,7 @@ import { addImageTaggingTelemetry, tagImage } from './tagImage';
 
 export async function pushImage(context: IActionContext, node: ImageTreeItem | undefined): Promise<void> {
     if (!node) {
+        await ext.imagesTree.refresh();
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
             noItemFoundErrorMessage: localize('vscode-docker.commands.images.push.noImages', 'No images are available to push'),

--- a/src/commands/images/runImage.ts
+++ b/src/commands/images/runImage.ts
@@ -20,6 +20,7 @@ export async function runImageInteractive(context: IActionContext, node?: ImageT
 
 async function runImageCore(context: IActionContext, node: ImageTreeItem | undefined, interactive: boolean): Promise<void> {
     if (!node) {
+        await ext.imagesTree.refresh();
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
             noItemFoundErrorMessage: localize('vscode-docker.commands.images.run.noImages', 'No images are available to run')

--- a/src/commands/images/tagImage.ts
+++ b/src/commands/images/tagImage.ts
@@ -15,6 +15,7 @@ import { extractRegExGroups } from '../../utils/extractRegExGroups';
 
 export async function tagImage(context: IActionContext, node?: ImageTreeItem, registry?: RegistryTreeItemBase): Promise<string> {
     if (!node) {
+        await ext.imagesTree.refresh();
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
             noItemFoundErrorMessage: localize('vscode-docker.commands.images.tag.noImages', 'No images are available to tag')

--- a/src/commands/networks/inspectNetwork.ts
+++ b/src/commands/networks/inspectNetwork.ts
@@ -12,6 +12,7 @@ import { callDockerodeWithErrorHandling } from "../../utils/callDockerode";
 
 export async function inspectNetwork(context: IActionContext, node?: NetworkTreeItem): Promise<void> {
     if (!node) {
+        await ext.networksTree.refresh();
         node = await ext.networksTree.showTreeItemPicker<NetworkTreeItem>(NetworkTreeItem.allContextRegExp, {
             ...context,
             noItemFoundErrorMessage: localize('vscode-docker.commands.networks.inspect.noNetworks', 'No networks are available to inspect')

--- a/src/commands/volumes/inspectVolume.ts
+++ b/src/commands/volumes/inspectVolume.ts
@@ -12,6 +12,7 @@ import { callDockerodeWithErrorHandling } from "../../utils/callDockerode";
 
 export async function inspectVolume(context: IActionContext, node?: VolumeTreeItem): Promise<void> {
     if (!node) {
+        await ext.volumesTree.refresh();
         node = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, { ...context, noItemFoundErrorMessage: localize('vscode-docker.commands.volumes.inspect.noVolumes', 'No volumes are available to inspect') });
     }
 

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -347,6 +347,7 @@ export class NetCoreDebugHelper implements DebugHelper {
     }
 
     private async getContainerNameToAttach(context: IActionContext): Promise<string> {
+        await ext.containersTree.refresh();
         const containerItem: ContainerTreeItem = await ext.containersTree.showTreeItemPicker(ContainerTreeItem.runningContainerRegExp, {
             ...context,
             noItemFoundErrorMessage: localize('vscode-docker.debug.netcore.noContainers', 'No running containers are available to attach.')

--- a/src/utils/multiSelectNodes.ts
+++ b/src/utils/multiSelectNodes.ts
@@ -31,6 +31,7 @@ export async function multiSelectNodes<T extends AzExtTreeItem>(
 
     if (nodes.length === 0) {
         // If still no selected nodes, need to prompt
+        await tree.refresh();
         nodes = await tree.showTreeItemPicker<T>(expectedContextValue, { ...context, canPickMany: true });
     } else if (expectedContextValue) {
         // Otherwise if there's a filter, need to filter our selection to exclude ineligible nodes


### PR DESCRIPTION
Fixes #2029

This intentionally does _not_ do the same thing for registries and contexts, as those should not be nearly as volatile as containers especially, and to a lesser extend images, networks, volumes.