### PR TITLE
Support creating an ACI context from palette / contexts view

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
                 },
                 {
                     "command": "vscode-docker.contexts.create.aci",
-                    "when": "vscode-docker:newCli"
+                    "when": "vscode-docker:newCliPresent"
                 }
             ],
             "editor/context": [
@@ -309,7 +309,7 @@
                 },
                 {
                     "command": "vscode-docker.contexts.create.aci",
-                    "when": "view == vscode-docker.views.dockerContexts && vscode-docker:newCli",
+                    "when": "view == vscode-docker.views.dockerContexts && vscode-docker:newCliPresent",
                     "group": "navigation@1"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,10 @@
                 {
                     "command": "vscode-docker.registries.reconnectRegistry",
                     "when": "never"
+                },
+                {
+                    "command": "vscode-docker.contexts.create.aci",
+                    "when": "vscode-docker:newCli"
                 }
             ],
             "editor/context": [
@@ -305,7 +309,7 @@
                 },
                 {
                     "command": "vscode-docker.contexts.create.aci",
-                    "when": "view == vscode-docker.views.dockerContexts",
+                    "when": "view == vscode-docker.views.dockerContexts && vscode-docker:newCli",
                     "group": "navigation@1"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -356,17 +356,17 @@
                 },
                 {
                     "command": "vscode-docker.containers.start",
-                    "when": "view == dockerContainers && viewItem =~ /^(created|dead|exited|paused|terminated)Container$/i",
+                    "when": "view == dockerContainers && viewItem =~ /^(created|dead|exited|paused|terminated)Container$/i && vscode-docker:aciContext != true",
                     "group": "containers_1_general@5"
                 },
                 {
                     "command": "vscode-docker.containers.stop",
-                    "when": "view == dockerContainers && viewItem =~ /^(paused|restarting|running)Container$/i",
+                    "when": "view == dockerContainers && viewItem =~ /^(paused|restarting|running)Container$/i && vscode-docker:aciContext != true",
                     "group": "containers_1_general@6"
                 },
                 {
                     "command": "vscode-docker.containers.restart",
-                    "when": "view == dockerContainers && viewItem =~ /^runningContainer$/i",
+                    "when": "view == dockerContainers && viewItem =~ /^runningContainer$/i && vscode-docker:aciContext != true",
                     "group": "containers_1_general@7"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
         "onCommand:vscode-docker.contexts.configureExplorer",
         "onCommand:vscode-docker.contexts.refresh",
         "onCommand:vscode-docker.contexts.help",
+        "onCommand:vscode-docker.contexts.create.aci",
         "onCommand:workbench.action.tasks.runTask",
         "onDebugInitialConfigurations",
         "onDebugResolve:docker-coreclr",
@@ -2522,6 +2523,11 @@
                 "title": "%vscode-docker.commands.contexts.help%",
                 "category": "%vscode-docker.commands.category.contexts%",
                 "icon": "$(question)"
+            },
+            {
+                "command": "vscode-docker.contexts.create.aci",
+                "title": "%vscode-docker.commands.contexts.create.aci%",
+                "category": "%vscode-docker.commands.category.contexts%"
             }
         ],
         "views": {

--- a/package.json
+++ b/package.json
@@ -304,6 +304,11 @@
                     "group": "navigation@9"
                 },
                 {
+                    "command": "vscode-docker.contexts.create.aci",
+                    "when": "view == vscode-docker.views.dockerContexts",
+                    "group": "navigation@1"
+                },
+                {
                     "command": "vscode-docker.contexts.configureExplorer",
                     "when": "view == vscode-docker.views.dockerContexts",
                     "group": "navigation@8"
@@ -2527,7 +2532,11 @@
             {
                 "command": "vscode-docker.contexts.create.aci",
                 "title": "%vscode-docker.commands.contexts.create.aci%",
-                "category": "%vscode-docker.commands.category.contexts%"
+                "category": "%vscode-docker.commands.category.contexts%",
+                "icon": {
+                    "light": "resources/light/add.svg",
+                    "dark": "resources/dark/add.svg"
+                }
             }
         ],
         "views": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -244,6 +244,7 @@
     "vscode-docker.commands.contexts.configureExplorer": "Configure Explorer...",
     "vscode-docker.commands.contexts.refresh": "Refresh",
     "vscode-docker.commands.contexts.help": "Docker Context Help",
