### PR TITLE
Map new ACI states

### DIFF
--- a/src/docker/DockerServeClient/DockerServeUtils.ts
+++ b/src/docker/DockerServeClient/DockerServeUtils.ts
@@ -41,7 +41,7 @@ export function containerToDockerContainer(container: Container.AsObject): Docke
         Id: container.id,
         Image: container.image,
         Name: container.id, // TODO ?
-        State: container.status,
+        State: mapContainerStatus(container.status),
         Status: container.status,
         ImageID: undefined, // TODO ?
         CreatedTime: undefined, // TODO ?
@@ -74,4 +74,15 @@ export function containerPortsToInspectionPorts(container: DockerContainer): { [
     }
 
     return result;
+}
+
+function mapContainerStatus(status: string): string {
+    switch (status) {
+        case 'Node Pending': // ACI has an intermediate starting state
+            return 'waiting';
+        case 'Node Stopped': // ACI has an intermediate stopping state
+            return 'terminated';
+        default:
+            return status;
+    }
 }


### PR DESCRIPTION
Fixes #2602.

ACI has new states "Node Pending" (which is part of startup, equivalent to "Waiting" for our purposes), and "Node Stopped" (part of shutdown, equivalent to "Terminated" for our purposes). It seems that it doesn't always go through "Node Stopped", sometimes it appears to skip directly to "Terminated". Either way, it always ends up at "Terminated". I have not seen it skip "Node Pending", but it's probably safe to assume that is a possibility.