### PR TITLE
Upgrade to language server 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3809,51 +3809,41 @@
             }
         },
         "dockerfile-ast": {
-            "version": "0.0.27",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.27.tgz",
-            "integrity": "sha512-U+1B6aA7qJw9hswL6rCg4/dHnXy+zmt1bwU6ONi+f+0w0AOSmrz4IcrZQu62g1RD+NoTO4dvJce3FjoXUHd9Dw==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.1.0.tgz",
+            "integrity": "sha512-qKftHMVoMliYBaYLkgttm+NXhRISVNkIMfAL4ecmXjiWRElfdfY+xNgITiehG0LpUEDbFUa/UDCByYq/2UZIpQ==",
             "requires": {
-                "vscode-languageserver-types": "^3.15.1"
+                "vscode-languageserver-types": "^3.16.0"
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.1.1.tgz",
-            "integrity": "sha512-oGWWKH7UzTulQDqvbONC4cGw8Zw43PnBXN2r3msXacV61n9YnrnbnqIJavl5zCrKEPLcu30rogMkNmrRBNNfJQ==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.2.0.tgz",
+            "integrity": "sha512-D6qT5w2y73pF02c+caAPYn/IG7T/231u8WD/qfyt3MBtnRe8x7ZIQK9+VAxFYvCtqbGuN7MiPVoRctkth/jcuA==",
             "requires": {
-                "dockerfile-language-service": "0.1.0",
-                "dockerfile-utils": "0.1.0",
-                "vscode-languageserver": "^6.1.1"
+                "dockerfile-language-service": "0.1.1",
+                "dockerfile-utils": "0.1.1",
+                "vscode-languageserver": "^7.0.0"
             }
         },
         "dockerfile-language-service": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.1.0.tgz",
-            "integrity": "sha512-vvFBLvQ/4RE5JyPzI1EynvT5h6Mg/jJ8HUcMs53uyfjy3RbaGeUL5c0eN6mk39WVF2Y8fsH1FKo4L29Z/W4N6g==",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.1.1.tgz",
+            "integrity": "sha512-Lw4QlxJoy9F1559wxX+0xe5iSNK95Fbzx/YhdmAzfwgbPvdPzvFouIuuMyMPj/Q5JyFH1QAr7VeagOe24w0cqg==",
             "requires": {
-                "dockerfile-ast": "0.0.27",
-                "dockerfile-utils": "0.1.0",
-                "vscode-languageserver-protocol": "^3.15.3",
-                "vscode-languageserver-types": "^3.15.1"
+                "dockerfile-ast": "0.1.0",
+                "dockerfile-utils": "0.1.1",
+                "vscode-languageserver-protocol": "^3.16.0",
+                "vscode-languageserver-types": "^3.16.0"
             }
         },
         "dockerfile-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.1.0.tgz",
-            "integrity": "sha512-eHDiSOSXzXaFTwp7UX+bMVKUDQd2E2x8IF/3xdSvNkGhBliRhjwLIL+ALLDmi8GqSlm+7xwc4mGLcvtCI668PQ==",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.1.1.tgz",
+            "integrity": "sha512-ddAA8PCAcT4pBQ1AFRnPjetJ31/7BqNKLHQkZebNE0hBAiOr8SzrnIWvJUcBDHrVbASCVl1Ye37hbaTsUmYHsw==",
             "requires": {
-                "dockerfile-ast": "0.0.28",
-                "vscode-languageserver-types": "3.15.1"
-            },
-            "dependencies": {
-                "dockerfile-ast": {
-                    "version": "0.0.28",
-                    "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.28.tgz",
-                    "integrity": "sha512-221P0R4+tx5C1ra99alQxmdRvtfKMbBE7MkESN4VEBN5CX90wijrcIg+EiRaGTCCT5OPk5KBeKy+EIOnmEu4xA==",
-                    "requires": {
-                        "vscode-languageserver-types": "^3.15.1"
-                    }
-                }
+                "dockerfile-ast": "0.1.0",
+                "vscode-languageserver-types": "^3.16.0"
             }
         },
         "dockerode": {
@@ -12813,47 +12803,59 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
-            "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
         },
         "vscode-languageclient": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.3.tgz",
-            "integrity": "sha512-YciJxk08iU5LmWu7j5dUt9/1OLjokKET6rME3cI4BRpiF6HZlusm2ZwPt0MYJ0lV5y43sZsQHhyon2xBg4ZJVA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
             "requires": {
-                "semver": "^6.3.0",
-                "vscode-languageserver-protocol": "^3.15.3"
+                "minimatch": "^3.0.4",
+                "semver": "^7.3.4",
+                "vscode-languageserver-protocol": "3.16.0"
             },
             "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                    "version": "7.3.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
                 }
             }
         },
         "vscode-languageserver": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz",
