### PR TITLE
Support environment files in Docker Compose tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1325,6 +1325,13 @@
                                     }
                                 }
                             },
+                            "envFiles": {
+                                "type": "array",
+                                "description": "%vscode-docker.tasks.docker-compose.dockerCompose.envFiles.description%",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
                             "files": {
                                 "type": "array",
                                 "description": "%vscode-docker.tasks.docker-compose.dockerCompose.files.description%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -109,6 +109,7 @@
     "vscode-docker.tasks.docker-compose.dockerCompose.down.removeImages": "Images to remove.",
     "vscode-docker.tasks.docker-compose.dockerCompose.down.removeVolumes": "Whether or not to remove named and anonymous volumes.",
     "vscode-docker.tasks.docker-compose.dockerCompose.down.customOptions": "Any other options to add to the `docker-compose down` command.",
+    "vscode-docker.tasks.docker-compose.dockerCompose.envFiles.description": "Files of environment variables read in and applied to the Docker containers.",
     "vscode-docker.tasks.docker-compose.dockerCompose.files.description": "The docker-compose files to include, in order.",
     "vscode-docker.config.docker.promptForRegistryWhenPushingImages": "Prompt for registry selection if the image is not explicitly tagged.",
     "vscode-docker.config.template.build.template": "The command template.",

--- a/src/tasks/DockerComposeTaskDefinitionBase.ts
+++ b/src/tasks/DockerComposeTaskDefinitionBase.ts
@@ -25,7 +25,7 @@ export interface DockerComposeDownOptions {
     };
 }
 
-export type DockerComposeOptions = (DockerComposeUpOptions | DockerComposeDownOptions) & { files?: string[] };
+export type DockerComposeOptions = (DockerComposeUpOptions | DockerComposeDownOptions) & { envFiles?: string[], files?: string[] };
 
 export interface DockerComposeTaskDefinitionBase extends TaskDefinitionBase {
     dockerCompose?: DockerComposeOptions;


### PR DESCRIPTION
Adds a `envFiles` property to the Docker Compose up/down tasks, which generate `--env-file` arguments on the `docker-compose` command line.

Resolves #2701.

>NOTE: Waiting to merge this PR until after 1.10 is out the door.