### PR TITLE
Use `python3` as the Python path within containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.8.1 - 18 November 2020
 ### Fixed
-* This update fixes an issue that prevented debugging Python applications in Docker containers. The latest version of the Python extension is also required. [#2455](https://github.com/microsoft/vscode-docker/issues/2455)
+* This update fixes an issue that prevented debugging Python applications in Docker containers. The latest version of the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) is also required. [#2455](https://github.com/microsoft/vscode-docker/issues/2455)
 * Fixed an issue where the logo was hard to see in the [extension gallery page](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) in the browser. [#2499](https://github.com/microsoft/vscode-docker/issues/2499)
 
 ## 1.8.0 - 16 November 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.8.1 - 17 November 2020
+## 1.8.1 - 18 November 2020
 ### Fixed
 * This update fixes an issue that prevented debugging Python applications in Docker containers. The latest version of the Python extension is also required. [#2455](https://github.com/microsoft/vscode-docker/issues/2455)
 * Fixed an issue where the logo was hard to see in the [extension gallery page](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) in the browser. [#2499](https://github.com/microsoft/vscode-docker/issues/2499)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.8.1 - 18 November 2020
+## 1.8.1 - 23 November 2020
 ### Fixed
 * This update fixes an issue that prevented debugging Python applications in Docker containers. The latest version of the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) is also required. [#2455](https://github.com/microsoft/vscode-docker/issues/2455)
 * Fixed an issue where the logo was hard to see in the [extension gallery page](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) in the browser. [#2499](https://github.com/microsoft/vscode-docker/issues/2499)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.8.1 - 17 November 2020
 ### Fixed
 * This update fixes an issue that prevented debugging Python applications in Docker containers. The latest version of the Python extension is also required. [#2455](https://github.com/microsoft/vscode-docker/issues/2455)
+* Fixed an issue where the logo was hard to see in the [extension gallery page](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) in the browser. [#2499](https://github.com/microsoft/vscode-docker/issues/2499)
 
 ## 1.8.0 - 16 November 2020
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.1 - 17 November 2020
+### Fixed
+* This update fixes an issue that prevented debugging Python applications in Docker containers. The latest version of the Python extension is also required. [#2455](https://github.com/microsoft/vscode-docker/issues/2455)
+
 ## 1.8.0 - 16 November 2020
 ### Added
 * Added a read-only file explorer for running containers, this can be seen in the Docker Explorer tab. [#2333](https://github.com/microsoft/vscode-docker/issues/2333)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-docker",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "icon": "resources/docker_blue.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "galleryBanner": {
-        "color": "#1289B9",
+        "color": "#1e1e1e",
         "theme": "dark"
     },
     "categories": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-docker",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "publisher": "ms-azuretools",
     "displayName": "Docker",
     "description": "Makes it easy to create, manage, and debug containerized applications.",

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -105,17 +105,17 @@ export class PythonDebugHelper implements DebugHelper {
 
             /* eslint-disable no-template-curly-in-string */
             // These settings control what Python interpreter gets used in what circumstance.
-            // debugAdapterPython controls the interpreter used to launch the adapter, on the local client
+            // debugAdapterPython controls the interpreter used by the Python extension to start the debug adapter, on the local client
             // We want it to use what it would normally use for local Python debugging, i.e. the chosen local interpreter
             debugAdapterPython: '${command:python.interpreterPath}',
 
-            // debugLauncherPython controls the interpreter used to launch the launcher, also on the local client
+            // debugLauncherPython controls the interpreter used by the debug adapter to start the launcher, also on the local client
             // We want it to use what it would normally use for local Python debugging, i.e. the chosen local interpreter
             // This actually launches our launcher in resources/python/launcher.py, which uses `docker exec -d <containerId> python3 /debugpy/launcher ...` to launch the real debugpy launcher in the container
             debugLauncherPython: '${command:python.interpreterPath}',
             /* eslint-enable no-template-curly-in-string */
 
-            // python controls the interpreter used to launch the application itself
+            // python controls the interpreter used by the launcher to start the application itself
             // Since this is in the container it should always use `python3`
             python: 'python3',
         };

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -102,7 +102,22 @@ export class PythonDebugHelper implements DebugHelper {
             redirectOutput: debugConfiguration.redirectOutput || true,
             args: args,
             cwd: '.',
-            python: 'python3', // This controls what Python path gets used by the launcher to launch the debuggee. In a container we should always use `python3` to launch it.
+
+            /* eslint-disable no-template-curly-in-string */
+            // These settings control what Python interpreter gets used in what circumstance.
+            // debugAdapterPython controls the interpreter used to launch the adapter, on the local client
+            // We want it to use what it would normally use for local Python debugging, i.e. the chosen local interpreter
+            debugAdapterPython: '${command:python.interpreterPath}',
+
+            // debugLauncherPython controls the interpreter used to launch the launcher, also on the local client
+            // We want it to use what it would normally use for local Python debugging, i.e. the chosen local interpreter
+            // This actually launches our launcher in resources/python/launcher.py, which uses `docker exec -d <containerId> python3 /debugpy/launcher ...` to launch the real debugpy launcher in the container
+            debugLauncherPython: '${command:python.interpreterPath}',
+            /* eslint-enable no-template-curly-in-string */
+
+            // python controls the interpreter used to launch the application itself
+            // Since this is in the container it should always use `python3`
+            python: 'python3',
         };
     }
 

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -101,7 +101,8 @@ export class PythonDebugHelper implements DebugHelper {
             program: debugConfiguration.file || pythonRunTaskOptions.file,
             redirectOutput: debugConfiguration.redirectOutput || true,
             args: args,
-            cwd: '.'
+            cwd: '.',
+            python: 'python3', // This controls what Python path gets used by the launcher to launch the debuggee. In a container we should always use `python3` to launch it.
         };
     }
 

--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -253,7 +253,7 @@ export class DockerContextManager implements ContextManager, Disposable {
 
             try {
                 if (isNewContextType(currentContext.ContextType)) {
-                    actionContext.telemetry.properties.hostProtocol = currentContext.ContextType
+                    actionContext.telemetry.properties.hostProtocol = currentContext.ContextType;
                 } else {
                     actionContext.telemetry.properties.hostProtocol = new URL(currentContext.DockerEndpoint).protocol;
                 }

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -36,7 +36,7 @@ export namespace PythonExtensionHelper {
 
     export async function getPythonExtension(): Promise<vscode.Extension<PythonExtensionAPI>> | undefined {
         const pyExtensionId = 'ms-python.python';
-        const minPyExtensionVersion = new semver.SemVer('2020.5.78807'); // TODO
+        const minPyExtensionVersion = new semver.SemVer('2020.11.0');
 
         const pyExt = vscode.extensions.getExtension(pyExtensionId);
         const button = localize('vscode-docker.tasks.pythonExt.openExtension', 'Open Extension');

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -36,7 +36,7 @@ export namespace PythonExtensionHelper {
 
     export async function getPythonExtension(): Promise<vscode.Extension<PythonExtensionAPI>> | undefined {
         const pyExtensionId = 'ms-python.python';
-        const minPyExtensionVersion = new semver.SemVer('2020.11.358366027'); // One patch version # higher than the just-released, still-affected build
+        const minPyExtensionVersion = new semver.SemVer('2020.11.367453362');
 
         const pyExt = vscode.extensions.getExtension(pyExtensionId);
         const button = localize('vscode-docker.tasks.pythonExt.openExtension', 'Open Extension');

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -36,7 +36,7 @@ export namespace PythonExtensionHelper {
 
     export async function getPythonExtension(): Promise<vscode.Extension<PythonExtensionAPI>> | undefined {
         const pyExtensionId = 'ms-python.python';
-        const minPyExtensionVersion = new semver.SemVer('2020.11.0');
+        const minPyExtensionVersion = new semver.SemVer('2020.11.358366027'); // One patch version # higher than the just-released, still-affected build
 
         const pyExt = vscode.extensions.getExtension(pyExtensionId);
         const button = localize('vscode-docker.tasks.pythonExt.openExtension', 'Open Extension');

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -36,7 +36,7 @@ export namespace PythonExtensionHelper {
 
     export async function getPythonExtension(): Promise<vscode.Extension<PythonExtensionAPI>> | undefined {
         const pyExtensionId = 'ms-python.python';
-        const minPyExtensionVersion = new semver.SemVer('2020.5.78807');
+        const minPyExtensionVersion = new semver.SemVer('2020.5.78807'); // TODO
 
         const pyExt = vscode.extensions.getExtension(pyExtensionId);
         const button = localize('vscode-docker.tasks.pythonExt.openExtension', 'Open Extension');


### PR DESCRIPTION
According to [this comment](https://github.com/microsoft/vscode-docker/issues/2455#issuecomment-724267419), this should be the changes needed on the Docker side to fix #2455.

@int19h, if I understand the flow correctly, I think that the Python extension handles `debugAdapterPython` and `debugLauncherPython`. The `debugLauncherPython` Python interpreter will start our "launcher", which then unconditionally uses `python3` to start the real debugpy launcher inside the container: https://github.com/microsoft/vscode-docker/blob/master/resources/python/launcher.py#L17

Then, using the `"python": "python3"` option in this PR, the launcher inside the container uses `python3` to launch the app, which is what is desired.

Does all this sound right?