### PR TITLE
Compatibility with 1.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
         "onFileSystem:docker",
         "onLanguage:dockerfile",
         "onLanguage:yaml",
+        "onLanguage:dockercompose",
         "onView:dockerContainers",
         "onView:dockerImages",
         "onView:dockerNetworks",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,16 +103,20 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
             scheme: 'file',
             pattern: COMPOSE_FILE_GLOB_PATTERN
         };
+        const COMPOSE_MODE_ID: vscode.DocumentFilter = {
+            language: 'dockercompose',
+            scheme: 'file',
+        };
         let yamlHoverProvider = new DockerComposeHoverProvider(
             new DockerComposeParser(),
             composeVersionKeys.All
         );
         ctx.subscriptions.push(
-            vscode.languages.registerHoverProvider(YAML_MODE_ID, yamlHoverProvider)
+            vscode.languages.registerHoverProvider([YAML_MODE_ID, COMPOSE_MODE_ID], yamlHoverProvider)
         );
         ctx.subscriptions.push(
             vscode.languages.registerCompletionItemProvider(
-                YAML_MODE_ID,
+                [YAML_MODE_ID, COMPOSE_MODE_ID],
                 new DockerComposeCompletionItemProvider(),
                 "."
             )


### PR DESCRIPTION
This change does two small things in 1.11, since 1.12 will not come out until a bit _after_ VSCode 1.55, which contains the new compose language ID.

1. Adds an activation event for `onLanguage:dockercompose`, so that the extension will be activated.
1. Adds a document filter for all `dockercompose` documents so the hover and completion providers work.