### PR TITLE
Use `HEAD` request to get digest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1900,7 +1900,7 @@
                 },
                 "docker.images.checkForOutdatedImages": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "%vscode-docker.config.docker.images.checkForOutdatedImages%"
                 },
                 "docker.networks.groupBy": {

--- a/src/docker/Images.ts
+++ b/src/docker/Images.ts
@@ -13,8 +13,9 @@ export interface DockerImage extends DockerObject {
 export interface DockerImageInspection extends DockerObject {
     readonly Config?: {
         readonly ExposedPorts?: { readonly [portAndProtocol: string]: unknown; };
-        readonly Image?: string;
     };
+
+    readonly RepoDigests?: string[];
 
     readonly Os: string;
     readonly Name: undefined; // Not defined for inspection

--- a/src/tree/images/imageChecker/OutdatedImageChecker.ts
+++ b/src/tree/images/imageChecker/OutdatedImageChecker.ts
@@ -16,9 +16,6 @@ import { ImageRegistry, registries } from './registries';
 
 const noneRegex = /<none>/i;
 
-const lastLiveOutdatedCheckKey = 'vscode-docker.outdatedImageChecker.lastLiveCheck';
-const outdatedImagesKey = 'vscode-docker.outdatedImageChecker.outdatedImages';
-
 export class OutdatedImageChecker {
     private shouldLoad: boolean;
     private readonly outdatedImageIds: string[] = [];
@@ -54,7 +51,6 @@ export class OutdatedImageChecker {
 
                 // Do a live check
                 context.telemetry.properties.checkSource = 'live';
-                await ext.context.globalState.update(lastLiveOutdatedCheckKey, Date.now());
 
                 const imageCheckPromises: Promise<void>[] = [];
 
@@ -75,7 +71,6 @@ export class OutdatedImageChecker {
 
                 // Load the data for all images then force the tree to refresh
                 await Promise.all(imageCheckPromises);
-                await ext.context.globalState.update(outdatedImagesKey, this.outdatedImageIds);
 
                 context.telemetry.measurements.outdatedImages = this.outdatedImageIds.length;
 
@@ -96,7 +91,7 @@ export class OutdatedImageChecker {
             const repo = registryAndRepo.replace(registry.registryMatch, '').replace(/^\/|\/$/, '');
 
             if (noneRegex.test(repo) || noneRegex.test(tag)) {
-                return 'outdated';
+                return 'unknown';
             }
 
             let token: string | undefined;

--- a/src/tree/images/imageChecker/OutdatedImageChecker.ts
+++ b/src/tree/images/imageChecker/OutdatedImageChecker.ts
@@ -10,7 +10,6 @@ import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azuree
 import { ociClientId } from '../../../constants';
 import { DockerImage } from '../../../docker/Images';
 import { ext } from '../../../extensionVariables';
-import { localize } from '../../../localize';
 import { getImagePropertyValue } from '../ImageProperties';
 import { DatedDockerImage } from '../ImagesTreeItem';
 import { ImageRegistry, registries } from './registries';
@@ -32,12 +31,13 @@ export class OutdatedImageChecker {
         const httpSettings = vscode.workspace.getConfiguration('http');
         const strictSSL = httpSettings.get<boolean>('proxyStrictSSL', true);
         this.defaultRequestOptions = {
-            method: 'GET',
+            method: 'HEAD',
             json: true,
             resolveWithFullResponse: true,
             strictSSL: strictSSL,
             headers: {
                 'X-Meta-Source-Client': ociClientId,
+                'Accept': 'application/vnd.docker.distribution.manifest.list.v2+json',
             },
         };
     }
@@ -52,43 +52,35 @@ export class OutdatedImageChecker {
                 context.errorHandling.suppressReportIssue = true;
                 context.errorHandling.suppressDisplay = true;
 
-                const lastCheck = ext.context.globalState.get<number | undefined>(lastLiveOutdatedCheckKey, undefined);
+                // Do a live check
+                context.telemetry.properties.checkSource = 'live';
+                await ext.context.globalState.update(lastLiveOutdatedCheckKey, Date.now());
 
-                if (lastCheck && Date.now() - lastCheck < 24 * 60 * 60 * 1000) {
-                    // Use the cached data
-                    context.telemetry.properties.checkSource = 'cache';
-                    this.outdatedImageIds.push(...ext.context.globalState.get<string[]>(outdatedImagesKey, []));
-                } else {
-                    // Do a live check
-                    context.telemetry.properties.checkSource = 'live';
-                    await ext.context.globalState.update(lastLiveOutdatedCheckKey, Date.now());
+                const imageCheckPromises: Promise<void>[] = [];
 
-                    const imageCheckPromises: Promise<void>[] = [];
+                for (const image of images) {
+                    const imageRegistry = getImagePropertyValue(image, 'Registry');
+                    const matchingRegistry = registries.find(r => r.registryMatch.test(imageRegistry));
 
-                    for (const image of images) {
-                        const imageRegistry = getImagePropertyValue(image, 'Registry');
-                        const matchingRegistry = registries.find(r => r.registryMatch.test(imageRegistry));
-
-                        if (matchingRegistry) {
-                            imageCheckPromises.push((async () => {
-                                if (await this.checkImage(context, matchingRegistry, image) === 'outdated') {
-                                    this.outdatedImageIds.push(image.Id);
-                                }
-                            })());
-                        }
+                    if (matchingRegistry) {
+                        imageCheckPromises.push((async () => {
+                            if (await this.checkImage(context, matchingRegistry, image) === 'outdated') {
+                                this.outdatedImageIds.push(image.Id);
+                            }
+                        })());
                     }
-
-                    context.telemetry.measurements.imagesChecked = imageCheckPromises.length;
-
-                    // Load the data for all images then force the tree to refresh
-                    await Promise.all(imageCheckPromises);
-                    await ext.context.globalState.update(outdatedImagesKey, this.outdatedImageIds);
-
-                    context.telemetry.measurements.outdatedImages = this.outdatedImageIds.length;
-
-                    // Don't wait
-                    void ext.imagesRoot.refresh(context);
                 }
+
+                context.telemetry.measurements.imagesChecked = imageCheckPromises.length;
+
+                // Load the data for all images then force the tree to refresh
+                await Promise.all(imageCheckPromises);
+                await ext.context.globalState.update(outdatedImagesKey, this.outdatedImageIds);
+
+                context.telemetry.measurements.outdatedImages = this.outdatedImageIds.length;
+
+                // Don't wait
+                void ext.imagesRoot.refresh(context);
             });
         }
 
@@ -111,16 +103,16 @@ export class OutdatedImageChecker {
 
             // 1. Get an OAuth token to access the resource. No Authorization header is required for public scopes.
             if (registry.getToken) {
-                token = await registry.getToken(this.defaultRequestOptions, `repository:library/${repo}:pull`);
+                token = await registry.getToken({ ...this.defaultRequestOptions, method: 'GET' }, `repository:library/${repo}:pull`);
             }
 
-            // 2. Get the latest image ID from the manifest
-            const latestConfigImageId = await this.getLatestConfigImageId(registry, repo, tag, token);
+            // 2. Get the latest image digest ID from the manifest
+            const latestImageDigest = await this.getLatestImageDigest(registry, repo, tag, token);
 
             // 3. Compare it with the current image's value
             const imageInspectInfo = await ext.dockerClient.inspectImage(context, image.Id);
 
-            if (latestConfigImageId.toLowerCase() !== imageInspectInfo?.Config?.Image?.toLowerCase()) {
+            if (imageInspectInfo?.RepoDigests?.[0]?.toLowerCase()?.indexOf(latestImageDigest.toLowerCase()) < 0) {
                 return 'outdated';
             }
 
@@ -130,7 +122,7 @@ export class OutdatedImageChecker {
         }
     }
 
-    private async getLatestConfigImageId(registry: ImageRegistry, repo: string, tag: string, oAuthToken: string | undefined): Promise<string> {
+    private async getLatestImageDigest(registry: ImageRegistry, repo: string, tag: string, oAuthToken: string | undefined): Promise<string> {
         const manifestOptions: request.RequestPromiseOptions = {
             ...this.defaultRequestOptions,
             auth: oAuthToken ? {
@@ -139,15 +131,6 @@ export class OutdatedImageChecker {
         };
 
         const manifestResponse = await request(`${registry.baseUrl}/${repo}/manifests/${tag}`, manifestOptions) as Response;
-        /* eslint-disable @typescript-eslint/tslint/config */
-        const firstHistory = JSON.parse(manifestResponse?.body?.history?.[0]?.v1Compatibility);
-        const latestConfigImageId: string = firstHistory?.config?.Image;
-        /* eslint-enable @typescript-eslint/tslint/config */
-
-        if (!latestConfigImageId) {
-            throw new Error(localize('vscode-docker.outdatedImageChecker.noManifest', 'Failed to acquire manifest token for image: \'{0}:{1}\'', repo, tag));
-        }
-
-        return latestConfigImageId;
+        return manifestResponse.headers['docker-content-digest'] as string;
     }
 }


### PR DESCRIPTION
This change does several things:

1. Uses the `Accept: application/vnd.docker.distribution.manifest.list.v2+json` header to enable doing `HEAD` requests--not subject to rate limiting--to check if an image is out-of-date
1. Re-enables out-of-date checking by default
1. Returns out-of-date checking to once per session instead of once per day. I don't feel strongly that it ought to be once-per-session, so if desired I can keep it at once-per-day.

I'd be OK with putting this in either 1.10.0 or 1.11.0.