### PR TITLE
Improve messaging for invalid URL error

### DIFF
--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -228,8 +228,8 @@ export class DockerContextManager implements ContextManager, Disposable {
                 } catch (err) {
                     // If URL parsing fails, let's catch it and give a better error message
                     const message = actionContext.telemetry.properties.hostSource === 'docker.host' ?
-                        localize('vscode-docker.docker.contextManager.invalidHostSetting', 'The value provided for the setting `docker.host` is invalid. It must include the protocol, for example, ssh://myuser@1.2.3.4, or tcp://1.2.3.4.') :
-                        localize('vscode-docker.docker.contextManager.invalidHostEnv', 'The value provided for the environment variable `DOCKER_HOST` is invalid. It must include the protocol, for example, ssh://myuser@1.2.3.4, or tcp://1.2.3.4.');
+                        localize('vscode-docker.docker.contextManager.invalidHostSetting', 'The value provided for the setting `docker.host` is invalid. It must include the protocol, for example, ssh://myuser@1.2.3.4 or tcp://1.2.3.4.') :
+                        localize('vscode-docker.docker.contextManager.invalidHostEnv', 'The value provided for the environment variable `DOCKER_HOST` is invalid. It must include the protocol, for example, ssh://myuser@1.2.3.4 or tcp://1.2.3.4.');
                     const button = localize('vscode-docker.docker.contextManager.openSettings', 'Open Settings');
 
                     void window.showErrorMessage(message, button)

--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -9,9 +9,9 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import { URL } from 'url';
-import { commands, Event, EventEmitter, workspace } from 'vscode';
+import { commands, Event, EventEmitter, window, workspace } from 'vscode';
 import { Disposable } from 'vscode';
-import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
+import { callWithTelemetryAndErrorHandling, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { AsyncLazy } from '../utils/lazy';
@@ -222,7 +222,26 @@ export class DockerContextManager implements ContextManager, Disposable {
             }
 
             if (dockerHostEnv !== undefined) {
-                actionContext.telemetry.properties.hostProtocol = new URL(dockerHostEnv).protocol;
+                try {
+                    // This will try to parse the URL, using the same logic docker-modem does
+                    actionContext.telemetry.properties.hostProtocol = new URL(dockerHostEnv).protocol;
+                } catch {
+                    // If URL parsing fails, let's catch it and give a better error message, and rethrow as user cancelled
+                    const message = actionContext.telemetry.properties.hostSource === 'docker.host' ?
+                        localize('vscode-docker.docker.contextManager.invalidHostSetting', 'The value provided for the setting `docker.host` is invalid. It must include the protocol, for example, ssh://myuser@1.2.3.4, or tcp://1.2.3.4.') :
+                        localize('vscode-docker.docker.contextManager.invalidHostEnv', 'The value provided for the environment variable `DOCKER_HOST` is invalid. It must include the protocol, for example, ssh://myuser@1.2.3.4, or tcp://1.2.3.4.');
+                    const button = localize('vscode-docker.docker.contextManager.openSettings', 'Open Settings');
+
+                    void window.showErrorMessage(message, button)
+                        .then((result: string) => {
+                            if (result === button) {
+                                void commands.executeCommand('workbench.action.openSettings', 'docker.host');
+                            }
+                        });
+
+                    throw new UserCancelledError();
+                }
+
                 this.setVsCodeContext('vscode-docker:contextLocked', true);
 
                 return [{


### PR DESCRIPTION
Fixes #2541. @ucheNkadiCode what do you think of the below?

Depending on whether the problem is with `DOCKER_HOST` env var or `docker.host` setting, a different message will be shown. In both cases, an "Open Settings" button is shown that takes the user directly to the `docker.host` setting.

![image](https://user-images.githubusercontent.com/36966225/101179108-d58f0600-3617-11eb-90e2-b9b6439317a6.png)
![image](https://user-images.githubusercontent.com/36966225/101179146-dd4eaa80-3617-11eb-9b48-76cf1fcfa42f.png)

Settings page opened to `docker.host`:
![image](https://user-images.githubusercontent.com/36966225/101179193-eb043000-3617-11eb-81ba-06c7c435b60e.png)
