### PR TITLE
Subset of services experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "onCommand:vscode-docker.compose.down",
         "onCommand:vscode-docker.compose.restart",
         "onCommand:vscode-docker.compose.up",
+        "onCommand:vscode-docker.compose.up.subset",
         "onCommand:vscode-docker.configure",
         "onCommand:vscode-docker.configureCompose",
         "onCommand:vscode-docker.containers.attachShell",
@@ -172,6 +173,10 @@
                 {
                     "command": "vscode-docker.contexts.use",
                     "when": "!vscode-docker:contextLocked"
+                },
+                {
+                    "command": "vscode-docker.compose.up.subset",
+                    "when": "vscode-docker:composeSubsetExp"
                 }
             ],
             "editor/context": [
@@ -201,6 +206,11 @@
                     "group": "docker"
                 },
                 {
+                    "when": "resourceFilename == docker-compose.yml && vscode-docker:composeSubsetExp",
+                    "command": "vscode-docker.compose.up.subset",
+                    "group": "docker"
+                },
+                {
                     "when": "resourceFilename == docker-compose.debug.yml",
                     "command": "vscode-docker.compose.down",
                     "group": "docker"
@@ -213,6 +223,11 @@
                 {
                     "when": "resourceFilename == docker-compose.debug.yml",
                     "command": "vscode-docker.compose.up",
+                    "group": "docker"
+                },
+                {
+                    "when": "resourceFilename == docker-compose.yml && vscode-docker:composeSubsetExp",
+                    "command": "vscode-docker.compose.up.subset",
                     "group": "docker"
                 },
                 {
@@ -245,6 +260,11 @@
                 {
                     "when": "resourceFilename =~ /docker-compose/i",
                     "command": "vscode-docker.compose.up",
+                    "group": "docker"
+                },
+                {
+                    "when": "resourceFilename =~ /docker-compose/i && vscode-docker:composeSubsetExp",
+                    "command": "vscode-docker.compose.up.subset",
                     "group": "docker"
                 },
                 {
@@ -2185,6 +2205,11 @@
             {
                 "command": "vscode-docker.compose.up",
                 "title": "%vscode-docker.commands.compose.up%",
+                "category": "%vscode-docker.commands.category.docker%"
+            },
+            {
+                "command": "vscode-docker.compose.up.subset",
+                "title": "%vscode-docker.commands.compose.up.subset%",
                 "category": "%vscode-docker.commands.category.docker%"
             },
             {

--- a/package.nls.json
+++ b/package.nls.json
@@ -188,6 +188,7 @@
     "vscode-docker.commands.compose.down": "Compose Down",
     "vscode-docker.commands.compose.restart": "Compose Restart",
     "vscode-docker.commands.compose.up": "Compose Up",
+    "vscode-docker.commands.compose.up.subset": "Compose Up - Choose Services",
     "vscode-docker.commands.configure": "Add Docker Files to Workspace...",
     "vscode-docker.commands.configureCompose": "Add Docker Compose Files to Workspace...",
     "vscode-docker.commands.containers.attachShell": "Attach Shell",

--- a/src/commands/compose/compose.ts
+++ b/src/commands/compose/compose.ts
@@ -53,7 +53,7 @@ async function compose(context: IActionContext, commands: ('up' | 'down' | 'upSu
                 build
             );
 
-            if (command === 'upSubset') {
+            if (command === 'upSubset' && !serviceListPlaceholder.test(terminalCommand)) {
                 // eslint-disable-next-line no-template-curly-in-string
                 terminalCommand += ' ${serviceList}';
             }

--- a/src/commands/compose/compose.ts
+++ b/src/commands/compose/compose.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { rewriteComposeCommandIfNeeded } from '../../docker/Contexts';
+import { ext } from '../../extensionVariables';
 import { localize } from "../../localize";
 import { executeAsTask } from '../../utils/executeAsTask';
 import { createFileItem, Item, quickPickDockerComposeFileItem } from '../../utils/quickPickFile';
@@ -13,7 +14,7 @@ import { quickPickWorkspaceFolder } from '../../utils/quickPickWorkspaceFolder';
 import { selectComposeCommand } from '../selectCommandTemplate';
 import { getComposeServiceList } from './getComposeServiceList';
 
-async function compose(context: IActionContext, commands: ('up' | 'down')[], message: string, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
+async function compose(context: IActionContext, commands: ('up' | 'down' | 'upSubset')[], message: string, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
     const folder: vscode.WorkspaceFolder = await quickPickWorkspaceFolder(context, localize('vscode-docker.commands.compose.workspaceFolder', 'To run Docker compose you must first open a folder or workspace in VS Code.'));
 
     let commandParameterFileUris: vscode.Uri[];
@@ -46,11 +47,16 @@ async function compose(context: IActionContext, commands: ('up' | 'down')[], mes
             let terminalCommand = await selectComposeCommand(
                 context,
                 folder,
-                command,
+                command === 'down' ? 'down' : 'up',
                 item?.relativeFilePath,
                 detached,
                 build
             );
+
+            if (command === 'upSubset') {
+                // eslint-disable-next-line no-template-curly-in-string
+                terminalCommand += ' ${serviceList}';
+            }
 
             // Add the service list if needed
             terminalCommand = await addServicesListIfNeeded(context, folder, terminalCommand);
@@ -67,12 +73,22 @@ export async function composeUp(context: IActionContext, dockerComposeFileUri?: 
     return await compose(context, ['up'], localize('vscode-docker.commands.compose.chooseUp', 'Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
+export async function composeUpSubset(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
+    return await compose(context, ['upSubset'], localize('vscode-docker.commands.compose.chooseUpSubset', 'Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
+}
+
 export async function composeDown(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
     return await compose(context, ['down'], localize('vscode-docker.commands.compose.chooseDown', 'Choose Docker Compose file to take down'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
 export async function composeRestart(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
     return await compose(context, ['down', 'up'], localize('vscode-docker.commands.compose.chooseRestart', 'Choose Docker Compose file to restart'), dockerComposeFileUri, selectedComposeFileUris);
+}
+
+export async function activateComposeUpSubsetExperiment(): Promise<void> {
+    if (await ext.experimentationService.isCachedFlightEnabled('vscode-docker.composeSubset')) {
+        await vscode.commands.executeCommand('setContext', 'vscode-docker:composeSubsetExp', true);
+    }
 }
 
 const serviceListPlaceholder = /\${serviceList}/i;

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -9,7 +9,7 @@ import { ext } from "../extensionVariables";
 import { scaffold } from "../scaffolding/scaffold";
 import { scaffoldCompose } from "../scaffolding/scaffoldCompose";
 import { scaffoldDebugConfig } from "../scaffolding/scaffoldDebugConfig";
-import { composeDown, composeRestart, composeUp, composeUpSubset } from "./compose/compose";
+import { activateComposeUpSubsetExperiment, composeDown, composeRestart, composeUp, composeUpSubset } from "./compose/compose";
 import { attachShellContainer } from "./containers/attachShellContainer";
 import { browseContainer } from "./containers/browseContainer";
 import { composeGroupDown, composeGroupLogs, composeGroupRestart } from "./containers/composeGroup";
@@ -119,6 +119,7 @@ export function registerCommands(): void {
     registerWorkspaceCommand('vscode-docker.compose.restart', composeRestart);
     registerWorkspaceCommand('vscode-docker.compose.up', composeUp);
     registerWorkspaceCommand('vscode-docker.compose.up.subset', composeUpSubset);
+    void activateComposeUpSubsetExperiment();
     registerCommand('vscode-docker.pruneSystem', pruneSystem);
 
     registerWorkspaceCommand('vscode-docker.containers.attachShell', attachShellContainer);

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -9,7 +9,7 @@ import { ext } from "../extensionVariables";
 import { scaffold } from "../scaffolding/scaffold";
 import { scaffoldCompose } from "../scaffolding/scaffoldCompose";
 import { scaffoldDebugConfig } from "../scaffolding/scaffoldDebugConfig";
-import { composeDown, composeRestart, composeUp } from "./compose/compose";
+import { composeDown, composeRestart, composeUp, composeUpSubset } from "./compose/compose";
 import { attachShellContainer } from "./containers/attachShellContainer";
 import { browseContainer } from "./containers/browseContainer";
 import { composeGroupDown, composeGroupLogs, composeGroupRestart } from "./containers/composeGroup";
@@ -118,6 +118,7 @@ export function registerCommands(): void {
     registerWorkspaceCommand('vscode-docker.compose.down', composeDown);
     registerWorkspaceCommand('vscode-docker.compose.restart', composeRestart);
     registerWorkspaceCommand('vscode-docker.compose.up', composeUp);
+    registerWorkspaceCommand('vscode-docker.compose.up.subset', composeUpSubset);
     registerCommand('vscode-docker.pruneSystem', pruneSystem);
 
     registerWorkspaceCommand('vscode-docker.containers.attachShell', attachShellContainer);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,6 @@ import * as vscode from 'vscode';
 import { AzureUserInput, callWithTelemetryAndErrorHandling, createAzExtOutputChannel, createExperimentationService, IActionContext, registerUIExtensionVariables, UserCancelledError } from 'vscode-azureextensionui';
 import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 import * as tas from 'vscode-tas-client';
-import { activateComposeUpSubsetExperiment } from './commands/compose/compose';
 import { registerCommands } from './commands/registerCommands';
 import { openStartPageAfterExtensionUpdate } from './commands/startPage/openStartPage';
 import { COMPOSE_FILE_GLOB_PATTERN, extensionVersion } from './constants';
@@ -152,7 +151,6 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
         registerListeners();
 
         void openStartPageAfterExtensionUpdate();
-        void activateComposeUpSubsetExperiment();
     });
 
     // If the magic VSCODE_DOCKER_TEAM environment variable is set to 1, export the mementos for use by the Memento Explorer extension

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { AzureUserInput, callWithTelemetryAndErrorHandling, createAzExtOutputChannel, createExperimentationService, IActionContext, registerUIExtensionVariables, UserCancelledError } from 'vscode-azureextensionui';
 import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 import * as tas from 'vscode-tas-client';
+import { activateComposeUpSubsetExperiment } from './commands/compose/compose';
 import { registerCommands } from './commands/registerCommands';
 import { openStartPageAfterExtensionUpdate } from './commands/startPage/openStartPage';
 import { COMPOSE_FILE_GLOB_PATTERN, extensionVersion } from './constants';
@@ -67,6 +68,8 @@ function initializeExtensionVariables(ctx: vscode.ExtensionContext): void {
     registerUIExtensionVariables(ext);
 }
 
+// TODO: Remove this
+// eslint-disable-next-line @typescript-eslint/tslint/config
 export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: { loadStartTime: number, loadEndTime: number | undefined }): Promise<unknown | undefined> {
     perfStats.loadEndTime = Date.now();
 
@@ -151,6 +154,10 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
         registerListeners();
 
         void openStartPageAfterExtensionUpdate();
+        void activateComposeUpSubsetExperiment();
+
+        // TODO: remove this
+        void vscode.commands.executeCommand('setContext', 'vscode-docker:composeSubsetExp', true);
     });
 
     // If the magic VSCODE_DOCKER_TEAM environment variable is set to 1, export the mementos for use by the Memento Explorer extension

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,8 +68,6 @@ function initializeExtensionVariables(ctx: vscode.ExtensionContext): void {
     registerUIExtensionVariables(ext);
 }
 
-// TODO: Remove this
-// eslint-disable-next-line @typescript-eslint/tslint/config
 export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: { loadStartTime: number, loadEndTime: number | undefined }): Promise<unknown | undefined> {
     perfStats.loadEndTime = Date.now();
 
@@ -155,9 +153,6 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
 
         void openStartPageAfterExtensionUpdate();
         void activateComposeUpSubsetExperiment();
-
-        // TODO: remove this
-        void vscode.commands.executeCommand('setContext', 'vscode-docker:composeSubsetExp', true);
     });
 
     // If the magic VSCODE_DOCKER_TEAM environment variable is set to 1, export the mementos for use by the Memento Explorer extension


### PR DESCRIPTION
Fixes #2646. This adds a new option to launch a subset of services directly; basically it is equivalent to appending `${serviceList}` to the end of your compose command. This is gated by an experiment.

![image](https://user-images.githubusercontent.com/36966225/105390373-f66ee300-5be6-11eb-81b9-cf9ff44c2552.png)

![image](https://user-images.githubusercontent.com/36966225/105390413-04246880-5be7-11eb-838c-ea85b71b1580.png)
