### PR TITLE
Change quoting on Windows hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * The use of keytar has been removed since VS Code now has a secret storage API. Users will need to log in to their registries again. [#2699](https://github.com/microsoft/vscode-docker/issues/2699)
+* In the files explorer, folders containing spaces should work. [#2739](https://github.com/microsoft/vscode-docker/issues/2739)
 * Adding Dockerfiles to a (ASP).NET app will now automatically generate the required .NET build task, using the C# extension. [#2669](https://github.com/microsoft/vscode-docker/issues/2669)
 * Python `docker-run` tasks should now respect the `dockerRun` `command` option in tasks.json. [#2725](https://github.com/microsoft/vscode-docker/issues/2725)
 * Microsoft Container Registry (MCR) images were sometimes incorrectly being flagged as out-of-date. [#2730](https://github.com/microsoft/vscode-docker/issues/2730)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "requires": true,
     "packages": {
         "": {
-            "version": "1.10.5-alpha",
+            "version": "1.11.0",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appservice": "^6.1.0",

--- a/src/docker/files/ContainerFilesUtils.ts
+++ b/src/docker/files/ContainerFilesUtils.ts
@@ -144,7 +144,7 @@ function parseWindowsDirectoryItems(input: string, parentPath: string): Director
 export async function listLinuxContainerDirectory(executor: DockerContainerExecutor, parentPath: string): Promise<DirectoryItem[]> {
     const commandProvider: DockerExecCommandProvider = shell => {
         return shell === 'windows'
-            ? ['/bin/sh', '-c', `"ls -la \"${parentPath}\""`]
+            ? ['/bin/sh', '-c', `"ls -la '${parentPath}'"`]
             : ['/bin/sh', '-c', `ls -la "${parentPath}"`];
     };
 


### PR DESCRIPTION
Fixes #2739. I tried out the command line that it comes up with--both the `stat` and `ls` commands--and each works on both cmd and PowerShell. (Also, of course, I tried it out in the UI)

In theory this should have no effect on Unix but I also validated on my Macbook just to be sure.