### PR TITLE
Cherry-pick debugpy path API

### DIFF
--- a/resources/python/launcher.py
+++ b/resources/python/launcher.py
@@ -14,7 +14,7 @@ adapterHost = args[0]
 if adapterHost.isnumeric():
     args[0] = 'host.docker.internal:' + adapterHost
 
-dockerExecArgs = ['docker', 'exec', '-d', containerId, 'python', '/pydbg/debugpy/launcher'] + args
+dockerExecArgs = ['docker', 'exec', '-d', containerId, 'python', '/debugpy/launcher'] + args
 
 command = ' '.join(dockerExecArgs)
 

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -5,6 +5,7 @@
 
 import * as path from 'path';
 import { ext } from '../../extensionVariables';
+import { PythonExtensionHelper } from '../../tasks/python/PythonExtensionHelper';
 import { PythonRunTaskDefinition } from '../../tasks/python/PythonTaskHelper';
 import LocalOSProvider from '../../utils/LocalOSProvider';
 import { PythonProjectType } from '../../utils/pythonUtils';
@@ -59,6 +60,11 @@ export class PythonDebugHelper implements DebugHelper {
     }
 
     public async resolveDebugConfiguration(context: DockerDebugContext, debugConfiguration: PythonDockerDebugConfiguration): Promise<ResolvedDebugConfiguration | undefined> {
+        const pyExt = await PythonExtensionHelper.getPythonExtension();
+        if (!pyExt) {
+            return undefined;
+        }
+
         const containerName = inferContainerName(debugConfiguration, context, context.folder.name);
         const projectType = debugConfiguration.python.projectType;
         const pythonRunTaskOptions = (context.runDefinition as PythonRunTaskDefinition).python;

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -5,11 +5,16 @@
 
 // This will eventually be replaced by an API in the Python extension. See https://github.com/microsoft/vscode-python/issues/7282
 
-import * as fse from 'fs-extra';
-import * as path from 'path';
 import * as semver from 'semver';
 import * as vscode from "vscode";
 import { localize } from '../../localize';
+
+// Adapted from https://github.com/microsoft/vscode-python/blob/master/src/client/api.ts
+interface PythonExtensionAPI {
+    debug: {
+        getDebuggerPackagePath(): Promise<string | undefined>;
+    }
+}
 
 export namespace PythonExtensionHelper {
     export interface DebugLaunchOptions {
@@ -19,6 +24,17 @@ export namespace PythonExtensionHelper {
     }
 
     export async function getLauncherFolderPath(): Promise<string> {
+        const pyExt = await getPythonExtension();
+        const debuggerPath = await pyExt?.exports?.debug?.getDebuggerPackagePath();
+
+        if (debuggerPath) {
+            return debuggerPath;
+        }
+
+        throw new Error(localize('vscode-docker.tasks.pythonExt.noDebugger', 'Unable to find the debugger in the Python extension.'));
+    }
+
+    export async function getPythonExtension(): Promise<vscode.Extension<PythonExtensionAPI>> | undefined {
         const pyExtensionId = 'ms-python.python';
         const minPyExtensionVersion = new semver.SemVer('2020.5.78807');
 
@@ -43,14 +59,10 @@ export namespace PythonExtensionHelper {
             return undefined;
         }
 
-        await pyExt.activate();
-
-        const debuggerPath = path.join(pyExt.extensionPath, 'pythonFiles', 'lib', 'python', 'debugpy', 'no_wheels');
-
-        if ((await fse.pathExists(debuggerPath))) {
-            return debuggerPath;
+        if (!pyExt.isActive) {
+            await pyExt.activate();
         }
 
-        throw new Error(localize('vscode-docker.tasks.pythonExt.noDebugger', 'Unable to find the debugger in the Python extension.'));
+        return pyExt;
     }
 }

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -35,7 +35,7 @@ export class PythonTaskHelper implements TaskHelper {
                 dockerBuild: {
                     tag: getDefaultImageName(context.folder.name),
                     dockerfile: unresolveWorkspaceFolder(context.dockerfile, context.folder),
-                    /* eslint-disable no-template-curly-in-string */
+                    // eslint-disable-next-line no-template-curly-in-string
                     context: '${workspaceFolder}',
                     pull: true
                 },
@@ -83,13 +83,14 @@ export class PythonTaskHelper implements TaskHelper {
         /* eslint-disable no-template-curly-in-string */
         buildOptions.context = buildOptions.context || '${workspaceFolder}';
         buildOptions.dockerfile = buildOptions.dockerfile || '${workspaceFolder}/Dockerfile';
+        /* eslint-enable no-template-curly-in-string */
+
         buildOptions.tag = buildOptions.tag || getDefaultImageName(context.folder.name);
 
         return buildOptions;
     }
 
     public async getDockerRunOptions(context: DockerRunTaskContext, runDefinition: DockerRunTaskDefinition): Promise<DockerRunOptions> {
-        // tslint:disable no-unsafe-any
         const runOptions: DockerRunOptions = runDefinition.dockerRun;
         const launcherFolder: string = await PythonExtensionHelper.getLauncherFolderPath();
 
@@ -117,7 +118,7 @@ export class PythonTaskHelper implements TaskHelper {
         const volumes = runOptions?.volumes ? [...runOptions.volumes] : [];
         const dbgVolume: DockerContainerVolume = {
             localPath: launcherFolder,
-            containerPath: '/pydbg',
+            containerPath: '/debugpy',
             permissions: 'ro'
         };
 


### PR DESCRIPTION
There is a recent breaking change since the location of "debugpy" changed in the Python extension. So the resolution is to use an API provided by the Python Extension to resolve the location of the debugger to be used.