### PR TITLE
Allow users to download container files

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "onCommand:vscode-docker.containers.attachShell",
         "onCommand:vscode-docker.containers.browse",
         "onCommand:vscode-docker.containers.configureExplorer",
+        "onCommand:vscode-docker.containers.downloadFile",
         "onCommand:vscode-docker.containers.inspect",
         "onCommand:vscode-docker.containers.openFile",
         "onCommand:vscode-docker.containers.prune",
@@ -128,6 +129,10 @@
     "contributes": {
         "menus": {
             "commandPalette": [
+                {
+                    "command": "vscode-docker.containers.downloadFile",
+                    "when": "never"
+                },
                 {
                     "command": "vscode-docker.containers.openFile",
                     "when": "never"
@@ -380,6 +385,10 @@
                     "command": "vscode-docker.containers.start",
                     "when": "view == dockerContainers && viewItem =~ /^(created|dead|exited|paused|terminated)Container$/i",
                     "group": "containers_1_general@5"
+                },
+                {
+                    "command": "vscode-docker.containers.downloadFile",
+                    "when": "view == dockerContainers && viewItem == containerFile"
                 },
                 {
                     "command": "vscode-docker.containers.openFile",
@@ -2211,6 +2220,11 @@
                     "light": "resources/light/settings.svg",
                     "dark": "resources/dark/settings.svg"
                 }
+            },
+            {
+                "command": "vscode-docker.containers.downloadFile",
+                "title": "%vscode-docker.commands.containers.downloadFile%",
+                "category": "%vscode-docker.commands.category.dockerContainers%"
             },
             {
                 "command": "vscode-docker.containers.inspect",

--- a/package.nls.json
+++ b/package.nls.json
@@ -193,6 +193,7 @@
     "vscode-docker.commands.containers.attachShell": "Attach Shell",
     "vscode-docker.commands.containers.browse": "Open in Browser",
     "vscode-docker.commands.containers.configureExplorer": "Configure Explorer...",
+    "vscode-docker.commands.containers.downloadFile": "Download",
     "vscode-docker.commands.containers.inspect": "Inspect",
     "vscode-docker.commands.containers.openFile": "Open",
     "vscode-docker.commands.containers.prune": "Prune...",

--- a/src/commands/containers/files/downloadContainerFile.ts
+++ b/src/commands/containers/files/downloadContainerFile.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../../../extensionVariables';
+import { localize } from '../../../localize';
+import { FileTreeItem } from '../../../tree/containers/files/FileTreeItem';
+import { multiSelectNodes } from '../../../utils/multiSelectNodes';
+
+export async function downloadContainerFile(context: IActionContext, node?: FileTreeItem, nodes?: FileTreeItem[]): Promise<void> {
+    nodes = await multiSelectNodes(
+        { ...context, noItemFoundErrorMessage: localize('vscode-docker.commands.containers.files.downloadContainerFile.noFiles', 'No files are available to download.') },
+        ext.containersTree,
+        'containerFile',
+        node,
+        nodes
+    );
+
+    const localFolderUris = await vscode.window.showOpenDialog(
+        {
+            canSelectFiles: false,
+            canSelectFolders: true,
+            canSelectMany: false,
+            openLabel: localize('vscode-docker.commands.containers.files.downloadContainerFile.openLabel', 'Select'),
+            title: localize('vscode-docker.commands.containers.files.downloadContainerFile.openTitle', 'Select folder for download')
+        });
+
+    await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            title: localize('vscode-docker.commands.containers.files.downloadContainerFile.opening', 'Downloading File(s)...')
+        },
+        async () => {
+            await Promise.all(
+                nodes.map(
+                    async n => {
+                        const containerFileUri = node.uri;
+                        const filePath = containerFileUri.path;
+                        const fileName = path.posix.basename(filePath);
+                        const localFileUri = vscode.Uri.joinPath(localFolderUris[0], fileName);
+
+                        const content = await vscode.workspace.fs.readFile(containerFileUri.uri);
+
+                        await vscode.workspace.fs.writeFile(localFileUri, content);
+                    }));
+        });
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -14,6 +14,7 @@ import { attachShellContainer } from "./containers/attachShellContainer";
 import { browseContainer } from "./containers/browseContainer";
 import { composeGroupDown, composeGroupLogs, composeGroupRestart } from "./containers/composeGroup";
 import { configureContainersExplorer } from "./containers/configureContainersExplorer";
+import { downloadContainerFile } from "./containers/files/downloadContainerFile";
 import { openContainerFile } from "./containers/files/openContainerFile";
 import { inspectContainer } from "./containers/inspectContainer";
 import { pruneContainers } from "./containers/pruneContainers";
@@ -121,6 +122,7 @@ export function registerCommands(): void {
 
     registerWorkspaceCommand('vscode-docker.containers.attachShell', attachShellContainer);
     registerCommand('vscode-docker.containers.browse', browseContainer);
+    registerCommand('vscode-docker.containers.downloadFile', downloadContainerFile);
     registerCommand('vscode-docker.containers.inspect', inspectContainer);
     registerCommand('vscode-docker.containers.configureExplorer', configureContainersExplorer);
     registerCommand('vscode-docker.containers.openFile', openContainerFile);


### PR DESCRIPTION
Currently users can open (text) files of running containers in the VS Code editor.  This change adds a new download command that, like in VS, allows the user to instead extract files from running containers and save them in a user-selected local folder.  Multiple files can be downloaded at a given time.  If the file already exists in the selected folder, the user will be prompted to skip that file, overwrite that file, or to cancel any remaining download.

Resolves #2466.