### PR TITLE
Update `vscode-azureextensionui` to 0.38.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12952,9 +12952,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.38.5",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.38.5.tgz",
-            "integrity": "sha512-qfpuX2cLDZHggWZAQO/gvMadg01Vjlc7k9EsIWz3M2nT+lwFXp1iNT0yw+1M0v0eZNlg3FjZw9IDGEJ0FbDQZA==",
+            "version": "0.38.6",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.38.6.tgz",
+            "integrity": "sha512-xZrCi2RMxE0TfqwMr3UApDAbMEnDimtE3InncpDVfBlCuAfbaKTC5zBWu25dR3I/fD1jdHqf8MLFgfJZkU9X+A==",
             "requires": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-storage": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -2760,7 +2760,7 @@
         "tar": "^6.1.0",
         "tar-stream": "^2.2.0",
         "vscode-azureappservice": "^0.72.2",
-        "vscode-azureextensionui": "^0.38.5",
+        "vscode-azureextensionui": "^0.38.6",
         "vscode-languageclient": "^7.0.0",
         "vscode-nls": "^5.0.0",
         "vscode-tas-client": "^0.1.17",


### PR DESCRIPTION
This version of `vscode-azureextensionui` reverts the prior change which was done to fix #2679. The upstream bug in VSCode was fixed so we no longer need to do anything special.