### PR TITLE
Allow building in Azure for any "Dockerfile" / "Dockerfile.*" / "*.dockerfile"

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
             ],
             "explorer/context": [
                 {
-                    "when": "resourceFilename =~ /(^|\\.)dockerfile$/i && isAzureAccountInstalled",
+                    "when": "editorLangId == dockerfile && isAzureAccountInstalled",
                     "command": "vscode-docker.registries.azure.buildImage",
                     "group": "docker"
                 },

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
             ],
             "explorer/context": [
                 {
-                    "when": "editorLangId == dockerfile && isAzureAccountInstalled",
+                    "when": "resourceFilename =~ /dockerfile/i && isAzureAccountInstalled",
                     "command": "vscode-docker.registries.azure.buildImage",
                     "group": "docker"
                 },


### PR DESCRIPTION
Fixes #2317. This "when clause" is the same as what we use for the "Build Image" context menu option for Dockerfiles, plus `isAzureAccountInstalled`. The files now counted also match what we treat as a Dockerfile for language purposes.