### PR TITLE
Fix bug in Python entrypoint logic

### DIFF
--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -105,6 +105,9 @@ export class PythonTaskHelper implements TaskHelper {
         // User input is honored in all of the below.
         runOptions.volumes = this.inferVolumes(runOptions, launcherFolder);
 
+        // If the user specifies command, we won't set entrypoint; otherwise if they set entrypoint we will respect it; otherwise use 'python3' to start an idle container
+        runOptions.entrypoint = runOptions.command ? undefined : runOptions.entrypoint || 'python3';
+
         return runOptions;
     }
 


### PR DESCRIPTION
Fixes #2725 (for real this time).

Python is different from .NET, in that with .NET we never make it to the `ENTRYPOINT` directive since we build only the first stage of the Dockerfile. Python builds the full Dockerfile, so the `CMD` directive _is_ reached, and the image no longer has `python` as the default, idle entrypoint. Thus, we _do_ need to set an idle entrypoint of `python3` in order to work.

The code as written will now respect user input for `command` or `entrypoint`, and if both are falsy, will use `python3`.