### PR TITLE
Enable debugging node apps in subfolders

### DIFF
--- a/resources/templates/docker-compose.debug.yml.template
+++ b/resources/templates/docker-compose.debug.yml.template
@@ -5,7 +5,7 @@ services:
     image: {{ serviceName }}
     build:
       context: {{ workspaceRelative . dockerBuildContext }}
-      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
+      dockerfile: {{ contextRelative . dockerfileDirectory }}/Dockerfile
 {{#if ports}}
     ports:
 {{#each ports}}

--- a/resources/templates/docker-compose.debug.yml.template
+++ b/resources/templates/docker-compose.debug.yml.template
@@ -4,8 +4,8 @@ services:
   {{ serviceName }}:
     image: {{ serviceName }}
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: {{ workspaceRelative . dockerBuildContext }}
+      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
 {{#if ports}}
     ports:
 {{#each ports}}

--- a/resources/templates/docker-compose.yml.template
+++ b/resources/templates/docker-compose.yml.template
@@ -5,7 +5,7 @@ services:
     image: {{ serviceName }}
     build:
       context: {{ workspaceRelative . dockerBuildContext }}
-      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
+      dockerfile: {{ contextRelative . dockerfileDirectory }}/Dockerfile
 {{#if ports}}
     ports:
 {{#each ports}}

--- a/resources/templates/docker-compose.yml.template
+++ b/resources/templates/docker-compose.yml.template
@@ -3,7 +3,9 @@ version: '3.4'
 services:
   {{ serviceName }}:
     image: {{ serviceName }}
-    build: .
+    build:
+      context: {{ workspaceRelative . dockerBuildContext }}
+      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
 {{#if ports}}
     ports:
 {{#each ports}}

--- a/resources/templates/java/docker-compose.debug.yml.template
+++ b/resources/templates/java/docker-compose.debug.yml.template
@@ -4,8 +4,8 @@ services:
   {{ serviceName }}:
     image: {{ serviceName }}
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: {{ workspaceRelative . dockerBuildContext }}
+      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
     environment:
       JAVA_OPTS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y
 {{#if (join ports debugPorts)}}

--- a/resources/templates/java/docker-compose.debug.yml.template
+++ b/resources/templates/java/docker-compose.debug.yml.template
@@ -5,7 +5,7 @@ services:
     image: {{ serviceName }}
     build:
       context: {{ workspaceRelative . dockerBuildContext }}
-      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
+      dockerfile: {{ contextRelative . dockerfileDirectory }}/Dockerfile
     environment:
       JAVA_OPTS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y
 {{#if (join ports debugPorts)}}

--- a/resources/templates/netCore/docker-compose.debug.yml.template
+++ b/resources/templates/netCore/docker-compose.debug.yml.template
@@ -9,7 +9,7 @@ services:
     image: {{ serviceName }}
     build:
       context: {{ workspaceRelative . dockerBuildContext }}
-      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
+      dockerfile: {{ contextRelative . dockerfileDirectory }}/Dockerfile
 {{#if ports}}
     ports:
 {{#each ports}}

--- a/resources/templates/netCore/docker-compose.debug.yml.template
+++ b/resources/templates/netCore/docker-compose.debug.yml.template
@@ -8,8 +8,8 @@ services:
   {{ serviceName }}:
     image: {{ serviceName }}
     build:
-      context: .
-      dockerfile: {{ dirname (workspaceRelative . artifact) 'Linux' }}/Dockerfile
+      context: {{ workspaceRelative . dockerBuildContext }}
+      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
 {{#if ports}}
     ports:
 {{#each ports}}

--- a/resources/templates/netCore/docker-compose.yml.template
+++ b/resources/templates/netCore/docker-compose.yml.template
@@ -9,7 +9,7 @@ services:
     image: {{ serviceName }}
     build:
       context: {{ workspaceRelative . dockerBuildContext }}
-      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
+      dockerfile: {{ contextRelative . dockerfileDirectory }}/Dockerfile
 {{#if ports}}
     ports:
 {{#each ports}}

--- a/resources/templates/netCore/docker-compose.yml.template
+++ b/resources/templates/netCore/docker-compose.yml.template
@@ -8,8 +8,8 @@ services:
   {{ serviceName }}:
     image: {{ serviceName }}
     build:
-      context: .
-      dockerfile: {{ dirname (workspaceRelative . artifact) 'Linux' }}/Dockerfile
+      context: {{ workspaceRelative . dockerBuildContext }}
+      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
 {{#if ports}}
     ports:
 {{#each ports}}

--- a/resources/templates/node/docker-compose.debug.yml.template
+++ b/resources/templates/node/docker-compose.debug.yml.template
@@ -5,7 +5,7 @@ services:
     image: {{ serviceName }}
     build:
       context: {{ workspaceRelative . dockerBuildContext }}
-      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
+      dockerfile: {{ contextRelative . dockerfileDirectory }}/Dockerfile
     environment:
       NODE_ENV: development
 {{#if (join ports debugPorts)}}

--- a/resources/templates/node/docker-compose.debug.yml.template
+++ b/resources/templates/node/docker-compose.debug.yml.template
@@ -3,7 +3,9 @@ version: '3.4'
 services:
   {{ serviceName }}:
     image: {{ serviceName }}
-    build: .
+    build:
+      context: {{ workspaceRelative . dockerBuildContext }}
+      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
     environment:
       NODE_ENV: development
 {{#if (join ports debugPorts)}}

--- a/resources/templates/node/docker-compose.yml.template
+++ b/resources/templates/node/docker-compose.yml.template
@@ -5,7 +5,7 @@ services:
     image: {{ serviceName }}
     build:
       context: {{ workspaceRelative . dockerBuildContext }}
-      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
+      dockerfile: {{ contextRelative . dockerfileDirectory }}/Dockerfile
     environment:
       NODE_ENV: production
 {{#if ports}}

--- a/resources/templates/node/docker-compose.yml.template
+++ b/resources/templates/node/docker-compose.yml.template
@@ -3,7 +3,9 @@ version: '3.4'
 services:
   {{ serviceName }}:
     image: {{ serviceName }}
-    build: .
+    build:
+      context: {{ workspaceRelative . dockerBuildContext }}
+      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
     environment:
       NODE_ENV: production
 {{#if ports}}

--- a/resources/templates/python/docker-compose.debug.yml.template
+++ b/resources/templates/python/docker-compose.debug.yml.template
@@ -4,8 +4,8 @@ services:
   {{ serviceName }}:
     image: {{ serviceName }}
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: {{ workspaceRelative . dockerBuildContext }}
+      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
     command: {{{ toQuotedArray pythonDebugCmdParts }}}
 {{#if (join ports debugPorts)}}
     ports:

--- a/resources/templates/python/docker-compose.debug.yml.template
+++ b/resources/templates/python/docker-compose.debug.yml.template
@@ -5,7 +5,7 @@ services:
     image: {{ serviceName }}
     build:
       context: {{ workspaceRelative . dockerBuildContext }}
-      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
+      dockerfile: {{ contextRelative . dockerfileDirectory }}/Dockerfile
     command: {{{ toQuotedArray pythonDebugCmdParts }}}
 {{#if (join ports debugPorts)}}
     ports:

--- a/resources/templates/python/docker-compose.yml.template
+++ b/resources/templates/python/docker-compose.yml.template
@@ -5,7 +5,7 @@ services:
     image: {{ serviceName }}
     build:
       context: {{ workspaceRelative . dockerBuildContext }}
-      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
+      dockerfile: {{ contextRelative . dockerfileDirectory }}/Dockerfile
 {{#if ports}}
     ports:
 {{#each ports}}

--- a/resources/templates/python/docker-compose.yml.template
+++ b/resources/templates/python/docker-compose.yml.template
@@ -4,8 +4,8 @@ services:
   {{ serviceName }}:
     image: {{ serviceName }}
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: {{ workspaceRelative . dockerBuildContext }}
+      dockerfile: {{ dirname (workspaceRelative . dockerfileDirectory) 'Linux' }}/Dockerfile
 {{#if ports}}
     ports:
 {{#each ports}}

--- a/src/debugging/DockerDebugScaffoldingProvider.ts
+++ b/src/debugging/DockerDebugScaffoldingProvider.ts
@@ -20,6 +20,11 @@ import { nodeDebugHelper } from './node/NodeDebugHelper';
 import { pythonDebugHelper } from './python/PythonDebugHelper';
 
 export type NetCoreScaffoldingOptions = NetCoreDebugScaffoldingOptions | NetCoreTaskScaffoldingOptions;
+
+export interface NodeScaffoldingOptions {
+    package?: string;
+}
+
 export interface PythonScaffoldingOptions {
     projectType?: PythonProjectType;
     target?: PythonTarget;
@@ -27,7 +32,7 @@ export interface PythonScaffoldingOptions {
 
 export interface IDockerDebugScaffoldingProvider {
     initializeNetCoreForDebugging(context: DockerDebugScaffoldContext, options?: NetCoreScaffoldingOptions): Promise<void>;
-    initializeNodeForDebugging(context: DockerDebugScaffoldContext): Promise<void>;
+    initializeNodeForDebugging(context: DockerDebugScaffoldContext, options?: NodeScaffoldingOptions): Promise<void>;
     initializePythonForDebugging(context: DockerDebugScaffoldContext, options: PythonScaffoldingOptions): Promise<void>;
 }
 
@@ -42,13 +47,13 @@ export class DockerDebugScaffoldingProvider implements IDockerDebugScaffoldingPr
         /* eslint-enable @typescript-eslint/promise-function-async */
     }
 
-    public async initializeNodeForDebugging(context: DockerDebugScaffoldContext): Promise<void> {
+    public async initializeNodeForDebugging(context: DockerDebugScaffoldContext, options?: NodeScaffoldingOptions): Promise<void> {
         await this.initializeForDebugging(
             context,
             /* eslint-disable @typescript-eslint/promise-function-async */
-            () => nodeDebugHelper.provideDebugConfigurations(context),
-            () => nodeTaskHelper.provideDockerBuildTasks(context),
-            () => nodeTaskHelper.provideDockerRunTasks(context));
+            () => nodeDebugHelper.provideDebugConfigurations(context, options),
+            () => nodeTaskHelper.provideDockerBuildTasks(context, options),
+            () => nodeTaskHelper.provideDockerRunTasks(context, options));
         /* eslint-enable @typescript-eslint/promise-function-async */
     }
 

--- a/src/debugging/node/NodeDebugHelper.ts
+++ b/src/debugging/node/NodeDebugHelper.ts
@@ -44,6 +44,7 @@ export class NodeDebugHelper implements DebugHelper {
         const nodeOptions: NodeDockerDebugOptions = NodeTaskHelper.getNodeOptionsForScaffolding(options?.package, context.folder);
 
         if (nodeOptions) {
+            // localRoot must match the build context
             nodeOptions.localRoot = unresolveWorkspaceFolder(path.dirname(options.package), context.folder)
         }
 

--- a/src/debugging/node/NodeDebugHelper.ts
+++ b/src/debugging/node/NodeDebugHelper.ts
@@ -3,11 +3,14 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import { NodeTaskHelper } from '../../tasks/node/NodeTaskHelper';
 import { inferPackageName, readPackage } from '../../utils/nodeUtils';
+import { unresolveWorkspaceFolder } from '../../utils/resolveVariables';
 import { DebugHelper, DockerDebugContext, DockerDebugScaffoldContext, inferContainerName, ResolvedDebugConfiguration, ResolvedDebugConfigurationOptions, resolveDockerServerReadyAction } from '../DebugHelper';
 import { DebugConfigurationBase, DockerDebugConfigurationBase } from '../DockerDebugConfigurationBase';
 import { DockerDebugConfiguration } from '../DockerDebugConfigurationProvider';
+import { NodeScaffoldingOptions } from '../DockerDebugScaffoldingProvider';
 
 export interface NodeDebugOptions {
     address?: string;
@@ -36,14 +39,22 @@ export interface NodeDockerDebugConfiguration extends DockerDebugConfigurationBa
 }
 
 export class NodeDebugHelper implements DebugHelper {
-    public async provideDebugConfigurations(context: DockerDebugScaffoldContext): Promise<DockerDebugConfiguration[]> {
+    public async provideDebugConfigurations(context: DockerDebugScaffoldContext, options?: NodeScaffoldingOptions): Promise<DockerDebugConfiguration[]> {
+        // If the package is at the root, we'll leave it out of the config for brevity, otherwise it must be specified explicitly
+        const nodeOptions: NodeDockerDebugOptions = NodeTaskHelper.getNodeOptionsForScaffolding(options?.package, context.folder);
+
+        if (nodeOptions) {
+            nodeOptions.localRoot = unresolveWorkspaceFolder(path.dirname(options.package), context.folder)
+        }
+
         return [
             {
                 name: 'Docker Node.js Launch',
                 type: 'docker',
                 request: 'launch',
                 preLaunchTask: 'docker-run: debug',
-                platform: 'node'
+                platform: 'node',
+                node: nodeOptions,
             }
         ];
     }

--- a/src/scaffolding/wizard/GatherInformationStep.ts
+++ b/src/scaffolding/wizard/GatherInformationStep.ts
@@ -16,9 +16,19 @@ export class GatherInformationStep<TWizardContext extends ScaffoldingWizardConte
         if (!wizardContext.version) {
             wizardContext.version = '0.0.1';
         }
+
+        if (!wizardContext.dockerBuildContext) {
+            // Most platforms (except Node) always use the root as the build context
+            wizardContext.dockerBuildContext = wizardContext.workspaceFolder.uri.fsPath;
+        }
+
+        if (!wizardContext.dockerfileDirectory) {
+            // Most platforms (except Node and .NET) always place the Dockerfile at the root
+            wizardContext.dockerfileDirectory = wizardContext.workspaceFolder.uri.fsPath;
+        }
     }
 
     public shouldPrompt(wizardContext: TWizardContext): boolean {
-        return !wizardContext.serviceName || !wizardContext.version;
+        return !wizardContext.serviceName || !wizardContext.version || !wizardContext.dockerBuildContext || !wizardContext.dockerfileDirectory;
     }
 }

--- a/src/scaffolding/wizard/ScaffoldDebuggingStep.ts
+++ b/src/scaffolding/wizard/ScaffoldDebuggingStep.ts
@@ -3,12 +3,11 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Progress } from 'vscode';
 import { AzureWizardExecuteStep } from 'vscode-azureextensionui';
 import { DockerDebugScaffoldContext } from '../../debugging/DebugHelper';
-import { dockerDebugScaffoldingProvider, NetCoreScaffoldingOptions, PythonScaffoldingOptions } from '../../debugging/DockerDebugScaffoldingProvider';
+import { dockerDebugScaffoldingProvider, NetCoreScaffoldingOptions, NodeScaffoldingOptions, PythonScaffoldingOptions } from '../../debugging/DockerDebugScaffoldingProvider';
 import { localize } from '../../localize';
 import { unresolveWorkspaceFolder } from '../../utils/resolveVariables';
 import { NetCoreScaffoldingWizardContext } from './netCore/NetCoreScaffoldingWizardContext';
@@ -21,25 +20,20 @@ export class ScaffoldDebuggingStep extends AzureWizardExecuteStep<ScaffoldingWiz
     public async execute(wizardContext: ScaffoldingWizardContext, progress: Progress<{ message?: string; increment?: number; }>): Promise<void> {
         progress.report({ message: localize('vscode-docker.scaffold.scaffoldDebuggingStep.progress', 'Adding debug configuration and tasks...') });
 
-        let dockerfilePath: string;
-        if (await fse.pathExists(wizardContext.artifact)) {
-            dockerfilePath = path.join(path.dirname(wizardContext.artifact) || wizardContext.workspaceFolder.uri.fsPath, 'Dockerfile');
-        } else {
-            // In the case of Python the artifact might be a module instead of a file; if so use the workspace folder as the root
-            dockerfilePath = path.join(wizardContext.workspaceFolder.uri.fsPath, 'Dockerfile');
-        }
-
         const scaffoldContext: DockerDebugScaffoldContext = {
             folder: wizardContext.workspaceFolder,
             actionContext: wizardContext,
-            dockerfile: dockerfilePath,
+            dockerfile: path.join(wizardContext.dockerfileDirectory, 'Dockerfile'),
             ports: wizardContext.ports,
         };
 
         switch (wizardContext.platform) {
             case 'Node.js':
                 scaffoldContext.platform = 'node';
-                await dockerDebugScaffoldingProvider.initializeNodeForDebugging(scaffoldContext);
+                const nodeOptions: NodeScaffoldingOptions = {
+                    package: wizardContext.artifact,
+                };
+                await dockerDebugScaffoldingProvider.initializeNodeForDebugging(scaffoldContext, nodeOptions);
                 break;
 
             case '.NET: ASP.NET Core':

--- a/src/scaffolding/wizard/ScaffoldFileStep.ts
+++ b/src/scaffolding/wizard/ScaffoldFileStep.ts
@@ -24,6 +24,13 @@ Handlebars.registerHelper('workspaceRelative', (wizardContext: ScaffoldingWizard
     );
 });
 
+Handlebars.registerHelper('contextRelative', (wizardContext: ScaffoldingWizardContext, absolutePath: string, platform: PlatformOS = 'Linux') => {
+    return pathNormalize(
+        path.relative(wizardContext.dockerBuildContext as string, absolutePath),
+        platform
+    );
+});
+
 Handlebars.registerHelper('eq', (a: string, b: string) => {
     return a === b;
 });

--- a/src/scaffolding/wizard/ScaffoldFileStep.ts
+++ b/src/scaffolding/wizard/ScaffoldFileStep.ts
@@ -149,12 +149,14 @@ export class ScaffoldFileStep<TWizardContext extends ScaffoldingWizardContext> e
     }
 
     private async getOutputPath(wizardContext: TWizardContext): Promise<string> {
-        if (this.fileType === 'Dockerfile' && wizardContext.artifact &&
-            (wizardContext.platform === 'Node.js' || wizardContext.platform === '.NET: ASP.NET Core' || wizardContext.platform === '.NET: Core Console')) {
-            // Dockerfiles may be placed in subpaths for Node and .NET; the others are always at the workspace folder level
-            return path.join(path.dirname(wizardContext.artifact), this.fileType);
-        } else {
-            return path.join(wizardContext.workspaceFolder.uri.fsPath, this.fileType);
+        switch (this.fileType) {
+            case 'Dockerfile':
+                return path.join(wizardContext.dockerfileDirectory, this.fileType);
+            case '.dockerignore':
+                return path.join(wizardContext.dockerBuildContext, this.fileType);
+            default:
+                // All other files go to the root
+                return path.join(wizardContext.workspaceFolder.uri.fsPath, this.fileType);
         }
     }
 

--- a/src/scaffolding/wizard/ScaffoldFileStep.ts
+++ b/src/scaffolding/wizard/ScaffoldFileStep.ts
@@ -26,7 +26,7 @@ Handlebars.registerHelper('workspaceRelative', (wizardContext: ScaffoldingWizard
 
 Handlebars.registerHelper('contextRelative', (wizardContext: ScaffoldingWizardContext, absolutePath: string, platform: PlatformOS = 'Linux') => {
     return pathNormalize(
-        path.relative(wizardContext.dockerBuildContext as string, absolutePath),
+        path.relative(wizardContext.dockerBuildContext, absolutePath),
         platform
     );
 });

--- a/src/scaffolding/wizard/ScaffoldingWizardContext.ts
+++ b/src/scaffolding/wizard/ScaffoldingWizardContext.ts
@@ -23,6 +23,10 @@ export interface ScaffoldingWizardContext extends IActionContext {
     // A project file (.NET Core), entrypoint file (Python), or package.json (Node). For applicable platforms, guaranteed to be defined after the prompt phase.
     artifact?: string;
 
+    // Additional info that depends on artifact and platform, guaranteed to be defined after the prompt phase.
+    dockerBuildContext?: string;
+    dockerfileDirectory?: string;
+
     // These are calculated depending on platform, with defaults
     version?: string;
     serviceName?: string;

--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import { SemVer } from 'semver';
 import { localize } from '../../../localize';
 import { hasTask } from '../../../tasks/TaskHelper';
@@ -70,11 +71,26 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             wizardContext.serviceName = getValidImageNameFromPath(wizardContext.artifact);
         }
 
+        if (!wizardContext.dockerBuildContext) {
+            // For .NET Core, build context is always at the root
+            wizardContext.dockerBuildContext = wizardContext.workspaceFolder.uri.fsPath;
+        }
+
+        if (!wizardContext.dockerfileDirectory) {
+            // For .NET Core, the Dockerfile is always adjacent the artifact (csproj)
+            wizardContext.dockerfileDirectory = path.dirname(wizardContext.artifact);
+        }
+
         await super.prompt(wizardContext);
     }
 
     public shouldPrompt(wizardContext: NetCoreScaffoldingWizardContext): boolean {
-        return !wizardContext.netCoreAssemblyName || !wizardContext.netCoreRuntimeBaseImage || !wizardContext.netCoreSdkBaseImage || !wizardContext.serviceName;
+        return !wizardContext.netCoreAssemblyName ||
+            !wizardContext.netCoreRuntimeBaseImage ||
+            !wizardContext.netCoreSdkBaseImage ||
+            !wizardContext.serviceName ||
+            !wizardContext.dockerBuildContext ||
+            !wizardContext.dockerfileDirectory;
     }
 
     protected setTelemetry(wizardContext: NetCoreScaffoldingWizardContext): void {

--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -71,26 +71,18 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             wizardContext.serviceName = getValidImageNameFromPath(wizardContext.artifact);
         }
 
-        if (!wizardContext.dockerBuildContext) {
-            // For .NET Core, build context is always at the root
-            wizardContext.dockerBuildContext = wizardContext.workspaceFolder.uri.fsPath;
-        }
-
         if (!wizardContext.dockerfileDirectory) {
             // For .NET Core, the Dockerfile is always adjacent the artifact (csproj)
             wizardContext.dockerfileDirectory = path.dirname(wizardContext.artifact);
         }
 
+        // No need to set dockerBuildContext because the superclass will set it to the proper value (the workspace root)
+
         await super.prompt(wizardContext);
     }
 
     public shouldPrompt(wizardContext: NetCoreScaffoldingWizardContext): boolean {
-        return !wizardContext.netCoreAssemblyName ||
-            !wizardContext.netCoreRuntimeBaseImage ||
-            !wizardContext.netCoreSdkBaseImage ||
-            !wizardContext.serviceName ||
-            !wizardContext.dockerBuildContext ||
-            !wizardContext.dockerfileDirectory;
+        return !wizardContext.netCoreAssemblyName || !wizardContext.netCoreRuntimeBaseImage || !wizardContext.netCoreSdkBaseImage || !wizardContext.serviceName || !wizardContext.dockerfileDirectory;
     }
 
     protected setTelemetry(wizardContext: NetCoreScaffoldingWizardContext): void {

--- a/src/scaffolding/wizard/node/NodeGatherInformationStep.ts
+++ b/src/scaffolding/wizard/node/NodeGatherInformationStep.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import { getValidImageName } from '../../../utils/getValidImageName';
 import { readPackage } from '../../../utils/nodeUtils';
 import { GatherInformationStep } from '../GatherInformationStep';
@@ -38,11 +39,21 @@ export class NodeGatherInformationStep extends GatherInformationStep<NodeScaffol
 
         wizardContext.debugPorts = [9229];
 
+        if (!wizardContext.dockerBuildContext) {
+            // For Node, build context is always adjacent the artifact (package.json)
+            wizardContext.dockerBuildContext = path.dirname(wizardContext.artifact);
+        }
+
+        if (!wizardContext.dockerfileDirectory) {
+            // For .NET Core, the Dockerfile is always adjacent the artifact (package.json)
+            wizardContext.dockerfileDirectory = path.dirname(wizardContext.artifact);
+        }
+
         await super.prompt(wizardContext);
     }
 
     public shouldPrompt(wizardContext: NodeScaffoldingWizardContext): boolean {
-        return !wizardContext.nodeCmdParts || !wizardContext.nodeDebugCmdParts;
+        return !wizardContext.nodeCmdParts || !wizardContext.nodeDebugCmdParts || !wizardContext.dockerBuildContext || !wizardContext.dockerfileDirectory;
     }
 
     protected setTelemetry(wizardContext: NodeScaffoldingWizardContext): void {

--- a/src/tasks/node/NodeTaskHelper.ts
+++ b/src/tasks/node/NodeTaskHelper.ts
@@ -46,6 +46,7 @@ export class NodeTaskHelper implements TaskHelper {
                     context: unresolveWorkspaceFolder(path.dirname(context.dockerfile), context.folder),
                     pull: true
                 },
+                // If the package is at the root, we'll leave it out of the config for brevity, otherwise it must be specified explicitly
                 node: NodeTaskHelper.getNodeOptionsForScaffolding(options?.package, context.folder),
             }
         ];
@@ -71,6 +72,7 @@ export class NodeTaskHelper implements TaskHelper {
                     }
                 },
                 node: {
+                    // If the package is at the root, we'll leave it out of the config for brevity, otherwise it must be specified explicitly
                     ...NodeTaskHelper.getNodeOptionsForScaffolding(options?.package, context.folder),
                     enableDebugging: true
                 },

--- a/src/tasks/node/NodeTaskHelper.ts
+++ b/src/tasks/node/NodeTaskHelper.ts
@@ -5,6 +5,7 @@
 
 import * as path from 'path';
 import { WorkspaceFolder } from 'vscode';
+import { NodeScaffoldingOptions } from '../../debugging/DockerDebugScaffoldingProvider';
 import { Lazy } from '../../utils/lazy';
 import { inferCommand, inferPackageName, InspectMode, NodePackage, readPackage } from '../../utils/nodeUtils';
 import { resolveVariables, unresolveWorkspaceFolder } from '../../utils/resolveVariables';
@@ -34,7 +35,7 @@ export interface NodeRunTaskDefinition extends DockerRunTaskDefinitionBase {
 }
 
 export class NodeTaskHelper implements TaskHelper {
-    public async provideDockerBuildTasks(context: DockerTaskScaffoldContext): Promise<DockerBuildTaskDefinition[]> {
+    public async provideDockerBuildTasks(context: DockerTaskScaffoldContext, options?: NodeScaffoldingOptions): Promise<DockerBuildTaskDefinition[]> {
         return [
             {
                 type: 'docker-build',
@@ -42,21 +43,22 @@ export class NodeTaskHelper implements TaskHelper {
                 platform: 'node',
                 dockerBuild: {
                     dockerfile: unresolveWorkspaceFolder(context.dockerfile, context.folder),
-                    /* eslint-disable-next-line no-template-curly-in-string */
-                    context: '${workspaceFolder}',
+                    context: unresolveWorkspaceFolder(path.dirname(context.dockerfile), context.folder),
                     pull: true
-                }
+                },
+                node: NodeTaskHelper.getNodeOptionsForScaffolding(options?.package, context.folder),
             }
         ];
     }
 
-    public async provideDockerRunTasks(context: DockerTaskScaffoldContext): Promise<DockerRunTaskDefinition[]> {
+    public async provideDockerRunTasks(context: DockerTaskScaffoldContext, options?: NodeScaffoldingOptions): Promise<DockerRunTaskDefinition[]> {
         return [
             {
                 type: 'docker-run',
                 label: 'docker-run: release',
                 dependsOn: ['docker-build'],
-                platform: 'node'
+                platform: 'node',
+                node: NodeTaskHelper.getNodeOptionsForScaffolding(options?.package, context.folder),
             },
             {
                 type: 'docker-run',
@@ -69,8 +71,9 @@ export class NodeTaskHelper implements TaskHelper {
                     }
                 },
                 node: {
+                    ...NodeTaskHelper.getNodeOptionsForScaffolding(options?.package, context.folder),
                     enableDebugging: true
-                }
+                },
             }
         ];
     }
@@ -161,6 +164,17 @@ export class NodeTaskHelper implements TaskHelper {
         } else {
             return path.join(folder.uri.fsPath, 'package.json');
         }
+    }
+
+    public static getNodeOptionsForScaffolding(packagePath: string | undefined, folder: WorkspaceFolder): { package?: string } | undefined {
+        // If the package is at the root, we'll leave it out of the config for brevity, otherwise it must be specified explicitly
+        if (packagePath && path.dirname(packagePath).toLowerCase() !== folder.uri.fsPath.toLowerCase()) {
+            return {
+                package: unresolveWorkspaceFolder(packagePath, folder),
+            };
+        }
+
+        return undefined;
     }
 
     private static inferBuildContextPath(packagePath: string): string {


### PR DESCRIPTION
Fixes #2057. Also makes locating files a little more consistent and puts the platform-specific code for that with the platforms themselves.

Tested:
- [x] Node in subfolder (F5, compose up, debug compose up)
- [x] Node not in subfolder (F5, compose up, debug compose up)
- [x] .NET in subfolder (F5, compose up, debug compose up)
- [x] .NET not in subfolder (F5, compose up, debug compose up)
- [x] Python (F5, compose up, debug compose up)
- [x] Some other platform