### PR TITLE
Improve extension activation time

### DIFF
--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -118,14 +118,14 @@ export class DockerContextManager implements ContextManager, Disposable {
             if (isNewContextType(currentContext.Type)) {
                 // Currently vscode-docker:aciContext vscode-docker:newSdkContext mean the same thing
                 // But that probably won't be true in the future, so define both as separate concepts now
-                await this.setVsCodeContext('vscode-docker:aciContext', true);
-                await this.setVsCodeContext('vscode-docker:newSdkContext', true);
+                this.setVsCodeContext('vscode-docker:aciContext', true);
+                this.setVsCodeContext('vscode-docker:newSdkContext', true);
 
                 const dsc = await import('./DockerServeClient/DockerServeClient');
                 ext.dockerClient = new dsc.DockerServeClient(currentContext);
             } else {
-                await this.setVsCodeContext('vscode-docker:aciContext', false);
-                await this.setVsCodeContext('vscode-docker:newSdkContext', false);
+                this.setVsCodeContext('vscode-docker:aciContext', false);
+                this.setVsCodeContext('vscode-docker:newSdkContext', false);
 
                 const dockerode = await import('./DockerodeApiClient/DockerodeApiClient');
                 ext.dockerClient = new dockerode.DockerodeApiClient(currentContext);
@@ -204,7 +204,7 @@ export class DockerContextManager implements ContextManager, Disposable {
 
             if (dockerHostEnv !== undefined) {
                 actionContext.telemetry.properties.hostProtocol = new URL(dockerHostEnv).protocol;
-                await this.setVsCodeContext('vscode-docker:contextLocked', true);
+                this.setVsCodeContext('vscode-docker:contextLocked', true);
 
                 return [{
                     ...defaultContext,
@@ -254,9 +254,9 @@ export class DockerContextManager implements ContextManager, Disposable {
             }
 
             if (dockerContextEnv) {
-                await this.setVsCodeContext('vscode-docker:contextLocked', true);
+                this.setVsCodeContext('vscode-docker:contextLocked', true);
             } else {
-                await this.setVsCodeContext('vscode-docker:contextLocked', false);
+                this.setVsCodeContext('vscode-docker:contextLocked', false);
             }
 
             return result;
@@ -294,12 +294,12 @@ export class DockerContextManager implements ContextManager, Disposable {
             }
 
             // Set the VSCode context to the result (which may expose commands, etc.)
-            await this.setVsCodeContext('vscode-docker:newCliPresent', result);
+            this.setVsCodeContext('vscode-docker:newCliPresent', result);
             return result;
         } catch { } // Best effort
     }
 
-    private async setVsCodeContext(vsCodeContext: VSCodeContext, value: boolean): Promise<void> {
-        return commands.executeCommand('setContext', vsCodeContext, value);
+    private setVsCodeContext(vsCodeContext: VSCodeContext, value: boolean): void {
+        void commands.executeCommand('setContext', vsCodeContext, value);
     }
 }

--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -193,7 +193,7 @@ export class DockerContextManager implements ContextManager, Disposable {
                 actionContext.telemetry.properties.hostSource = 'docker.context';
             } else if ((dockerContextEnv = process.env.DOCKER_CONTEXT)) { // Assignment + check is intentional
                 actionContext.telemetry.properties.hostSource = 'envContext';
-            } else if (!fse.pathExistsSync(dockerContextsFolder) || fse.readdirSync(dockerContextsFolder).length === 0) { // Sync is intentionally used for performance
+            } else if (!fse.pathExistsSync(dockerContextsFolder) || fse.readdirSync(dockerContextsFolder).length === 0) { // Sync is intentionally used for performance, this is on the activation code path
                 // If there's nothing inside ~/.docker/contexts/meta, then there's only the default, unmodifiable DOCKER_HOST-based context
                 // It is unnecessary to call `docker context inspect`
                 actionContext.telemetry.properties.hostSource = 'defaultContextOnly';

--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -193,7 +193,7 @@ export class DockerContextManager implements ContextManager, Disposable {
                 actionContext.telemetry.properties.hostSource = 'docker.context';
             } else if ((dockerContextEnv = process.env.DOCKER_CONTEXT)) { // Assignment + check is intentional
                 actionContext.telemetry.properties.hostSource = 'envContext';
-            } else if (!(await fse.pathExists(dockerContextsFolder)) || (await fse.readdir(dockerContextsFolder)).length === 0) {
+            } else if (!fse.pathExistsSync(dockerContextsFolder) || fse.readdirSync(dockerContextsFolder).length === 0) { // Sync is intentionally used for performance
                 // If there's nothing inside ~/.docker/contexts/meta, then there's only the default, unmodifiable DOCKER_HOST-based context
                 // It is unnecessary to call `docker context inspect`
                 actionContext.telemetry.properties.hostSource = 'defaultContextOnly';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as assert from 'assert';
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
@@ -31,7 +30,6 @@ import { AzureAccountExtensionListener } from './utils/AzureAccountExtensionList
 import { cryptoUtils } from './utils/cryptoUtils';
 import { Keytar } from './utils/keytar';
 import { isLinux, isMac, isWindows } from './utils/osUtils';
-import { bufferToString } from './utils/spawnAsync';
 
 export type KeyInfo = { [keyName: string]: string };
 
@@ -162,8 +160,9 @@ async function getDockerInstallationIDHash(): Promise<string> {
                 installIdFilePath = path.join(os.homedir(), 'Library', 'Group Containers', 'group.com.docker', 'userId');
             }
 
-            if (installIdFilePath && await fse.pathExists(installIdFilePath)) {
-                let result = bufferToString(await fse.readFile(installIdFilePath));
+            // Sync is intentionally used for performance
+            if (installIdFilePath && fse.pathExistsSync(installIdFilePath)) {
+                let result = fse.readFileSync(installIdFilePath, 'utf-8');
                 result = cryptoUtils.hashString(result);
                 await ext.context.globalState.update('docker.installIdHash', result);
                 return result;
@@ -250,7 +249,6 @@ function activateLanguageClient(ctx: vscode.ExtensionContext): void {
                 "server.js"
             )
         );
-        assert(true === await fse.pathExists(serverModule), "Could not find language client module");
 
         let debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,7 +160,7 @@ async function getDockerInstallationIDHash(): Promise<string> {
                 installIdFilePath = path.join(os.homedir(), 'Library', 'Group Containers', 'group.com.docker', 'userId');
             }
 
-            // Sync is intentionally used for performance
+            // Sync is intentionally used for performance, this is on the activation code path
             if (installIdFilePath && fse.pathExistsSync(installIdFilePath)) {
                 let result = fse.readFileSync(installIdFilePath, 'utf-8');
                 result = cryptoUtils.hashString(result);


### PR DESCRIPTION
Fixes #2371.

This covers:
- [x] Get Docker ID (this is already a one-time penalty, it's cached from then on)
- [x] Filesystem checks for Docker context paths
- [x] Setting the VSCode contexts
- [ ] Don't wait on Docker context loading at all?? Can that be done without substantial refactoring?

In the most common case (no Docker contexts, therefore don't need to run CLI), the remaining time spent on activation is mostly dominated (~75%) by Dockerode loading. Nevertheless that will stay as-is; it was an improvement to lazy load the Docker client provider.