### PR TITLE
Add inline open/download commands and tweak order

### DIFF
--- a/package.json
+++ b/package.json
@@ -2233,7 +2233,7 @@
                 "command": "vscode-docker.containers.openFile",
                 "title": "%vscode-docker.commands.containers.openFile%",
                 "category": "%vscode-docker.commands.category.dockerContainers%",
-                "icon": "$(file-symlink-file)"
+                "icon": "$(go-to-file)"
             },
             {
                 "command": "vscode-docker.containers.prune",

--- a/package.json
+++ b/package.json
@@ -373,11 +373,13 @@
                 },
                 {
                     "command": "vscode-docker.containers.downloadFile",
-                    "when": "view == dockerContainers && viewItem == containerFile"
+                    "when": "view == dockerContainers && viewItem == containerFile",
+                    "group": "files_1@2"
                 },
                 {
                     "command": "vscode-docker.containers.openFile",
-                    "when": "view == dockerContainers && viewItem == containerFile"
+                    "when": "view == dockerContainers && viewItem == containerFile",
+                    "group": "files_1@1"
                 },
                 {
                     "command": "vscode-docker.containers.stop",
@@ -603,6 +605,16 @@
                     "command": "vscode-docker.contexts.remove",
                     "when": "view == vscode-docker.views.dockerContexts && viewItem =~ /^customContext/i",
                     "group": "contexts_2_destructive@1"
+                },
+                {
+                    "command": "vscode-docker.containers.downloadFile",
+                    "when": "view == dockerContainers && viewItem == containerFile",
+                    "group": "inline@2"
+                },
+                {
+                    "command": "vscode-docker.containers.openFile",
+                    "when": "view == dockerContainers && viewItem == containerFile",
+                    "group": "inline@1"
                 }
             ]
         },
@@ -2209,7 +2221,8 @@
             {
                 "command": "vscode-docker.containers.downloadFile",
                 "title": "%vscode-docker.commands.containers.downloadFile%",
-                "category": "%vscode-docker.commands.category.dockerContainers%"
+                "category": "%vscode-docker.commands.category.dockerContainers%",
+                "icon": "$(desktop-download)"
             },
             {
                 "command": "vscode-docker.containers.inspect",
@@ -2219,7 +2232,8 @@
             {
                 "command": "vscode-docker.containers.openFile",
                 "title": "%vscode-docker.commands.containers.openFile%",
-                "category": "%vscode-docker.commands.category.dockerContainers%"
+                "category": "%vscode-docker.commands.category.dockerContainers%",
+                "icon": "$(file-symlink-file)"
             },
             {
                 "command": "vscode-docker.containers.prune",


### PR DESCRIPTION
Adds inline commands for container file open/download (which is sometimes quicker than the context menu).  Also makes the open command first (as that's most likely the one being used).

<img width="568" alt="Screenshot 2021-01-21 at 14 25 00" src="https://user-images.githubusercontent.com/6402946/105420160-bc0c4280-5bf4-11eb-9994-ceed3cb06206.png">
