### PR TITLE
Fix up right-click behavior by not changing tree IDs so much

### DIFF
--- a/src/tree/LocalRootTreeItemBase.ts
+++ b/src/tree/LocalRootTreeItemBase.ts
@@ -373,12 +373,12 @@ export abstract class LocalRootTreeItemBase<TItem extends DockerObject, TPropert
             isDockerStatusChanged = pollingDockerStatus !== this._currentDockerStatus;
         }
 
-        const hasChanged = !this.areArraysEqual(this._currentItems, this._itemsFromPolling) || isDockerStatusChanged
+        const hasChanged = !this.areArraysEqual(this._currentItems, this._itemsFromPolling) || isDockerStatusChanged;
         this._currentDockerStatus = pollingDockerStatus;
         return hasChanged;
     }
 
-    private areArraysEqual(array1: TItem[] | undefined, array2: TItem[] | undefined): boolean {
+    protected areArraysEqual(array1: TItem[] | undefined, array2: TItem[] | undefined): boolean {
         if (array1 === array2) {
             return true;
         } else if (array1 && array2) {
@@ -407,5 +407,5 @@ export function getTreeId(object: DockerObject): string {
     // Several of these aren't defined for all Docker objects, but the concatenation of whatever exists among them is enough to always be unique
     // *and* change the ID when the state of the object changes
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return `${object.Id}${object.Name}${(object as any).State}${(object as any).Current}${(object as any).Outdated}${(object as any).Status}`;
+    return `${object.Id}${object.Name}${(object as any).State}${(object as any).Current}${(object as any).Outdated}`;
 }

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -128,7 +128,7 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInf
             return false;
         }
 
-        // Containers' labels/descriptions (status in particular) can change. If they do, we want to cause a refresh. But, we also don't want to change the tree ID based on status.
+        // Containers' labels/descriptions (status in particular) can change. If they do, we want to cause a refresh. But, we also don't want to change the tree ID based on status (in `getTreeId()` in LocalRootTreeItemBase.ts).
         return !array1.some((item, index) => {
             return this.getTreeItemLabel(item) !== this.getTreeItemLabel(array2[index]) ||
                 this.getTreeItemDescription(item) !== this.getTreeItemDescription(array2[index]);

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as dayjs from "dayjs";
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
 import { DockerContainer } from "../../docker/Containers";
 import { ext } from "../../extensionVariables";
@@ -92,7 +91,7 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInf
                 // We make status a sticky value. The result is that in the life of a DockerContainerInfo object, the Status property value will not change after it is first accessed.
                 // That way, when a newly-polled DockerContainerInfo has a *different* status (e.g. it goes from "a few seconds ago" to "a minute ago"), we recognize the difference from old -> new, and areArraysEqual below returns false.
                 if (!item.lastStatus) {
-                    item.lastStatus = dayjs(item.CreatedTime).fromNow();
+                    item.lastStatus = item.Status;
                 }
 
                 return item.lastStatus;

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -19,7 +19,6 @@ import { ContainerTreeItem } from "./ContainerTreeItem";
 
 export type DockerContainerInfo = DockerContainer & {
     showFiles: boolean;
-    lastStatus?: string;
 };
 
 export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInfo, ContainerProperty> {
@@ -88,13 +87,7 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInf
             case 'State':
                 return item.State;
             case 'Status':
-                // We make status a sticky value. The result is that in the life of a DockerContainerInfo object, the Status property value will not change after it is first accessed.
-                // That way, when a newly-polled DockerContainerInfo has a *different* status (e.g. it goes from "a few seconds ago" to "a minute ago"), we recognize the difference from old -> new, and areArraysEqual below returns false.
-                if (!item.lastStatus) {
-                    item.lastStatus = item.Status;
-                }
-
-                return item.lastStatus;
+                return item.Status;
             case 'Compose Project Name':
                 return getComposeProjectName(item);
             default:


### PR DESCRIPTION
Fixes #2744. When the tree ID changes, if you right clicked the object with the "old" ID, then choose an action--that item is lost now. It will drop the quick pick to make you go find the container again. This is really annoying.

During the first minute of a container's life, the tree ID is changing every ~2 seconds, which makes right click actions very difficult to do.

This change makes it so that we consider the container label for the purposes of deciding whether or not to refresh, but without changing its tree ID, so right click contexts isn't lost.