### PR TITLE
Template change to make .NET scaffolding friendlier

### DIFF
--- a/resources/templates/netCore/docker-compose.debug.yml.template
+++ b/resources/templates/netCore/docker-compose.debug.yml.template
@@ -14,7 +14,7 @@ services:
     ports:
 {{#each ports}}
 {{#unless (eq . 443)}}
-      - {{ . }}:{{ . }}
+      - {{ . }}
 {{/unless}}
 {{/each}}
 {{/if}}

--- a/resources/templates/netCore/docker-compose.yml.template
+++ b/resources/templates/netCore/docker-compose.yml.template
@@ -14,7 +14,7 @@ services:
     ports:
 {{#each ports}}
 {{#unless (eq . 443)}}
-      - {{ . }}:{{ . }}
+      - {{ . }}
 {{/unless}}
 {{/each}}
 {{/if}}


### PR DESCRIPTION
Opening based on [this comment](https://github.com/microsoft/vscode-docker/issues/2228#issuecomment-692006276). A template change will make .NET friendlier to compose up. Other platforms don't typically use ports < 1024 so don't really need this.

This change allows Docker to randomly assign the host-side ports rather than them being fixed to 80 by default.

Side note: this new template-based code makes maintenance so much easier!