### PR TITLE
Use access_token grant instead of refresh_token

### DIFF
--- a/src/commands/context/aci/createAciContext.ts
+++ b/src/commands/context/aci/createAciContext.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Progress } from 'vscode';
-import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IResourceGroupWizardContext, LocationListStep, parseError, ResourceGroupListStep } from 'vscode-azureextensionui';
+import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IResourceGroupWizardContext, parseError, ResourceGroupListStep } from 'vscode-azureextensionui';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { RegistryApi } from '../../../tree/registries/all/RegistryApi';
@@ -37,7 +37,6 @@ export async function createAciContext(actionContext: IActionContext): Promise<v
 
     // Add additional prompt steps
     promptSteps.push(new ResourceGroupListStep());
-    LocationListStep.addStep(wizardContext, promptSteps);
 
     // Set up the execute steps
     const executeSteps: AzureWizardExecuteStep<IAciWizardContext>[] = [
@@ -66,10 +65,11 @@ class AciContextCreateStep extends AzureWizardExecuteStep<IAciWizardContext> {
 
     public async execute(wizardContext: IAciWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         const creatingNewContext: string = localize('vscode-docker.commands.contexts.create.aci.creatingContext', 'Creating ACI context "{0}"...', wizardContext.contextName);
+        const createdContext: string = localize('vscode-docker.commands.contexts.create.aci.createdContext', 'Created ACI context "{0}".', wizardContext.contextName);
         ext.outputChannel.appendLine(creatingNewContext);
         progress.report({ message: creatingNewContext });
 
-        const command = `docker context create aci ${wizardContext.contextName} --subscription-id ${wizardContext.subscriptionId} --location ${wizardContext.location.name} --resource-group ${wizardContext.resourceGroup.name}`;
+        const command = `docker context create aci ${wizardContext.contextName} --subscription-id ${wizardContext.subscriptionId} --resource-group ${wizardContext.resourceGroup.name}`;
 
         try {
             await execAsync(command);
@@ -85,6 +85,9 @@ class AciContextCreateStep extends AzureWizardExecuteStep<IAciWizardContext> {
                 throw err;
             }
         }
+
+        ext.outputChannel.appendLine(createdContext);
+        progress.report({ message: createdContext });
     }
 
     public shouldExecute(context: IAciWizardContext): boolean {

--- a/src/commands/context/aci/createAciContext.ts
+++ b/src/commands/context/aci/createAciContext.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Progress } from 'vscode';
-import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IResourceGroupWizardContext, parseError, ResourceGroupListStep } from 'vscode-azureextensionui';
+import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IResourceGroupWizardContext, LocationListStep, parseError, ResourceGroupListStep } from 'vscode-azureextensionui';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { RegistryApi } from '../../../tree/registries/all/RegistryApi';
@@ -37,6 +37,7 @@ export async function createAciContext(actionContext: IActionContext): Promise<v
 
     // Add additional prompt steps
     promptSteps.push(new ResourceGroupListStep());
+    LocationListStep.addStep(wizardContext, promptSteps);
 
     // Set up the execute steps
     const executeSteps: AzureWizardExecuteStep<IAciWizardContext>[] = [
@@ -65,11 +66,10 @@ class AciContextCreateStep extends AzureWizardExecuteStep<IAciWizardContext> {
 
     public async execute(wizardContext: IAciWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         const creatingNewContext: string = localize('vscode-docker.commands.contexts.create.aci.creatingContext', 'Creating ACI context "{0}"...', wizardContext.contextName);
-        const createdContext: string = localize('vscode-docker.commands.contexts.create.aci.createdContext', 'Created ACI context "{0}".', wizardContext.contextName);
         ext.outputChannel.appendLine(creatingNewContext);
         progress.report({ message: creatingNewContext });
 
-        const command = `docker context create aci ${wizardContext.contextName} --subscription-id ${wizardContext.subscriptionId} --resource-group ${wizardContext.resourceGroup.name}`;
+        const command = `docker context create aci ${wizardContext.contextName} --subscription-id ${wizardContext.subscriptionId} --location ${wizardContext.location.name} --resource-group ${wizardContext.resourceGroup.name}`;
 
         try {
             await execAsync(command);
@@ -85,9 +85,6 @@ class AciContextCreateStep extends AzureWizardExecuteStep<IAciWizardContext> {
                 throw err;
             }
         }
-
-        ext.outputChannel.appendLine(createdContext);
-        progress.report({ message: createdContext });
     }
 
     public shouldExecute(context: IAciWizardContext): boolean {

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -57,11 +57,9 @@ export async function acquireAcrRefreshToken(registryHost: string, subContext: I
     const response = <{ refresh_token: string }>await request.post(`https://${registryHost}/oauth2/exchange`, {
         form: {
             /* eslint-disable-next-line camelcase */
-            grant_type: 'refresh_token',
+            grant_type: 'access_token',
             service: registryHost,
             tenant: subContext.tenantId,
-            /* eslint-disable-next-line camelcase */
-            refresh_token: aadTokenResponse.refreshToken,
             /* eslint-disable-next-line camelcase */
             access_token: aadTokenResponse.accessToken,
         },


### PR DESCRIPTION
This substantially mitigates #1959 or possibly eliminates the issue entirely. Changing the ADAL token <=> ACR token exchange's `grant_type` to `access_token`, and not passing in the ADAL `refresh_token`, dramatically reduces the size of the obtained ACR `refresh_token`. My token's size was pretty consistently about 950 bytes, compared to > 2600 before.

It may be functionally impossible to get a token using this different mechanism that is too long for Docker CLI. We won't update people's existing Docker configs (at least not now...), but we hopefully will never need to suggest disabling Wincred again.

The disadvantage to this grant type is that if the ADAL `access_token` is near expiry, they (ACR) will not be able to use the ADAL `refresh_token` to get a new one--however, that shouldn't be an issue for us since we get a fresh ADAL token from the Azure Account extension every time.