### PR TITLE
Change to use PAT auth for GitLab

### DIFF
--- a/src/tree/registries/gitLab/GitLabAccountTreeItem.ts
+++ b/src/tree/registries/gitLab/GitLabAccountTreeItem.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RequestPromiseOptions } from "request-promise-native";
-import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
+import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, parseError } from "vscode-azureextensionui";
 import { PAGE_SIZE } from "../../../constants";
 import { ext } from "../../../extensionVariables";
 import { nonNullProp } from "../../../utils/nonNull";
@@ -23,7 +23,6 @@ export class GitLabAccountTreeItem extends AzExtParentTreeItem implements IRegis
     public baseUrl: string = 'https://gitlab.com/';
     public cachedProvider: ICachedRegistryProvider;
 
-    private _token?: string;
     private _nextLink?: string;
 
     public constructor(parent: AzExtParentTreeItem, provider: ICachedRegistryProvider) {
@@ -49,24 +48,24 @@ export class GitLabAccountTreeItem extends AzExtParentTreeItem implements IRegis
     public async loadMoreChildrenImpl(clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
         if (clearCache) {
             this._nextLink = undefined;
+        }
 
-            try {
-                await this.refreshToken();
-            } catch (err) {
-                // If creds are invalid, the above refreshToken will fail
+        try {
+            const url: string = this._nextLink || `api/v4/projects?per_page=${PAGE_SIZE}&simple=true&membership=true`;
+            let response = await registryRequest<IProject[]>(this, 'GET', url);
+            this._nextLink = getNextLinkFromHeaders(response);
+            return this.createTreeItemsWithErrorHandling(
+                response.body,
+                'invalidGitLabProject',
+                n => new GitLabProjectTreeItem(this, n.id.toString(), n.path_with_namespace.toLowerCase()),
+                n => n.path_with_namespace
+            );
+        } catch (err) {
+            const errorType: string = parseError(err).errorType.toLowerCase();
+            if (errorType === '401' || errorType === 'unauthorized') {
                 return [new RegistryConnectErrorTreeItem(this, err, this.cachedProvider)];
             }
         }
-
-        const url: string = this._nextLink || `api/v4/projects?per_page=${PAGE_SIZE}&simple=true&membership=true`;
-        let response = await registryRequest<IProject[]>(this, 'GET', url);
-        this._nextLink = getNextLinkFromHeaders(response);
-        return this.createTreeItemsWithErrorHandling(
-            response.body,
-            'invalidGitLabProject',
-            n => new GitLabProjectTreeItem(this, n.id.toString(), n.path_with_namespace.toLowerCase()),
-            n => n.path_with_namespace
-        );
     }
 
     public hasMoreChildrenImpl(): boolean {
@@ -74,26 +73,7 @@ export class GitLabAccountTreeItem extends AzExtParentTreeItem implements IRegis
     }
 
     public async addAuth(options: RequestPromiseOptions): Promise<void> {
-        if (this._token) {
-            options.auth = {
-                bearer: this._token
-            }
-        }
-    }
-
-    private async refreshToken(): Promise<void> {
-        this._token = undefined;
-        const options = {
-            form: {
-                /* eslint-disable-next-line camelcase */
-                grant_type: "password",
-                username: this.username,
-                password: await this.getPassword()
-            }
-        };
-
-        const response = await registryRequest<IToken>(this, 'POST', 'oauth/token', options);
-        this._token = response.body.access_token;
+        options.headers['PRIVATE-TOKEN'] = await this.getPassword();
     }
 }
 
@@ -101,9 +81,4 @@ interface IProject {
     id: number;
     /* eslint-disable-next-line camelcase */
     path_with_namespace: string;
-}
-
-interface IToken {
-    /* eslint-disable-next-line camelcase */
-    access_token: string
 }

--- a/src/tree/registries/gitLab/gitLabRegistryProvider.ts
+++ b/src/tree/registries/gitLab/gitLabRegistryProvider.ts
@@ -17,6 +17,7 @@ export const gitLabRegistryProvider: IRegistryProvider = {
         wizardTitle: localize('vscode-docker.tree.registries.gitlab.signIn', 'Sign in to GitLab'),
         includeUsername: true,
         includePassword: true,
+        passwordPrompt: localize('vscode-docker.tree.registries.gitlab.pat', 'GitLab Personal Access Token'),
     },
     treeItemFactory: (parent, cachedProvider) => new GitLabAccountTreeItem(parent, cachedProvider),
     persistAuth: async (cachedProvider, secret) => await setRegistryPassword(cachedProvider, secret),


### PR DESCRIPTION
Fixes #1968 (and #2688). Using OAuth for GitLab is no longer feasible since it requires the user to register a client application and provide that app ID and secret in addition to username and password. Personal access token auth is the only realistic option at this point.