### PR TITLE
Disable NPS survey for now

### DIFF
--- a/src/telemetry/surveys/SurveyManager.ts
+++ b/src/telemetry/surveys/SurveyManager.ts
@@ -8,10 +8,9 @@ import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azuree
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { awareness } from './awareness';
-import { nps2 } from './nps2';
 
 // Currently-active surveys should be registered here
-const currentSurveys = [nps2, awareness];
+const currentSurveys = [awareness];
 
 const surveyRespondedKeyPrefix = 'vscode-docker.surveys.response';
 const surveyFlightPrefix = 'vscode-docker.surveys';


### PR DESCRIPTION
For slight performance gain we can disable the NPS survey since we do not have the experiment enabled at this time.

@BigMorty Are you OK removing this? Here's the implications--
1. Slight performance improvement
1. We can't re-enable this NPS survey from server side

NOTE: For the next NPS survey, we will need to make a code change anyway--to advance the survey ID from `nps2` to `nps4` (I skipped 3 because we called this one "NPS 3" in the experimentation service).