### PR TITLE
[Python] Fix an issue with args escaping in the custom launcher

### DIFF
--- a/resources/python/launcher.py
+++ b/resources/python/launcher.py
@@ -16,5 +16,7 @@ if adapterHost.isnumeric():
 
 dockerExecArgs = ['docker', 'exec', '-d', containerId, 'python', '/pydbg/debugpy/launcher'] + args
 
-print(' '.join(dockerExecArgs))
-os.execvp('docker', dockerExecArgs)
+command = ' '.join(dockerExecArgs)
+
+print(command)
+os.system(command)

--- a/src/utils/pythonUtils.ts
+++ b/src/utils/pythonUtils.ts
@@ -39,8 +39,8 @@ export function inferPythonArgs(projectType: PythonProjectType, ports: number[])
                 'run',
                 '--no-debugger',
                 '--no-reload',
-                '--host 0.0.0.0',
-                `--port ${ports !== undefined ? ports[0] : PythonDefaultPorts.get(projectType)}`,
+                '--host', '0.0.0.0',
+                '--port', `${ports !== undefined ? ports[0] : PythonDefaultPorts.get(projectType)}`,
             ]
         default:
             return undefined;


### PR DESCRIPTION
The issue here is that since we pass in the args (i.e. --host 0.0.0.0 --port 5000) as a list in order to ensure proper escaping, then each arg/value has to be its own entry in the args list. For example, it should look like this:
```
"args": [
"run",
"--no-debugger",
"--no-reload",
"--host", "0.0.0.0",
"--port", "5000"
]
```

Instead of this:
```
"args": [
"run",
"--no-debugger",
"--no-reload",
"--host 0.0.0.0",
"--port 5000"
]
```

This PR changes the scaffolding to make sure it's in the proper format, and also falls back to concatenating the args into a single string and pass that command for Python to execute. This compromises the escaping (**note**: it is already not handled in the released version, so this is not a regression), however it ensures we do not break existing projects on Linux and Mac, so it appears to be a good compromise.

We should make sure to capture that in the docs so as to motivate users to change their existing projects into the proper format, and at some point in the future we can move back to honoring the escaping with the potential to break fewer projects.

If the user is blocked by an escaping issue, they can always create their own custom launcher, so there exists a valid workaround.