### PR TITLE
Better UX on context removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -541,17 +541,17 @@
                 },
                 {
                     "command": "vscode-docker.contexts.inspect",
-                    "when": "view == vscode-docker.views.dockerContexts && viewItem == context",
+                    "when": "view == vscode-docker.views.dockerContexts && viewItem =~ /Context$/i",
                     "group": "contexts_1_general@1"
                 },
                 {
                     "command": "vscode-docker.contexts.use",
-                    "when": "view == vscode-docker.views.dockerContexts && viewItem == context",
+                    "when": "view == vscode-docker.views.dockerContexts && viewItem =~ /Context$/i",
                     "group": "contexts_1_general@2"
                 },
                 {
                     "command": "vscode-docker.contexts.remove",
-                    "when": "view == vscode-docker.views.dockerContexts && viewItem == context",
+                    "when": "view == vscode-docker.views.dockerContexts && viewItem =~ /^customContext$/i",
                     "group": "contexts_2_destructive@1"
                 }
             ]

--- a/src/commands/context/inspectDockerContext.ts
+++ b/src/commands/context/inspectDockerContext.ts
@@ -10,7 +10,7 @@ import { ContextTreeItem } from '../../tree/contexts/ContextTreeItem';
 
 export async function inspectDockerContext(actionContext: IActionContext, node?: ContextTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.contextsTree.showTreeItemPicker<ContextTreeItem>(ContextTreeItem.contextValue, {
+        node = await ext.contextsTree.showTreeItemPicker<ContextTreeItem>(ContextTreeItem.allContextRegExp, {
             ...actionContext,
             noItemFoundErrorMessage: localize('vscode-docker.commands.contexts.inspect.noContexts', 'No Docker contexts are available to inspect')
         });

--- a/src/commands/context/removeDockerContext.ts
+++ b/src/commands/context/removeDockerContext.ts
@@ -8,39 +8,22 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { ContextTreeItem } from '../../tree/contexts/ContextTreeItem';
-import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
-export async function removeDockerContext(actionContext: IActionContext, node?: ContextTreeItem, nodes?: ContextTreeItem[]): Promise<void> {
-    nodes = await multiSelectNodes(
-        { ...actionContext, suppressCreatePick: true, noItemFoundErrorMessage: localize('vscode-docker.commands.contexts.remove.noContexts', 'No Docker contexts are available to remove') },
-        ext.contextsTree,
-        ContextTreeItem.contextValue,
-        node,
-        nodes
-    );
-
-    if (nodes.length === 1 && nodes[0].current) {
-        actionContext.errorHandling.suppressReportIssue = true;
-        throw new Error(localize('vscode-docker.commands.context.remove.cannotRemoveContextInUse', 'Docker context \'{0}\' is currently in use and cannot be removed', nodes[0].name));
+export async function removeDockerContext(actionContext: IActionContext, node?: ContextTreeItem): Promise<void> {
+    if (!node) {
+        node = await ext.contextsTree.showTreeItemPicker<ContextTreeItem>(ContextTreeItem.removableContextRegExp, {
+            ...actionContext,
+            noItemFoundErrorMessage: localize('vscode-docker.commands.contexts.remove.noContexts', 'No Docker contexts are available to remove')
+        });
     }
 
-    let removeConfirmationMessage: string;
-    if (nodes.length === 1) {
-        removeConfirmationMessage = localize('vscode-docker.commands.context.remove.confirmSingle', 'Are you sure you want to remove Docker context \'{0}\'?', nodes[0].name);
-    } else {
-        const nonCurrentNodes = nodes.filter(n => !n.current)
-        if (nodes.length === nonCurrentNodes.length) {
-            removeConfirmationMessage = localize('vscode-docker.commands.context.remove.confirmMultiple', 'Are you sure you want to remove selected Docker contexts?');
-        } else {
-            removeConfirmationMessage = localize('vscode-docker.commands.context.remove.confirmSingleFiltered', 'One of the selected Docker contexts is being used, and cannot be removed. Do you want to remove the remaining contexts?');
-        }
-    }
+    const removeConfirmationMessage = localize('vscode-docker.commands.context.remove.confirmSingle', 'Are you sure you want to remove Docker context \'{0}\'?', node.name);
 
     // no need to check result - cancel will throw a UserCancelledError
     await ext.ui.showWarningMessage(removeConfirmationMessage, { modal: true }, { title: localize('vscode-docker.commands.context.remove', 'Remove') });
 
     const removingMessage: string = localize('vscode-docker.commands.context.remove.removing', 'Removing Docker context(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removingMessage }, async () => {
-        await Promise.all(nodes.map(async n => await n.deleteTreeItem(actionContext)));
+        await node.deleteTreeItem(actionContext);
     });
 }

--- a/src/commands/context/useDockerContext.ts
+++ b/src/commands/context/useDockerContext.ts
@@ -13,7 +13,7 @@ import { LocalRootTreeItemBase } from '../../tree/LocalRootTreeItemBase';
 export async function useDockerContext(actionContext: IActionContext, node?: ContextTreeItem): Promise<void> {
     let invokedFromCommandPalette = false;
     if (!node) {
-        node = await ext.contextsTree.showTreeItemPicker<ContextTreeItem>(ContextTreeItem.contextValue, {
+        node = await ext.contextsTree.showTreeItemPicker<ContextTreeItem>(ContextTreeItem.allContextRegExp, {
             ...actionContext,
             noItemFoundErrorMessage: localize('vscode-docker.commands.contexts.use.noContexts', 'No Docker contexts are available to use')
         });

--- a/src/tree/contexts/ContextTreeItem.ts
+++ b/src/tree/contexts/ContextTreeItem.ts
@@ -21,7 +21,7 @@ export class ContextTreeItem extends AzExtTreeItem {
     }
 
     public get contextValue(): string {
-        if (/^default$/i.test(this.name)) {
+        if (this.name === 'default') {
             return 'defaultContext';
         } else if (this.current) {
             return 'currentCustomContext';

--- a/src/tree/contexts/ContextTreeItem.ts
+++ b/src/tree/contexts/ContextTreeItem.ts
@@ -10,13 +10,24 @@ import { getThemedIconPath, IconPath } from '../IconPath';
 import { LocalContextInfo } from "./LocalContextInfo";
 
 export class ContextTreeItem extends AzExtTreeItem {
-    public static contextValue: string = 'context';
-    public contextValue: string = ContextTreeItem.contextValue;
+    public static allContextRegExp: RegExp = /Context$/;
+    public static removableContextRegExp: RegExp = /^customContext$/i;
+
     private readonly _item: LocalContextInfo;
 
     public constructor(parent: AzExtParentTreeItem, item: LocalContextInfo) {
         super(parent);
         this._item = item;
+    }
+
+    public get contextValue(): string {
+        if (/^default$/i.test(this.name)) {
+            return 'defaultContext';
+        } else if (this.current) {
+            return 'currentCustomContext';
+        }
+
+        return 'customContext';
     }
 
     public get createdTime(): number {

--- a/src/tree/registerTrees.ts
+++ b/src/tree/registerTrees.ts
@@ -82,7 +82,7 @@ export function registerTrees(): void {
     ext.contextsRoot = new ContextsTreeItem(undefined);
     const contextsLoadMore = 'vscode-docker.contexts.loadMore';
     ext.contextsTree = new AzExtTreeDataProvider(ext.contextsRoot, contextsLoadMore);
-    ext.contextsTreeView = vscode.window.createTreeView('vscode-docker.views.dockerContexts', { treeDataProvider: ext.contextsTree, canSelectMany: true });
+    ext.contextsTreeView = vscode.window.createTreeView('vscode-docker.views.dockerContexts', { treeDataProvider: ext.contextsTree, canSelectMany: false });
     ext.context.subscriptions.push(ext.contextsTreeView);
     ext.contextsRoot.registerRefreshEvents(ext.contextsTreeView);
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */
@@ -90,7 +90,7 @@ export function registerTrees(): void {
 
     const helpRoot = new HelpsTreeItem(undefined);
     const helpTreeDataProvider = new AzExtTreeDataProvider(helpRoot, 'vscode-docker.help.loadMore');
-    const helpTreeView = vscode.window.createTreeView('vscode-docker.views.help', { treeDataProvider: helpTreeDataProvider, canSelectMany: true });
+    const helpTreeView = vscode.window.createTreeView('vscode-docker.views.help', { treeDataProvider: helpTreeDataProvider, canSelectMany: false });
     ext.context.subscriptions.push(helpTreeView);
 
     registerCommand('vscode-docker.openUrl', async (_context: IActionContext, node: OpenUrlTreeItem) => node.openUrl());

--- a/src/utils/refreshDockerode.ts
+++ b/src/utils/refreshDockerode.ts
@@ -111,7 +111,7 @@ async function addDockerContextHostToEnv(actionContext: IActionContext, newEnv: 
 
     if (dockerContext === undefined) { // Undefined context means there's only the default context
         actionContext.telemetry.properties.hostSource = 'defaultContextOnly';
-    } else if (/^default$/i.test(dockerContext.Name)) {
+    } else if (dockerContext.Name === 'default') {
         actionContext.telemetry.properties.hostSource = 'defaultContextSelected';
     } else {
         actionContext.telemetry.properties.hostSource = 'customContextSelected';


### PR DESCRIPTION
Fixes #2098

1. Context tree is no longer multi-select enabled (removing multiple contexts at once is not a realistic use case, and inspect and use aren't enabled anyway [use isn't even possible for multi-select nor does it make sense])
1. The default and current context cannot be removed--the "Remove" option won't even appear in the context menu, nor will the default or current context show when using "Remove" from the command palette
1. Help tree is no longer multi-select enabled (it never needed to be)

Can't remove in-use custom context, or default context, from tree:
![image](https://user-images.githubusercontent.com/36966225/85567877-380ebf80-b5ff-11ea-9093-ede29ed826b1.png) ![image](https://user-images.githubusercontent.com/36966225/85567954-46f57200-b5ff-11ea-8e3c-0e698e56c1d8.png)

Or from palette:
![image](https://user-images.githubusercontent.com/36966225/85568398-a6ec1880-b5ff-11ea-9656-80bb5c85781a.png)

Upon switching back to default:
![image](https://user-images.githubusercontent.com/36966225/85568483-b79c8e80-b5ff-11ea-8ed4-fba16ac3f870.png) ![image](https://user-images.githubusercontent.com/36966225/85568527-bff4c980-b5ff-11ea-9e59-db466682d689.png)
