### PR TITLE
Upgrade language server to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2961,73 +2961,42 @@
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.0.24",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.0.24.tgz",
-            "integrity": "sha512-tG0cE6yIyj80eKHMbDBMNPHc1l40GW8v7b8jeDRs0Jv42boG0s6DEsM/eDFQw92mwAtBry07mB1tM+jSwqGzJw==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.1.0.tgz",
+            "integrity": "sha512-j+0dGmA/sQp+rC/1J3tMC4s7V0MktL68X9Shpskn9uuumg6004UJK8erHXINCofYxfBGunOAVCfoaGGCXoThPQ==",
             "requires": {
-                "dockerfile-language-service": "0.0.12",
-                "dockerfile-utils": "0.0.11",
+                "dockerfile-language-service": "0.1.0",
+                "dockerfile-utils": "0.1.0",
                 "vscode-languageserver": "^6.1.1"
             }
         },
         "dockerfile-language-service": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.0.12.tgz",
-            "integrity": "sha512-73ZEQW8LCL/SIWzWekqqLdH41pZ8+N2BYD5K16cBQCQfsZPjFoJC04tv7jlTnEPypJZs3zV0hpBLVTi7zhRFfw==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.1.0.tgz",
+            "integrity": "sha512-vvFBLvQ/4RE5JyPzI1EynvT5h6Mg/jJ8HUcMs53uyfjy3RbaGeUL5c0eN6mk39WVF2Y8fsH1FKo4L29Z/W4N6g==",
             "requires": {
-                "dockerfile-ast": "0.0.25",
-                "dockerfile-utils": "0.0.16",
+                "dockerfile-ast": "0.0.27",
+                "dockerfile-utils": "0.1.0",
                 "vscode-languageserver-protocol": "^3.15.3",
                 "vscode-languageserver-types": "^3.15.1"
-            },
-            "dependencies": {
-                "dockerfile-ast": {
-                    "version": "0.0.25",
-                    "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.25.tgz",
-                    "integrity": "sha512-Yiolk/ktLUjThacBuIEqyoRYzDdGrp8rjKjcdZA/hhtIUHrU5iVrS1MIm3p3PWKpnD7va4Jlp/FV0ywP3AdKrg==",
-                    "requires": {
-                        "vscode-languageserver-types": "^3.15.1"
-                    }
-                },
-                "dockerfile-utils": {
-                    "version": "0.0.16",
-                    "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.16.tgz",
-                    "integrity": "sha512-d/XlyVUEs+oGqoffvgYYItbGLNNSz3I2vIwzXxT9Xbx5YHH8WA8dFvTQU21k5j2Z8MoU6OYfyEZpbUqRC9N2fA==",
-                    "requires": {
-                        "dockerfile-ast": "0.0.25",
-                        "vscode-languageserver-types": "3.6.0"
-                    },
-                    "dependencies": {
-                        "vscode-languageserver-types": {
-                            "version": "3.6.0",
-                            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.0.tgz",
-                            "integrity": "sha512-GSgQtGmtza4PoNH0+iHWylWg/1sw2DODezqYWRxbN910dPchI3CQaSJN76csKcQGv55wsWgX82T6n74q8mFSpw=="
-                        }
-                    }
-                }
             }
         },
         "dockerfile-utils": {
-            "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.0.11.tgz",
-            "integrity": "sha512-LNdPIgcl58343dF4KNCHvFzUScUhgLI9BRAR+Vln6D1tVBGvv1k5/qHuxWRCAM2uyFbj73QVkKMScXPhY7TqfQ==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.1.0.tgz",
+            "integrity": "sha512-eHDiSOSXzXaFTwp7UX+bMVKUDQd2E2x8IF/3xdSvNkGhBliRhjwLIL+ALLDmi8GqSlm+7xwc4mGLcvtCI668PQ==",
             "requires": {
-                "dockerfile-ast": "0.0.12",
-                "vscode-languageserver-types": "3.6.0"
+                "dockerfile-ast": "0.0.28",
+                "vscode-languageserver-types": "3.15.1"
             },
             "dependencies": {
                 "dockerfile-ast": {
-                    "version": "0.0.12",
-                    "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.12.tgz",
-                    "integrity": "sha512-cIV8oXkAxpIuN5XgG0TGg07nLDgrj4olkfrdT77OTA3VypscsYHBUg/FjHxW9K3oA+CyH4Th/qtoMgTVpzSobw==",
+                    "version": "0.0.28",
+                    "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.28.tgz",
+                    "integrity": "sha512-221P0R4+tx5C1ra99alQxmdRvtfKMbBE7MkESN4VEBN5CX90wijrcIg+EiRaGTCCT5OPk5KBeKy+EIOnmEu4xA==",
                     "requires": {
-                        "vscode-languageserver-types": "^3.5.0"
+                        "vscode-languageserver-types": "^3.15.1"
                     }
-                },
-                "vscode-languageserver-types": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.0.tgz",
-                    "integrity": "sha512-GSgQtGmtza4PoNH0+iHWylWg/1sw2DODezqYWRxbN910dPchI3CQaSJN76csKcQGv55wsWgX82T6n74q8mFSpw=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -2657,7 +2657,7 @@
         "azure-arm-website": "^5.7.0",
         "azure-storage": "^2.10.3",
         "dockerfile-ast": "^0.0.27",
-        "dockerfile-language-server-nodejs": "^0.0.24",
+        "dockerfile-language-server-nodejs": "^0.1.0",
         "dockerode": "^3.2.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.6",


### PR DESCRIPTION
This update provides the following changes:
- continued improvements and fixes to the semantic tokens parser (#2055)
- editor visuals for the deprecated `MAINTAINER` instruction
- linting fixes due to incorrect calculations of ranges
- navigation of build stages (#2043)

![image](https://user-images.githubusercontent.com/15629116/87227277-f18fc380-c367-11ea-85ba-a040dbd3259d.png)

Please use the Dockerfile to test the new changes and bug fixes.
```Dockerfile
FROM alpine AS base
# this should not be a link anymore, issue 2043
# instead, clicking on it now should jump to the stage definition above
# https://github.com/microsoft/vscode-docker/issues/2043
FROM base
# this will now have a strikeout decoration to indicate that it is deprecated
# not sure if this is only for VS Code 1.47 or not though...?
MAINTAINER user

# the A should be coloured like X and Y
RUN --mount=X=Y,A echo

FROM scratch
# this should create an error because the ENV has no arguments
ENV \
    # comment
```
The following Dockerfiles have very specific whitespace characters to reproduce the error in question. Simply copy and paste the content into a Dockerfile and and open the Output panel and select the Dockerfile Language Server to verify that there are no errors being logged. Do not save the file as the formatter will change the integrity of the file.
```Dockerfile
# issue 2055
# https://github.com/microsoft/vscode-docker/issues/2055
FROM alpine
ENV \
    # common variables:
    ENV1=something
```
```Dockerfile
FROM alpine
COPY a b \
\ 
/dir
```
```Dockerfile
# there are two problems here
# 1 - the semantic tokens is buggy and there is an infinite loop here
# 2 - the validation is wrong, the red squiggles should be over the whole argument
# which spans across all 3 lines instead of simply the `/di\` in the beginning
FROM alpine
COPY a b /di\
\
\r
```