### PR TITLE
Try, try again (with different Windows users)

### DIFF
--- a/src/docker/files/ContainerFilesUtils.ts
+++ b/src/docker/files/ContainerFilesUtils.ts
@@ -336,9 +336,13 @@ async function statWindowsContainerFile(executor: DockerContainerExecutor, itemP
     const command = ['cmd', '/C', `wmic datafile where "name='${name}'" get ${CreationDate}, ${FileSize}, ${LastModified} /format:list`];
 
     try {
-        const result = await executor(command);
+        const parsedResult = await tryWithItems(
+            users,
+            async user => {
+                const result = await executor(command, user);
 
-        const parsedResult = parseWmiList(result);
+                return parseWmiList(result);
+            });
 
         if (parsedResult) {
             return {

--- a/src/docker/files/ContainerFilesUtils.ts
+++ b/src/docker/files/ContainerFilesUtils.ts
@@ -180,7 +180,7 @@ export async function listWindowsContainerDirectory(executor: DockerContainerExe
 
     const output = await tryWithItems(
         users,
-        user => executor(command, user));
+        async user => await executor(command, user));
 
     return parseWindowsDirectoryItems(output, parentPath);
 }


### PR DESCRIPTION
Updates the `stat()` metadata retrieval calls for Windows containers to retry their calls using different Docker users if the preceding call fails or does not return any data.  Resolves an issues seen on some containers where we were able to list a directory/file (e.g. because we already have retries in that logic) but then not be able to get its metadata.