### PR TITLE
Replace ADD with COPY

### DIFF
--- a/resources/templates/python/Dockerfile.template
+++ b/resources/templates/python/Dockerfile.template
@@ -18,11 +18,11 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 # Install pip requirements
-ADD requirements.txt .
+COPY requirements.txt .
 RUN python -m pip install -r requirements.txt
 
 WORKDIR /app
-ADD . /app
+COPY . /app
 
 {{#unless (isRootPort ports)}}
 # Switching to a non-root user, please refer to https://aka.ms/vscode-docker-python-user-rights


### PR DESCRIPTION
Hi,

Docker docs [suggests](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy) to use COPY for files and directories that do not require ADD’s tar auto-extraction capability. So there is a little change.