### PR TITLE
Use managed service identity for pulling from ACR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appservice": "^6.1.0",
+                "@azure/arm-authorization": "^8.3.3",
                 "@azure/arm-containerregistry": "^8.0.0",
                 "@azure/storage-blob": "^12.4.1",
                 "@docker/sdk": "^1.0.3",
@@ -24,6 +25,7 @@
                 "semver": "^7.3.4",
                 "tar": "^6.1.0",
                 "tar-stream": "^2.2.0",
+                "uuid": "^3.4.0",
                 "vscode-azureappservice": "^0.74.0",
                 "vscode-azureextensionui": "^0.39.2",
                 "vscode-languageclient": "^7.0.0",
@@ -44,6 +46,7 @@
                 "@types/semver": "^7.3.4",
                 "@types/string-replace-webpack-plugin": "^0.1.0",
                 "@types/tar-stream": "^2.2.0",
+                "@types/uuid": "^8.3.0",
                 "@types/vscode": "1.53.0",
                 "@types/xml2js": "^0.4.8",
                 "@typescript-eslint/eslint-plugin": "^4.15.0",
@@ -109,6 +112,16 @@
                 "@azure/ms-rest-azure-js": "^2.0.1",
                 "@azure/ms-rest-js": "^2.0.4",
                 "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/@azure/arm-authorization": {
+            "version": "8.3.3",
+            "resolved": "https://registry.npmjs.org/@azure/arm-authorization/-/arm-authorization-8.3.3.tgz",
+            "integrity": "sha512-CcsUxidMRmioLqFapshYxg3g12A6NUdCnfVARPzxH61Tz5FqATfLDzdSIoLT2EfuKkjA/jEWzkFvoBbNaWBUNA==",
+            "dependencies": {
+                "@azure/ms-rest-azure-js": "^2.0.0",
+                "@azure/ms-rest-js": "^2.0.3",
+                "tslib": "^1.9.3"
             }
         },
         "node_modules/@azure/arm-containerregistry": {
@@ -1243,6 +1256,12 @@
             "dependencies": {
                 "source-map": "^0.6.1"
             }
+        },
+        "node_modules/@types/uuid": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+            "dev": true
         },
         "node_modules/@types/vscode": {
             "version": "1.53.0",
@@ -17926,6 +17945,16 @@
                 "tslib": "^1.10.0"
             }
         },
+        "@azure/arm-authorization": {
+            "version": "8.3.3",
+            "resolved": "https://registry.npmjs.org/@azure/arm-authorization/-/arm-authorization-8.3.3.tgz",
+            "integrity": "sha512-CcsUxidMRmioLqFapshYxg3g12A6NUdCnfVARPzxH61Tz5FqATfLDzdSIoLT2EfuKkjA/jEWzkFvoBbNaWBUNA==",
+            "requires": {
+                "@azure/ms-rest-azure-js": "^2.0.0",
+                "@azure/ms-rest-js": "^2.0.3",
+                "tslib": "^1.9.3"
+            }
+        },
         "@azure/arm-containerregistry": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/@azure/arm-containerregistry/-/arm-containerregistry-8.0.0.tgz",
@@ -18938,6 +18967,12 @@
             "requires": {
                 "source-map": "^0.6.1"
             }