+    "vscode-docker.commands.contexts.create.aci": "Create Azure Container Instances Context",
     "vscode-docker.commands.help": "Docker Help",
     "vscode-docker.commands.category.docker": "Docker",
     "vscode-docker.commands.category.dockerContainers": "Docker Containers",

--- a/package.nls.json
+++ b/package.nls.json
@@ -244,7 +244,7 @@
     "vscode-docker.commands.contexts.configureExplorer": "Configure Explorer...",
     "vscode-docker.commands.contexts.refresh": "Refresh",
     "vscode-docker.commands.contexts.help": "Docker Context Help",
-    "vscode-docker.commands.contexts.create.aci": "Create Azure Container Instances Context",
+    "vscode-docker.commands.contexts.create.aci": "Create Azure Container Instances Context...",
     "vscode-docker.commands.help": "Docker Help",
     "vscode-docker.commands.category.docker": "Docker",
     "vscode-docker.commands.category.dockerContainers": "Docker Containers",

--- a/src/commands/context/aci/createAciContext.ts
+++ b/src/commands/context/aci/createAciContext.ts
@@ -76,7 +76,6 @@ class AciContextCreateStep extends AzureWizardExecuteStep<IAciWizardContext> {
         } catch (err) {
             const error = parseError(err);
 
-            // TODO: get the real error code
             if (error.errorType === '5' || /not logged in/i.test(error.message)) {
                 // If error is due to being not logged in, we'll go through login and try again
                 await execAsync('docker login azure');

--- a/src/commands/context/aci/createAciContext.ts
+++ b/src/commands/context/aci/createAciContext.ts
@@ -77,7 +77,7 @@ class AciContextCreateStep extends AzureWizardExecuteStep<IAciWizardContext> {
             const error = parseError(err);
 
             // TODO: get the real error code
-            if (error.errorType === '1234') {
+            if (error.errorType === '5' || /not logged in/i.test(error.message)) {
                 // If error is due to being not logged in, we'll go through login and try again
                 await execAsync('docker login azure');
                 await execAsync(command);

--- a/src/commands/context/aci/createAciContext.ts
+++ b/src/commands/context/aci/createAciContext.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Progress } from 'vscode';
+import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IResourceGroupWizardContext, LocationListStep, ResourceGroupListStep } from 'vscode-azureextensionui';
+import { ext } from '../../../extensionVariables';
+import { localize } from '../../../localize';
+import { RegistryApi } from '../../../tree/registries/all/RegistryApi';
+import { AzureAccountTreeItem } from '../../../tree/registries/azure/AzureAccountTreeItem';
+import { azureRegistryProviderId } from '../../../tree/registries/azure/azureRegistryProvider';
+import { execAsync } from '../../../utils/spawnAsync';
+
+interface IAciWizardContext extends IResourceGroupWizardContext {
+    contextName: string;
+}
+
+export async function createAciContext(actionContext: IActionContext): Promise<void> {
+    const wizardContext: IActionContext & Partial<IAciWizardContext> = {
+        ...actionContext,
+    };
+
+    const promptSteps: AzureWizardPromptStep<IAciWizardContext>[] = [];
+    // Create a temporary azure account tree item since Azure might not be connected
+    const azureAccountTreeItem = new AzureAccountTreeItem(ext.registriesRoot, { id: azureRegistryProviderId, api: RegistryApi.DockerV2 });
+
+    // Add a subscription prompt step (skipped if there is exactly one subscription)
+    const subscriptionStep = await azureAccountTreeItem.getSubscriptionPromptStep(wizardContext);
+    if (subscriptionStep) {
+        promptSteps.push(subscriptionStep);
+    }
+
+    // Add additional prompt steps
+    promptSteps.push(...[
+        new ContextNameStep(),
+        new ResourceGroupListStep(),
+    ]);
+
+    // Add a location prompt step
+    LocationListStep.addStep(wizardContext, promptSteps);
+
+    const executeSteps: AzureWizardExecuteStep<IAciWizardContext>[] = [
+        new DockerLoginAzureStep(),
+        new AciCreateStep(),
+    ];
+
+    const title = localize('vscode-docker.commands.contexts.create.aci.title', 'Create new Azure Container Instances context');
+
+    const wizard = new AzureWizard(wizardContext, { title, promptSteps, executeSteps });
+    await wizard.prompt();
+    await wizard.execute();
+}
+
+class ContextNameStep extends AzureWizardPromptStep<IAciWizardContext> {
+    public async prompt(context: IAciWizardContext): Promise<void> {
+        context.contextName = await ext.ui.showInputBox({ prompt: localize('vscode-docker.commands.contexts.create.aci.enterContextName', 'Enter context name'), validateInput: validateContextName });
+    }
+
+    public shouldPrompt(wizardContext: IActionContext): boolean {
+        return true;
+    }
+}
+
+class DockerLoginAzureStep extends AzureWizardExecuteStep<IAciWizardContext> {
+    public priority: number = 100;
+
+    public async execute(wizardContext: IAciWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        const loggingIn: string = localize('vscode-docker.commands.contexts.create.aci.loginAzure', 'Logging in to Azure...');
+        ext.outputChannel.appendLine(loggingIn);
+        progress.report({ message: loggingIn });
+
+        await execAsync('docker login azure');
+    }
+
+    public shouldExecute(context: IAciWizardContext): boolean {
+        return true;
+    }
+}
+
+class AciCreateStep extends AzureWizardExecuteStep<IAciWizardContext> {
+    public priority: number = 200;
+
+    public async execute(wizardContext: IAciWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        const creatingNewContext: string = localize('vscode-docker.commands.contexts.create.aci.creatingContext', 'Creating ACI context "{0}"...', wizardContext.contextName);
+        ext.outputChannel.appendLine(creatingNewContext);
+        progress.report({ message: creatingNewContext });
+
+        const command = `docker context create aci ${wizardContext.contextName} --subscription-id ${wizardContext.subscriptionId} --location ${wizardContext.location.name} --resource-group ${wizardContext.resourceGroup.name}`;
+        await execAsync(command);
+    }
+
+    public shouldExecute(context: IAciWizardContext): boolean {
+        return true;
+    }
+}
+
+// Slightly more strict than CLI
+const contextNameRegex = /^[a-z0-9][a-z0-9_-]+$/i;
+function validateContextName(value: string | undefined): string | undefined {
+    if (!contextNameRegex.test(value)) {
+        return localize('vscode-docker.tree.contexts.create.aci.contextNameValidation', 'Context names must be start with an alphanumeric character and can only contain alphanumeric characters, underscores, and dashes.');
+    } else {
+        return undefined;
+    }
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -22,6 +22,7 @@ import { selectContainer } from "./containers/selectContainer";
 import { startContainer } from "./containers/startContainer";
 import { stopContainer } from "./containers/stopContainer";
 import { viewContainerLogs } from "./containers/viewContainerLogs";
+import { createAciContext } from "./context/aci/createAciContext";
 import { configureDockerContextsExplorer, dockerContextsHelp } from "./context/DockerContextsViewCommands";
 import { inspectDockerContext } from "./context/inspectDockerContext";
 import { removeDockerContext } from "./context/removeDockerContext";
@@ -163,6 +164,7 @@ export function registerCommands(): void {
     registerCommand('vscode-docker.contexts.inspect', inspectDockerContext);
     registerCommand('vscode-docker.contexts.remove', removeDockerContext);
     registerCommand('vscode-docker.contexts.use', useDockerContext);
+    registerCommand('vscode-docker.contexts.create.aci', createAciContext);
 
     registerLocalCommand('vscode-docker.installDocker', installDocker);
 

--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -103,6 +103,8 @@ export class DockerContextManager implements ContextManager, Disposable {
 
             // Create a new client
             if (currentContext.Type === 'aci') {
+                // Currently vscode-docker:aciContext vscode-docker:newSdkContext mean the same thing
+                // But that probably won't be true in the future, so define both as separate concepts now
                 await this.setVsCodeContext('vscode-docker:aciContext', true);
                 await this.setVsCodeContext('vscode-docker:newSdkContext', true);
                 ext.dockerClient = new DockerServeClient();


### PR DESCRIPTION
Fixes (mostly) #2114. Adds support for creating an ACI context in the command palette and contexts view. The command will _not_ show up unless we can positively confirm that the new CLI is present, according to the following rules--
1. If another ACI context already exists, OR
1. If the output of `docker serve --help` starts with "Start an api server"

TODO: add screenshots