### PR TITLE
Recognize "compose.yaml" as a compose file

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,37 +181,22 @@
                     "group": "docker"
                 },
                 {
-                    "when": "resourceFilename =~ /^(?:(?!^docker-compose\\.ya?ml$).)*\\.ya?ml$/i && isAzureAccountInstalled",
+                    "when": "resourceFilename =~ /^(?:(?!compose.*\\.ya?ml$).)*\\.ya?ml$/i && isAzureAccountInstalled",
                     "command": "vscode-docker.registries.azure.runFileAsTask",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceFilename == docker-compose.yml",
+                    "when": "resourceFilename =~ /compose.*\\.ya?ml$/i",
                     "command": "vscode-docker.compose.down",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceFilename == docker-compose.yml",
+                    "when": "resourceFilename =~ /compose.*\\.ya?ml$/i",
                     "command": "vscode-docker.compose.restart",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceFilename == docker-compose.yml",
-                    "command": "vscode-docker.compose.up",
-                    "group": "docker"
-                },
-                {
-                    "when": "resourceFilename == docker-compose.debug.yml",
-                    "command": "vscode-docker.compose.down",
-                    "group": "docker"
-                },
-                {
-                    "when": "resourceFilename == docker-compose.debug.yml",
-                    "command": "vscode-docker.compose.restart",
-                    "group": "docker"
-                },
-                {
-                    "when": "resourceFilename == docker-compose.debug.yml",
+                    "when": "resourceFilename =~ /compose.*\\.ya?ml$/i",
                     "command": "vscode-docker.compose.up",
                     "group": "docker"
                 },
@@ -228,22 +213,22 @@
                     "group": "docker"
                 },
                 {
-                    "when": "resourceFilename =~ /^(?:(?!^docker-compose\\.ya?ml$).)*\\.ya?ml$/i && isAzureAccountInstalled",
+                    "when": "resourceFilename =~ /^(?:(?!compose.*\\.ya?ml$).)*\\.ya?ml$/i && isAzureAccountInstalled",
                     "command": "vscode-docker.registries.azure.runFileAsTask",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceFilename =~ /docker-compose/i",
+                    "when": "resourceFilename =~ /compose.*\\.ya?ml$/i",
                     "command": "vscode-docker.compose.down",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceFilename =~ /docker-compose/i",
+                    "when": "resourceFilename =~ /compose.*\\.ya?ml$/i",
                     "command": "vscode-docker.compose.restart",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceFilename =~ /docker-compose/i",
+                    "when": "resourceFilename =~ /compose.*\\.ya?ml$/i",
                     "command": "vscode-docker.compose.up",
                     "group": "docker"
                 },

--- a/resources/templates/.dockerignore.template
+++ b/resources/templates/.dockerignore.template
@@ -20,6 +20,7 @@
 {{/unless}}
 **/charts
 **/docker-compose*
+**/compose*
 **/Dockerfile*
 **/node_modules
 **/npm-debug.log

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,7 +23,7 @@ export const imageTagRegExp = new RegExp('^[a-zA-Z0-9.-_/]{1,256}:(?![.-])[a-zA-
 
 // GLOB Patterns
 export const FROM_DIRECTIVE_PATTERN = /^\s*FROM\s*([\w-\/:]*)(\s*AS\s*[a-z][a-z0-9-_\\.]*)?$/i;
-export const COMPOSE_FILE_GLOB_PATTERN = '**/[dD][oO][cC][kK][eE][rR]-[cC][oO][mM][pP][oO][sS][eE]*.{[yY][aA][mM][lL],[yY][mM][lL]}';
+export const COMPOSE_FILE_GLOB_PATTERN = '**/*[cC][oO][mM][pP][oO][sS][eE]*.{[yY][aA][mM][lL],[yY][mM][lL]}';
 export const DOCKERFILE_GLOB_PATTERN = '**/{*.[dD][oO][cC][kK][eE][rR][fF][iI][lL][eE],[dD][oO][cC][kK][eE][rR][fF][iI][lL][eE]}';
 export const YAML_GLOB_PATTERN = '**/*.{[yY][aA][mM][lL],[yY][mM][lL]}';
 export const CSPROJ_GLOB_PATTERN = '**/*.{[cC][sS][pP][rR][oO][jJ]}';

--- a/src/telemetry/registerListeners.ts
+++ b/src/telemetry/registerListeners.ts
@@ -23,7 +23,7 @@ export function registerListeners(): void {
 
         registerEvent('composefilesave', workspace.onDidSaveTextDocument, async (context: IActionContext, doc: TextDocument) => {
             // If it's not a compose file, skip
-            if (!/compose.*\.ya?ml/i.test(doc.fileName)) {
+            if (!/compose.*\.ya?ml$/i.test(doc.fileName)) {
                 context.telemetry.suppressAll = true;
                 return;
             }


### PR DESCRIPTION
Fixes #2618. This will _not_ make the icons for "compose.yaml" etc. show up as the pink whale; that is controlled by the file icon theme. However, the easiest thing to do would be to ignore that issue for now, and resolve it when creating a compose language. See here for more info: https://github.com/microsoft/vscode-docker/issues/2618#issuecomment-764804032