+        },
+        "@types/uuid": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+            "dev": true
         },
         "@types/vscode": {
             "version": "1.53.0",

--- a/package.json
+++ b/package.json
@@ -2728,6 +2728,7 @@
         "@types/semver": "^7.3.4",
         "@types/string-replace-webpack-plugin": "^0.1.0",
         "@types/tar-stream": "^2.2.0",
+        "@types/uuid": "^8.3.0",
         "@types/vscode": "1.53.0",
         "@types/xml2js": "^0.4.8",
         "@typescript-eslint/eslint-plugin": "^4.15.0",
@@ -2757,6 +2758,7 @@
     },
     "dependencies": {
         "@azure/arm-appservice": "^6.1.0",
+        "@azure/arm-authorization": "^8.3.3",
         "@azure/arm-containerregistry": "^8.0.0",
         "@azure/storage-blob": "^12.4.1",
         "@docker/sdk": "^1.0.3",
@@ -2772,6 +2774,7 @@
         "semver": "^7.3.4",
         "tar": "^6.1.0",
         "tar-stream": "^2.2.0",
+        "uuid": "^3.4.0",
         "vscode-azureappservice": "^0.74.0",
         "vscode-azureextensionui": "^0.39.2",
         "vscode-languageclient": "^7.0.0",

--- a/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
+++ b/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Progress } from "vscode";
+import { IAppServiceWizardContext } from "vscode-azureappservice"; // These are only dev-time imports so don't need to be lazy
+import { AzureWizardExecuteStep, createAzureClient } from "vscode-azureextensionui";
+import { ext } from "../../../extensionVariables";
+import { localize } from "../../../localize";
+import { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
+import { RemoteTagTreeItem } from '../../../tree/registries/RemoteTagTreeItem';
+
+export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
+    public priority: number = 141; // execute after DockerSiteCreateStep
+
+    public constructor(private readonly tagTreeItem: RemoteTagTreeItem) {
+        super();
+    }
+
+    public async execute(context: IAppServiceWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        const message: string = localize('vscode-docker.commands.registries.azure.deployImage.assigningPullRole', 'Granting permission for App Service to pull image from ACR...');
+        ext.outputChannel.appendLine(message);
+        progress.report({ message: message });
+
+        const armAuth = await import('@azure/arm-authorization');
+        const armContainerRegistry = await import('@azure/arm-containerregistry');
+        const armAppService = await import('@azure/arm-appservice');
+        const authClient = createAzureClient(context, armAuth.AuthorizationManagementClient);
+        const crmClient = createAzureClient(context, armContainerRegistry.ContainerRegistryManagementClient);
+        const appSvcClient = createAzureClient(context, armAppService.WebSiteManagementClient);
+
+        // If we're in execute, then `shouldExecute` passed and `this.treeItem.parent.parent` is guaranteed to be an AzureRegistryTreeItem
+        const registryTreeItem: AzureRegistryTreeItem = this.tagTreeItem.parent.parent as AzureRegistryTreeItem;
+
+        // 1. Get the registry resource. We will need the ID.
+        const registry = await crmClient.registries.get(registryTreeItem.resourceGroup, registryTreeItem.registryName);
+
+        // 2. Get the role definition for the AcrPull role. We will need the definition ID.
+        const acrPullRoleDefinition = (await authClient.roleDefinitions.list(registry.id, { filter: `roleName eq 'AcrPull'` }))[0];
+
+        // 3. Get the info for the now-created web site. We will need the principal ID.
+        const siteInfo = await appSvcClient.webApps.get(context.site.resourceGroup, context.site.name);
+
+        // 4. On the registry, assign the AcrPull role to the principal representing the website
+        await authClient.roleAssignments.create(registry.id, (await import('uuid')).v4(), {
+            principalId: siteInfo.identity.principalId,
+            roleDefinitionId: acrPullRoleDefinition.id,
+            principalType: 'ServicePrincipal',
+        });
+    }
+
+    public shouldExecute(context: IAppServiceWizardContext): boolean {
+        return !!(context.site) && !!(this.tagTreeItem?.parent?.parent) && this.tagTreeItem.parent.parent instanceof AzureRegistryTreeItem;
+    }
+}

--- a/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
+++ b/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
@@ -30,7 +30,7 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
         const crmClient = createAzureClient(context, armContainerRegistry.ContainerRegistryManagementClient);
         const appSvcClient = createAzureClient(context, armAppService.WebSiteManagementClient);
 
-        // If we're in execute, then `shouldExecute` passed and `this.treeItem.parent.parent` is guaranteed to be an AzureRegistryTreeItem
+        // If we're in `execute`, then `shouldExecute` passed and `this.tagTreeItem.parent.parent` is guaranteed to be an AzureRegistryTreeItem
         const registryTreeItem: AzureRegistryTreeItem = this.tagTreeItem.parent.parent as AzureRegistryTreeItem;
 
         // 1. Get the registry resource. We will need the ID.

--- a/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
+++ b/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
@@ -48,6 +48,11 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
             roleDefinitionId: acrPullRoleDefinition.id,
             principalType: 'ServicePrincipal',
         });
