### PR TITLE
Use recommended EXEC form of commands

### DIFF
--- a/src/configureWorkspace/configure.ts
+++ b/src/configureWorkspace/configure.ts
@@ -28,6 +28,7 @@ export interface PackageInfo {
     author: string;
     version: string;
     artifactName: string;
+    main?: string;
 }
 
 interface JsonPackageContents {
@@ -156,7 +157,8 @@ function getDefaultPackageInfo(): PackageInfo {
         cmd: ['npm', 'start'],
         author: 'author',
         version: '0.0.1',
-        artifactName: ''
+        artifactName: '',
+        main: 'index.js',
     };
 }
 
@@ -172,8 +174,14 @@ async function readPackageJson(folderPath: string): Promise<{ packagePath?: stri
 
         if (json.scripts && typeof json.scripts.start === "string") {
             packageInfo.cmd = ['npm', 'start'];
+
+            const matches = /node (.+)/i.exec(json.scripts.start);
+            if (matches?.[1]) {
+                packageInfo.main = matches[1];
+            }
         } else if (typeof json.main === "string") {
             packageInfo.cmd = ['node', json.main];
+            packageInfo.main = json.main;
         }
 
         if (typeof json.author === "string") {

--- a/src/configureWorkspace/configure.ts
+++ b/src/configureWorkspace/configure.ts
@@ -24,9 +24,7 @@ import { ConfigureTelemetryProperties, genCommonDockerIgnoreFile, getSubfolderDe
 import { openFilesIfRequired, registerScaffolder, scaffold, Scaffolder, ScaffolderContext, ScaffoldFile } from './scaffolding';
 
 export interface PackageInfo {
-    npmStart: boolean; // has npm start
-    cmd: string;
-    fullCommand: string; // full command
+    cmd: string | string[];
     author: string;
     version: string;
     artifactName: string;
@@ -155,9 +153,7 @@ async function getPackageJson(folderPath: string): Promise<vscode.Uri[]> {
 
 function getDefaultPackageInfo(): PackageInfo {
     return {
-        npmStart: true,
-        fullCommand: 'npm start',
-        cmd: 'npm start',
+        cmd: ['npm', 'start'],
         author: 'author',
         version: '0.0.1',
         artifactName: ''
@@ -175,15 +171,9 @@ async function readPackageJson(folderPath: string): Promise<{ packagePath?: stri
         const json = <JsonPackageContents>JSON.parse(fse.readFileSync(packagePath, 'utf8'));
 
         if (json.scripts && typeof json.scripts.start === "string") {
-            packageInfo.npmStart = true;
-            packageInfo.fullCommand = json.scripts.start;
-            packageInfo.cmd = 'npm start';
+            packageInfo.cmd = ['npm', 'start'];
         } else if (typeof json.main === "string") {
-            packageInfo.npmStart = false;
-            packageInfo.fullCommand = 'node' + ' ' + json.main;
-            packageInfo.cmd = packageInfo.fullCommand;
-        } else {
-            packageInfo.fullCommand = '';
+            packageInfo.cmd = ['node', json.main];
         }
 
         if (typeof json.author === "string") {

--- a/src/configureWorkspace/configureGo.ts
+++ b/src/configureWorkspace/configureGo.ts
@@ -45,7 +45,7 @@ services:
 ${getComposePorts(ports)}`;
 }
 
-function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { fullCommand: cmd }: Partial<PackageInfo>): string {
+function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], _: Partial<PackageInfo>): string {
     return `version: '3.4'
 
 services:

--- a/src/configureWorkspace/configureJava.ts
+++ b/src/configureWorkspace/configureJava.ts
@@ -40,7 +40,7 @@ services:
 ${getComposePorts(ports)}`;
 }
 
-function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { fullCommand: cmd }: Partial<PackageInfo>): string {
+function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], _: Partial<PackageInfo>): string {
     return `version: '3.4'
 
 services:

--- a/src/configureWorkspace/configureNode.ts
+++ b/src/configureWorkspace/configureNode.ts
@@ -50,13 +50,12 @@ services:
 ${getComposePorts(ports)}`;
 }
 
-function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { cmd }: Partial<PackageInfo>): string {
+function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { cmd, main }: Partial<PackageInfo>): string {
     const inspectConfig = '--inspect=0.0.0.0:9229';
 
     let cmdDirective: string;
-    if (Array.isArray(cmd) && cmd[0].toLowerCase() === 'node') {
-        cmd.splice(1, 0, inspectConfig);
-        cmdDirective = `command: ${toCMDArray(cmd)}`;
+    if (main) {
+        cmdDirective = `command: ${toCMDArray(['node', inspectConfig, main])}`;
     } else {
         cmdDirective = `## set your startup file here\n    command: ["node", "${inspectConfig}", "index.js"]`;
     }

--- a/src/configureWorkspace/configureNode.ts
+++ b/src/configureWorkspace/configureNode.ts
@@ -18,7 +18,7 @@ export let configureNode: IPlatformGeneratorInfo = {
     initializeForDebugging,
 };
 
-function genDockerFile(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { cmd, author, version, artifactName }: Partial<PackageInfo>): string {
+function genDockerFile(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { cmd }: Partial<PackageInfo>): string {
     let exposeStatements = getExposeStatements(ports);
 
     let cmdDirective: string;
@@ -50,7 +50,7 @@ services:
 ${getComposePorts(ports)}`;
 }
 
-function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { cmd: cmd }: Partial<PackageInfo>): string {
+function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { cmd }: Partial<PackageInfo>): string {
     const inspectConfig = '--inspect=0.0.0.0:9229';
 
     let cmdDirective: string;
@@ -85,11 +85,11 @@ async function initializeForDebugging(context: IActionContext, folder: Workspace
 }
 
 function toCMDArray(cmdArray: string[]): string {
-    return cmdArray.map(part => {
+    return `[${cmdArray.map(part => {
         if (part.startsWith('"') && part.endsWith('"')) {
             return part;
         }
 
         return `"${part}"`;
-    }).join(', ');
+    }).join(', ')}]`;
 }

--- a/src/configureWorkspace/configureOther.ts
+++ b/src/configureWorkspace/configureOther.ts
@@ -17,7 +17,7 @@ function genDockerFile(serviceNameAndRelativePath: string, platform: string, os:
     return `FROM docker/whalesay:latest
 LABEL Name=${serviceNameAndRelativePath} Version=${version}
 RUN apt-get -y update && apt-get install -y fortunes
-CMD /usr/games/fortune -a | cowsay
+CMD ["sh", "-c", "/usr/games/fortune -a | cowsay"]
 `;
 }
 

--- a/src/configureWorkspace/configureOther.ts
+++ b/src/configureWorkspace/configureOther.ts
@@ -31,7 +31,7 @@ services:
 ${getComposePorts(ports)}`;
 }
 
-function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { fullCommand: cmd }: Partial<PackageInfo>): string {
+function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], _: Partial<PackageInfo>): string {
     return `version: '3.4'
 
 services:

--- a/src/configureWorkspace/configureRuby.ts
+++ b/src/configureWorkspace/configureRuby.ts
@@ -44,7 +44,7 @@ services:
 ${getComposePorts(ports)}`;
 }
 
-function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], { fullCommand: cmd }: Partial<PackageInfo>): string {
+function genDockerComposeDebug(serviceNameAndRelativePath: string, platform: string, os: string | undefined, ports: number[], _: Partial<PackageInfo>): string {
     return `version: '3.4'
 
 services:

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -471,13 +471,13 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('docker-compose.debug.yml', '9229:9229');
             assertFileContains('docker-compose.debug.yml', 'image: testoutput');
             assertFileContains('docker-compose.debug.yml', 'NODE_ENV: development');
-            assertFileContains('docker-compose.debug.yml', 'command: node --inspect=0.0.0.0:9229 index.js');
+            assertFileContains('docker-compose.debug.yml', 'command: ["node", "--inspect=0.0.0.0:9229", "index.js"]');
 
             assertFileContains('docker-compose.yml', '1234');
             assertNotFileContains('docker-compose.yml', '9229:9229');
             assertFileContains('docker-compose.yml', 'image: testoutput');
             assertFileContains('docker-compose.yml', 'NODE_ENV: production');
-            assertNotFileContains('docker-compose.yml', 'command: node --inspect=0.0.0.0:9229 index.js');
+            assertNotFileContains('docker-compose.yml', 'command: ["node", "--inspect=0.0.0.0:9229", "index.js"]');
 
             assertFileContains('.dockerignore', '.vscode');
         });
@@ -542,13 +542,13 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             assertFileContains('docker-compose.debug.yml', '9229:9229');
             assertFileContains('docker-compose.debug.yml', 'image: testoutput');
             assertFileContains('docker-compose.debug.yml', 'NODE_ENV: development');
-            assertFileContains('docker-compose.debug.yml', 'command: node --inspect=0.0.0.0:9229 ./bin/www');
+            assertFileContains('docker-compose.debug.yml', 'command: ["node", "--inspect=0.0.0.0:9229", "./bin/www"]');
 
             assertFileContains('docker-compose.yml', '4321');
             assertNotFileContains('docker-compose.yml', '9229:9229');
             assertFileContains('docker-compose.yml', 'image: testoutput');
             assertFileContains('docker-compose.yml', 'NODE_ENV: production');
-            assertNotFileContains('docker-compose.yml', 'command: node --inspect=0.0.0.0:9229 ./bin/www');
+            assertNotFileContains('docker-compose.yml', 'command: ["node", "--inspect=0.0.0.0:9229", "./bin/www"]');
 
             assertFileContains('.dockerignore', '.vscode');
         });
@@ -583,7 +583,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                 ['package.json', 'Dockerfile', 'docker-compose.debug.yml', 'docker-compose.yml', '.dockerignore']
             );
 
-            assertNotFileContains('docker-compose.yml', 'command: node --inspect=0.0.0.0:9229 index.js');
+            assertNotFileContains('docker-compose.yml', 'command: ["node", "--inspect=0.0.0.0:9229", "index.js"]');
         });
 
         testInEmptyFolder("Without start script", async () => {

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -1350,7 +1350,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
                 FROM docker/whalesay:latest
                 LABEL Name=testoutput Version=1.2.3
                 RUN apt-get -y update && apt-get install -y fortunes
-                CMD /usr/games/fortune -a | cowsay
+                CMD ["sh", "-c", "/usr/games/fortune -a | cowsay"]
                 `));
             assert.strictEqual(composeContents, removeIndentation(`
                 version: '3.4'

--- a/test/configure.test.ts
+++ b/test/configure.test.ts
@@ -465,7 +465,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             );
 
             assertFileContains('Dockerfile', 'EXPOSE 1234');
-            assertFileContains('Dockerfile', 'CMD npm start');
+            assertFileContains('Dockerfile', 'CMD ["npm", "start"]');
 
             assertFileContains('docker-compose.debug.yml', '1234');
             assertFileContains('docker-compose.debug.yml', '9229:9229');
@@ -496,7 +496,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             );
 
             assertFileContains('Dockerfile', 'EXPOSE 1234');
-            assertFileContains('Dockerfile', 'CMD npm start');
+            assertFileContains('Dockerfile', 'CMD ["npm", "start"]');
 
             assertFileContains('.dockerignore', '.vscode');
         });
@@ -536,7 +536,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             );
 
             assertFileContains('Dockerfile', 'EXPOSE 4321');
-            assertFileContains('Dockerfile', 'CMD npm start');
+            assertFileContains('Dockerfile', 'CMD ["npm", "start"]');
 
             assertFileContains('docker-compose.debug.yml', '4321');
             assertFileContains('docker-compose.debug.yml', '9229:9229');
@@ -616,7 +616,7 @@ suite("Configure (Add Docker files to Workspace)", function (this: Suite): void 
             );
 
             assertFileContains('Dockerfile', 'EXPOSE 4321');
-            assertFileContains('Dockerfile', 'CMD node ./out/dockerExtension');
+            assertFileContains('Dockerfile', 'CMD ["node", "./out/dockerExtension"]');
         });
     });
 


### PR DESCRIPTION
Fixes #2090

NOTE: the "Other" scaffolding still uses the other form (`CMD /usr/games/fortune -a | cowsay`). I don't think there's value in changing that for two reasons--
1. The "Other" Dockerfile is little more than a demonstration of how Dockerfiles look.
1. The intended behavior of the image does not work when using the EXEC form + `sh`, `-c`. It is supposed to output a random bit of text (the output from `/usr/games/fortune`) and put it into a text box being spoken by the Docker whale (the pipe into `cowsay`). If the EXEC form is used, nothing is output to the terminal doing the `docker run`; instead the output is just into the container itself.