### PR TITLE
Fix codicons root path in bundled extension

### DIFF
--- a/src/commands/startPage/StartPage.ts
+++ b/src/commands/startPage/StartPage.ts
@@ -29,7 +29,10 @@ class StartPage {
 
     public async createOrShow(context: IActionContext): Promise<void> {
         const resourcesRoot = vscode.Uri.joinPath(ext.context.extensionUri, 'resources');
-        const codiconsRoot = vscode.Uri.joinPath(ext.context.extensionUri, 'node_modules', 'vscode-codicons', 'dist');
+
+        // If we're using the bundled version, the codicons root URI is at <extensionRoot>/dist/node_modules/vscode-codicons/dist
+        // If we're not using the bundled version, the codicons root URI is <extensionRoot>/node_modules/vscode-codicons/dist
+        const codiconsRoot = vscode.Uri.joinPath(ext.context.extensionUri, ...ext.ignoreBundle ? ['node_modules'] : ['dist', 'node_modules'], 'vscode-codicons', 'dist');
 
         if (!this.activePanel) {
             this.activePanel = vscode.window.createWebviewPanel(


### PR DESCRIPTION
Fixes an issue where the codicons were not showing up in the bundled extension:
![image](https://user-images.githubusercontent.com/36966225/98690044-84526600-233a-11eb-9385-d9550eb8f8e6.png)

With the fix:
![image](https://user-images.githubusercontent.com/36966225/98690093-93391880-233a-11eb-883d-820f4d311796.png)