+
+        // 5. Set the web app to use the desired ACR image, which was not done in DockerSiteCreateStep. Get the config and then update it.
+        const config = await appSvcClient.webApps.getConfiguration(context.site.resourceGroup, context.site.name);
+        config.linuxFxVersion = `DOCKER|${registryTreeItem.baseImagePath}/${this.tagTreeItem.repoNameAndTag}`;
+        await appSvcClient.webApps.updateConfiguration(context.site.resourceGroup, context.site.name, config);
     }
 
     public shouldExecute(context: IAppServiceWizardContext): boolean {

--- a/src/commands/registries/azure/DockerSiteCreateStep.ts
+++ b/src/commands/registries/azure/DockerSiteCreateStep.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WebSiteManagementClient, WebSiteManagementModels } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
+import { Progress } from "vscode";
+import { IAppServiceWizardContext } from "vscode-azureappservice"; // These are only dev-time imports so don't need to be lazy
+import { AzureWizardExecuteStep, createAzureClient } from "vscode-azureextensionui";
+import { ext } from "../../../extensionVariables";
+import { localize } from "../../../localize";
+import { nonNullProp, nonNullValueAndProp } from "../../../utils/nonNull";
+
+export class DockerSiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
+    public priority: number = 140;
+
+    public constructor(private readonly siteConfig: WebSiteManagementModels.SiteConfig) {
+        super();
+    }
+
+    public async execute(context: IAppServiceWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        const creatingNewApp: string = localize('vscode-docker.commands.registries.azure.deployImage.creatingWebApp', 'Creating web app "{0}"...', context.newSiteName);
+        ext.outputChannel.appendLine(creatingNewApp);
+        progress.report({ message: creatingNewApp });
+
+        const armAppService = await import('@azure/arm-appservice');
+        const client: WebSiteManagementClient = createAzureClient(context, armAppService.WebSiteManagementClient);
+        context.site = await client.webApps.createOrUpdate(nonNullValueAndProp(context.resourceGroup, 'name'), nonNullProp(context, 'newSiteName'), {
+            name: context.newSiteName,
+            kind: 'app,linux',
+            location: nonNullValueAndProp(context.location, 'name'),
+            serverFarmId: nonNullValueAndProp(context.plan, 'id'),
+            siteConfig: this.siteConfig,
+            identity: {
+                type: 'SystemAssigned'
+            },
+        });
+    }
+
+    public shouldExecute(context: IAppServiceWizardContext): boolean {
+        return !context.site;
+    }
+}

--- a/src/commands/registries/azure/DockerWebhookCreateStep.ts
+++ b/src/commands/registries/azure/DockerWebhookCreateStep.ts
@@ -18,7 +18,7 @@ import { cryptoUtils } from '../../../utils/cryptoUtils';
 import { nonNullProp } from "../../../utils/nonNull";
 
 export class DockerWebhookCreateStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
-    public priority: number = 141; // execute after DockerSiteCreate
+    public priority: number = 142; // execute after DockerAssignAcrPullRoleStep
     private _treeItem: RemoteTagTreeItem;
     public constructor(treeItem: RemoteTagTreeItem) {
         super();

--- a/src/commands/registries/azure/deployImageToAzure.ts
+++ b/src/commands/registries/azure/deployImageToAzure.ts
@@ -88,14 +88,18 @@ async function getNewSiteConfig(node: RemoteTagTreeItem): Promise<WebSiteManagem
     let username: string | undefined;
     let password: string | undefined;
     let appSettings: WebSiteManagementModels.NameValuePair[] = [];
-    let acrUseManagedIdentityCreds: boolean | undefined;
-    if (registryTI instanceof DockerHubNamespaceTreeItem) {
+
+    if (registryTI instanceof AzureRegistryTreeItem) {
+        appSettings.push({ name: "DOCKER_ENABLE_CI", value: 'true' });
+
+        // Don't need an image, username, or password--just create an empty web app to assign permissions and then configure with an image
+        return {
+            acrUseManagedIdentityCreds: true,
+            appSettings
+        };
+    } else if (registryTI instanceof DockerHubNamespaceTreeItem) {
         username = registryTI.parent.username;
         password = await registryTI.parent.getPassword();
-    } else if (registryTI instanceof AzureRegistryTreeItem) {
-        // Don't need username / password, just linuxFxVersion (set below) and acrUseManagedIdentityCreds = true
-        acrUseManagedIdentityCreds = true;
-        appSettings.push({ name: "DOCKER_ENABLE_CI", value: 'true' });
     } else if (registryTI instanceof DockerV2RegistryTreeItemBase) {
         appSettings.push({ name: "DOCKER_REGISTRY_SERVER_URL", value: registryTI.baseUrl });
 
@@ -118,7 +122,6 @@ async function getNewSiteConfig(node: RemoteTagTreeItem): Promise<WebSiteManagem
 
     return {
         linuxFxVersion,
-        appSettings,
-        acrUseManagedIdentityCreds,
+        appSettings
     };
 }


### PR DESCRIPTION
Fixes #1685 so we can finally stop punting it. :smile:

Still need to verify:
- [x] The newly-added `@azure/arm-authorization` package does _not_ get loaded before `Deploy to Azure App Service` is called
    - [x] Unpacked
    - [x] Webpacked
- [x] Unconditionally setting the `identity` field doesn't cause problems with deployments from other container registries (e.g. Docker Hub)