### PR TITLE
[Python] Handle the case where the debug configuration is undefined

### DIFF
--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -67,7 +67,7 @@ export class PythonDebugHelper implements DebugHelper {
 
         const containerName = inferContainerName(debugConfiguration, context, context.folder.name);
         const projectType = debugConfiguration.python.projectType;
-        const pythonRunTaskOptions = (context.runDefinition as PythonRunTaskDefinition).python;
+        const pythonRunTaskOptions = (context.runDefinition as PythonRunTaskDefinition)?.python || {};
 
         const dockerServerReadyAction =
             resolveDockerServerReadyAction(


### PR DESCRIPTION
Handle the case where the debug configuration is undefined and let VS Code show its default error message:
![image](https://user-images.githubusercontent.com/5480153/85341986-5dd08300-b49e-11ea-8308-81ef88f94b11.png)
