### PR TITLE
Remove extension kind from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,6 @@
     "license": "SEE LICENSE IN LICENSE.md",
     "icon": "resources/docker.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
-    "extensionKind": [
-        "workspace",
-        "ui"
-    ],
     "galleryBanner": {
         "color": "#1289B9",
         "theme": "dark"


### PR DESCRIPTION
Fixes #2356, but even better than we expected. IMO the user experience here is the best possible.

When the user first connects to the remote session, the Extensions page directs them to install Docker in the remote (which is what we want almost everybody to do):
![image](https://user-images.githubusercontent.com/36966225/96623228-0cfc5a00-12d9-11eb-8560-9744325f386f.png)

Once they install it in the remote, it starts working right away:
![image](https://user-images.githubusercontent.com/36966225/96623313-2f8e7300-12d9-11eb-82ce-9035de8159b6.png)
![image](https://user-images.githubusercontent.com/36966225/96623342-3ae19e80-12d9-11eb-9b57-01e1d7dfed73.png)
(Notice the name of the image--makes it easy to tell that it's getting this data from Docker on my SSH target)

HOWEVER! Here's the good part that I did not expect. The user can forcibly override it to use UI mode, using the setting:
```json
    "remote.extensionKind": {
        "ms-azuretools.vscode-docker": [
            "ui"
        ]
    }
```

When they apply this setting and reload VSCode, Docker becomes active in UI mode:
![image](https://user-images.githubusercontent.com/36966225/96623512-7c724980-12d9-11eb-8fc0-6bbbb19ca05f.png)
![image](https://user-images.githubusercontent.com/36966225/96623532-83995780-12d9-11eb-9cd1-13f668eb971a.png)
(These are images on my local machine)