-            "integrity": "sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
             "requires": {
-                "vscode-languageserver-protocol": "^3.15.3"
+                "vscode-languageserver-protocol": "3.16.0"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.15.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz",
-            "integrity": "sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
             "requires": {
-                "vscode-jsonrpc": "^5.0.1",
-                "vscode-languageserver-types": "3.15.1"
+                "vscode-jsonrpc": "6.0.0",
+                "vscode-languageserver-types": "3.16.0"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
-            "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
         "vscode-nls": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -2788,7 +2788,7 @@
         "@docker/sdk": "^1.0.3",
         "@grpc/grpc-js": "^1.2.2",
         "dayjs": "^1.9.7",
-        "dockerfile-language-server-nodejs": "^0.1.1",
+        "dockerfile-language-server-nodejs": "^0.2.0",
         "dockerode": "^3.2.1",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.6",
@@ -2800,7 +2800,7 @@
         "tar": "^6.0.5",
         "vscode-azureappservice": "^0.72.1",
         "vscode-azureextensionui": "^0.38.2",
-        "vscode-languageclient": "^6.1.3",
+        "vscode-languageclient": "^7.0.0",
         "vscode-nls": "^5.0.0",
         "vscode-tas-client": "^0.1.15",
         "xml2js": "^0.4.23"

--- a/src/docker/ContextChangeCancelClient.ts
+++ b/src/docker/ContextChangeCancelClient.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable } from 'vscode';
+import { CancellationToken, Disposable } from 'vscode';
 import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
-import { CancellationToken } from 'vscode-languageclient';
 import { CancellationPromiseSource, getCancelPromise, TimeoutPromiseSource } from '../utils/promiseUtils';
 
 export abstract class ContextChangeCancelClient implements Disposable {

--- a/src/docker/DockerApiClient.ts
+++ b/src/docker/DockerApiClient.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable } from 'vscode';
+import { CancellationToken, Disposable } from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
-import { CancellationToken } from 'vscode-languageclient';
 import { DockerInfo, DockerOSType, PruneResult } from './Common';
 import { DockerContainer, DockerContainerInspection } from './Containers';
 import { DockerImage, DockerImageInspection } from './Images';

--- a/src/docker/DockerodeApiClient/DockerodeApiClient.ts
+++ b/src/docker/DockerodeApiClient/DockerodeApiClient.ts
@@ -6,8 +6,8 @@
 import Dockerode = require('dockerode');
 import * as stream from 'stream';
 import * as tar from 'tar';
+import { CancellationToken } from 'vscode';
 import { IActionContext, parseError } from 'vscode-azureextensionui';
-import { CancellationToken } from 'vscode-languageclient';
 import { localize } from '../../localize';
 import { addDockerSettingsToEnv } from '../../utils/addDockerSettingsToEnv';
 import { cloneObject } from '../../utils/cloneObject';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzureUserInput, callWithTelemetryAndErrorHandling, createAzExtOutputChannel, createExperimentationService, IActionContext, registerUIExtensionVariables, UserCancelledError } from 'vscode-azureextensionui';
-import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient/lib/main';
+import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 import * as tas from 'vscode-tas-client';
 import { registerCommands } from './commands/registerCommands';
 import { openStartPageAfterExtensionUpdate } from './commands/startPage/openStartPage';

--- a/src/utils/promiseUtils.ts
+++ b/src/utils/promiseUtils.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode';
 import { UserCancelledError } from 'vscode-azureextensionui';
-import { Disposable } from 'vscode-languageclient';
 import { localize } from '../localize';
 
 export async function delay(ms: number, token?: vscode.CancellationToken): Promise<void> {
@@ -63,7 +62,7 @@ export class TimeoutPromiseSource implements vscode.Disposable {
         this.emitter = new vscode.EventEmitter<void>();
     }
 
-    public onTimeout(callback: () => void): Disposable {
+    public onTimeout(callback: () => void): vscode.Disposable {
         return this.emitter.event(callback);
     }
 


### PR DESCRIPTION
This new release depends on `vscode-languageclient` 7.0.0 which has introduced some API changes. It seems like it no longer re-exports some VS Code API types so I've changed imports from `vscode-languageclient` to `vscode` where applicable.

This update to 0.2.0 brings two small fixes to the editor. As always, just copy/paste the examples below in a Dockerfile editor and do not save (as auto-formatting may change the content that is being parsed).

1. Having an escaped newline as the only argument of an instruction should not be valid. This will now be flagged as an error correctly.
```
FROM alpine
USER \
```

2. This used to cause an infinite loop and break semantic highlighting. This bug has now been fixed.
```
FROM alpine
ENV a \
b
```
```
[Error - 10:15:15 AM] Request textDocument/semanticTokens failed.
  Message: Request textDocument/semanticTokens failed with message: Maximum call stack size exceeded
  Code: -32603 
```