### PR TITLE
Prevent uncaught background errors

### DIFF
--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -128,9 +128,13 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInf
             return false;
         }
 
-        // If they are both undefined, return true (matches the behavior of the base class implementation)
+        // If they are both undefined, return true
+        // If only one is undefined, return false
+        // This matches the behavior of the base class implementation, and guards against null refs below
         if (array1 === undefined && array2 === undefined) {
             return true;
+        } else if (array1 === undefined || array2 === undefined) {
+            return false;
         }
 
         // Containers' labels/descriptions (status in particular) can change. If they do, we want to cause a refresh. But, we also don't want to change the tree ID based on status (in `getTreeId()` in LocalRootTreeItemBase.ts).

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -128,6 +128,11 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInf
             return false;
         }
 
+        // If they are both undefined, return true (matches the behavior of the base class implementation)
+        if (array1 === undefined && array2 === undefined) {
+            return true;
+        }
+
         // Containers' labels/descriptions (status in particular) can change. If they do, we want to cause a refresh. But, we also don't want to change the tree ID based on status (in `getTreeId()` in LocalRootTreeItemBase.ts).
         return !array1.some((item, index) => {
             return this.getTreeItemLabel(item) !== this.getTreeItemLabel(array2[index]) ||


### PR DESCRIPTION
If the Containers tree view had an error node instead of an empty array, the `areArraysEqual` implementation would throw because it was trying to do `.some()` on `undefined`. This adds a guard against one or both of the arrays being `undefined`, while mirroring the behavior of the base class' implementation if both were `undefined`.