### PR TITLE
Prompt to add Dockerfile first

### DIFF
--- a/src/scaffolding/scaffoldCompose.ts
+++ b/src/scaffolding/scaffoldCompose.ts
@@ -10,6 +10,7 @@ import { ChoosePlatformStep } from './wizard/ChoosePlatformStep';
 import { ChooseWorkspaceFolderStep } from './wizard/ChooseWorkspaceFolderStep';
 import { ScaffoldFileStep } from './wizard/ScaffoldFileStep';
 import { ScaffoldingWizardContext } from './wizard/ScaffoldingWizardContext';
+import { VerifyDockerfileStep } from './wizard/VerifyDockerfileStep';
 
 export async function scaffoldCompose(wizardContext: Partial<ScaffoldingWizardContext>, apiInput?: ScaffoldingWizardContext): Promise<void> {
     copyWizardContext(wizardContext, apiInput);
@@ -19,6 +20,7 @@ export async function scaffoldCompose(wizardContext: Partial<ScaffoldingWizardCo
     const promptSteps: AzureWizardPromptStep<ScaffoldingWizardContext>[] = [
         new ChooseWorkspaceFolderStep(),
         new ChoosePlatformStep(),
+        new VerifyDockerfileStep(),
     ];
 
     const executeSteps: AzureWizardExecuteStep<ScaffoldingWizardContext>[] = [

--- a/src/scaffolding/wizard/VerifyDockerfileStep.ts
+++ b/src/scaffolding/wizard/VerifyDockerfileStep.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { localize } from '../../localize';
+import { ScaffoldingWizardContext } from './ScaffoldingWizardContext';
+import { TelemetryPromptStep } from './TelemetryPromptStep';
+
+export class VerifyDockerfileStep<TWizardContext extends ScaffoldingWizardContext> extends TelemetryPromptStep<TWizardContext> {
+    public async prompt(wizardContext: TWizardContext): Promise<void> {
+        if (!(await fse.pathExists(path.join(wizardContext.dockerfileDirectory, 'Dockerfile')))) {
+            wizardContext.errorHandling.suppressReportIssue = true;
+            wizardContext.errorHandling.buttons = [
+                {
+                    callback: async () => {
+                        void vscode.commands.executeCommand('vscode-docker.configure', wizardContext); // They have already answered several questions, so we can copy in the current wizard context to save time
+                    },
+                    title: localize('vscode-docker.scaffold.verifyDockerfileStep.addDockerfiles', 'Add Docker Files'),
+                }
+            ]
+
+            throw new Error(localize('vscode-docker.scaffold.verifyDockerfileStep.noDockerfile', 'No Dockerfile is present in the workspace. Please add Docker files before adding Compose files.'));
+        }
+    }
+
+    public shouldPrompt(wizardContext: TWizardContext): boolean {
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes #2566.

If they click the "Add Docker Files" button, it will essentially assume that they want Dockerfiles *and* compose files, i.e. equivalent to running "Add Docker Files..." + compose = yes. In most or all cases, the user has already answered all the necessary questions, so it will not need to prompt again for them to answer.

The prompt looks like this:
![image](https://user-images.githubusercontent.com/36966225/103670757-01b7e280-4f48-11eb-8ca7-4c95655474f0.png)