### PR TITLE
Robustness to malformed user settings

### DIFF
--- a/src/commands/selectCommandTemplate.ts
+++ b/src/commands/selectCommandTemplate.ts
@@ -97,6 +97,9 @@ async function selectCommandTemplate(context: IActionContext, command: TemplateC
     // Get template(s) from settings
     if (typeof (templateSetting) === 'string') {
         templates = [{ template: templateSetting }] as CommandTemplate[];
+    } else if (!templateSetting) {
+        // If templateSetting is some falsy value, make this an empty array so the hardcoded default above gets used
+        templates = [];
     } else {
         templates = templateSetting;
     }


### PR DESCRIPTION
Due to frequent user error of setting a command setting to an invalid value, I'm adding some robustness so that in that scenario, it will ignore the invalid value and fall back to the universal default.

#2030, #2072, #2108