### PR TITLE
Use ENV key=value in Dockerfile templates

### DIFF
--- a/resources/templates/node/Dockerfile.template
+++ b/resources/templates/node/Dockerfile.template
@@ -1,5 +1,5 @@
 FROM node:12.18-alpine
-ENV NODE_ENV production
+ENV NODE_ENV=production
 WORKDIR /usr/src/app
 COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
 RUN npm install --production --silent && mv node_modules ../

--- a/resources/templates/python/Dockerfile.template
+++ b/resources/templates/python/Dockerfile.template
@@ -12,10 +12,10 @@ EXPOSE {{ . }}
 
 {{/if}}
 # Keeps Python from generating .pyc files in the container
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # Turns off buffering for easier container logging
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 # Install pip requirements
 ADD requirements.txt .


### PR DESCRIPTION
Hi,
In our docs.docker.com we've removed the examples that used the old syntax `ENV key value` and replaced it with the better `ENV key=value` syntax (related https://github.com/docker/docker.github.io/pull/11414). 
The old style had its problems when using multiple environment variables `ENV ONE TWO= THREE=world`

Just yesterday I used the Docker extension in preparation for a Docker beginners video course and saw that the Docker extension uses the old style.

This PR changes the templates to the new style and helps users to use the good practice. 
