### PR TITLE
Support sovereign clouds with ACI features

### DIFF
--- a/src/commands/registries/azure/deployImageToAci.ts
+++ b/src/commands/registries/azure/deployImageToAci.ts
@@ -10,6 +10,7 @@ import { localize } from '../../../localize';
 import { ContextTreeItem } from '../../../tree/contexts/ContextTreeItem';
 import { registryExpectedContextValues } from '../../../tree/registries/registryContextValues';
 import { RemoteTagTreeItem } from '../../../tree/registries/RemoteTagTreeItem';
+import { promptForAciCloud } from '../../../utils/azureUtils';
 import { executeAsTask } from '../../../utils/executeAsTask';
 import { execAsync } from '../../../utils/spawnAsync';
 import { addImageTaggingTelemetry } from '../../images/tagImage';
@@ -51,7 +52,7 @@ export async function deployImageToAci(context: IActionContext, node?: RemoteTag
         await executeAsTask(context, command, title, { ...options, rejectOnError: true });
     } catch {
         // If it fails, try logging in and make one more attempt
-        await executeAsTask(context, 'docker login azure', title, options);
+        await executeAsTask(context, `docker login azure --cloud-name ${await promptForAciCloud(context)}`, title, options);
         await executeAsTask(context, command, title, options);
     }
 }

--- a/src/commands/registries/azure/deployImageToAci.ts
+++ b/src/commands/registries/azure/deployImageToAci.ts
@@ -84,33 +84,35 @@ async function getImagePorts(fullTag: string): Promise<number[]> {
 
 async function promptForAciCloud(context: IActionContext): Promise<string> {
     let result: string;
-    const other = 'Other';
+    const custom = 'custom';
+
+    // Obtained these names from https://github.com/microsoft/vscode-azure-account/blob/78799ce1a3b902aad52744a600b81a2f4fd06380/src/azure-account.ts
     const wellKnownClouds: IAzureQuickPickItem<string>[] = [
         {
-            label: localize('vscode-docker.azureUtils.publicCloud', 'Public'),
+            label: localize('vscode-docker.azureUtils.publicCloud', 'Azure'),
             data: 'AzureCloud',
         },
         {
-            label: localize('vscode-docker.azureUtils.chinaCloud', 'China'),
+            label: localize('vscode-docker.azureUtils.chinaCloud', 'Azure China'),
             data: 'AzureChinaCloud',
         },
         {
-            label: localize('vscode-docker.azureUtils.usGovtCloud', 'US Government'),
+            label: localize('vscode-docker.azureUtils.usGovtCloud', 'Azure US Government'),
             data: 'AzureUSGovernment',
         },
         {
-            label: localize('vscode-docker.azureUtils.germanCloud', 'Germany'), // TODO: AzureGermanCloud is closing in October 2021, remove this then
+            label: localize('vscode-docker.azureUtils.germanCloud', 'Azure Germany'), // TODO: AzureGermanCloud is closing in October 2021, remove this then
             data: 'AzureGermanCloud',
         },
         {
-            label: localize('vscode-docker.azureUtils.otherCloud', 'Other (specify)...'),
-            data: other,
+            label: localize('vscode-docker.azureUtils.customCloud', 'Azure Custom Cloud (specify)...'),
+            data: custom,
         },
     ];
 
     const choice = await ext.ui.showQuickPick(wellKnownClouds, { placeHolder: localize('vscode-docker.azureUtils.chooseCloud', 'Choose an Azure cloud to log in to') });
 
-    if (choice.data === other) {
+    if (choice.data === custom) {
         // The user wants to enter a different cloud name, so prompt with an input box
         result = await ext.ui.showInputBox({ prompt: localize('vscode-docker.azureUtils.inputCloudName', 'Enter an Azure cloud name') });
     } else {

--- a/src/commands/registries/azure/deployImageToAci.ts
+++ b/src/commands/registries/azure/deployImageToAci.ts
@@ -91,16 +91,16 @@ async function promptForAciCloud(context: IActionContext): Promise<string> {
             data: 'AzureCloud',
         },
         {
-            label: localize('vscode-docker.azureUtils.germanCloud', 'Germany'),
-            data: 'AzureGermanCloud',
-        },
-        {
             label: localize('vscode-docker.azureUtils.chinaCloud', 'China'),
             data: 'AzureChinaCloud',
         },
         {
             label: localize('vscode-docker.azureUtils.usGovtCloud', 'US Government'),
             data: 'AzureUSGovernment',
+        },
+        {
+            label: localize('vscode-docker.azureUtils.germanCloud', 'Germany'), // TODO: AzureGermanCloud is closing in October 2021, remove this then
+            data: 'AzureGermanCloud',
         },
         {
             label: localize('vscode-docker.azureUtils.otherCloud', 'Other (specify)...'),

--- a/src/tree/contexts/aci/AciContextCreateStep.ts
+++ b/src/tree/contexts/aci/AciContextCreateStep.ts
@@ -7,6 +7,7 @@ import { Progress } from 'vscode';
 import { AzureWizardExecuteStep, parseError } from 'vscode-azureextensionui';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
+import { promptForAciCloud } from '../../../utils/azureUtils';
 import { executeAsTask } from '../../../utils/executeAsTask';
 import { execAsync } from '../../../utils/spawnAsync';
 import { IAciWizardContext } from './IAciWizardContext';
@@ -30,7 +31,7 @@ export class AciContextCreateStep extends AzureWizardExecuteStep<IAciWizardConte
             if (error.errorType === '5' || /not logged in/i.test(error.message)) {
                 // If error is due to being not logged in, we'll go through login and try again
                 // Because login could involve device auth we do this step in the terminal
-                await executeAsTask(wizardContext, 'docker login azure', localize('vscode-docker.commands.contexts.create.aci.azureLogin', 'Azure Login'), { rejectOnError: true });
+                await executeAsTask(wizardContext, `docker login azure --cloud-name ${await promptForAciCloud(wizardContext)}`, localize('vscode-docker.commands.contexts.create.aci.azureLogin', 'Azure Login'), { rejectOnError: true });
                 await execAsync(command);
             } else {
                 // Otherwise rethrow

--- a/src/tree/contexts/aci/AciContextCreateStep.ts
+++ b/src/tree/contexts/aci/AciContextCreateStep.ts
@@ -7,7 +7,6 @@ import { Progress } from 'vscode';
 import { AzureWizardExecuteStep, parseError } from 'vscode-azureextensionui';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
-import { promptForAciCloud } from '../../../utils/azureUtils';
 import { executeAsTask } from '../../../utils/executeAsTask';
 import { execAsync } from '../../../utils/spawnAsync';
 import { IAciWizardContext } from './IAciWizardContext';
@@ -31,7 +30,7 @@ export class AciContextCreateStep extends AzureWizardExecuteStep<IAciWizardConte
             if (error.errorType === '5' || /not logged in/i.test(error.message)) {
                 // If error is due to being not logged in, we'll go through login and try again
                 // Because login could involve device auth we do this step in the terminal
-                await executeAsTask(wizardContext, `docker login azure --cloud-name ${await promptForAciCloud(wizardContext)}`, localize('vscode-docker.commands.contexts.create.aci.azureLogin', 'Azure Login'), { rejectOnError: true });
+                await executeAsTask(wizardContext, `docker login azure --cloud-name ${wizardContext.environment.name}`, localize('vscode-docker.commands.contexts.create.aci.azureLogin', 'Azure Login'), { rejectOnError: true });
                 await execAsync(command);
             } else {
                 // Otherwise rethrow

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -5,8 +5,7 @@
 
 import { Request } from 'node-fetch';
 import { URLSearchParams } from 'url';
-import { IActionContext, IAzureQuickPickItem, ISubscriptionContext } from 'vscode-azureextensionui';
-import { ext } from '../extensionVariables';
+import { ISubscriptionContext } from 'vscode-azureextensionui';
 import { localize } from '../localize';
 import { httpRequest, RequestOptionsLike } from './httpRequest';
 
@@ -71,42 +70,3 @@ export async function acquireAcrRefreshToken(registryHost: string, subContext: I
     return (await response.json()).refresh_token;
 }
 /* eslint-enable camelcase */
-
-export async function promptForAciCloud(context: IActionContext): Promise<string> {
-    let result: string;
-    const other = 'Other';
-    const wellKnownClouds: IAzureQuickPickItem<string>[] = [
-        {
-            label: localize('vscode-docker.azureUtils.publicCloud', 'Public'),
-            data: 'AzureCloud',
-        },
-        {
-            label: localize('vscode-docker.azureUtils.germanCloud', 'Germany'),
-            data: 'AzureGermanCloud',
-        },
-        {
-            label: localize('vscode-docker.azureUtils.chinaCloud', 'China'),
-            data: 'AzureChinaCloud',
-        },
-        {
-            label: localize('vscode-docker.azureUtils.usGovtCloud', 'US Government'),
-            data: 'AzureUSGovernment',
-        },
-        {
-            label: localize('vscode-docker.azureUtils.otherCloud', 'Other (specify)...'),
-            data: other,
-        },
-    ];
-
-    const choice = await ext.ui.showQuickPick(wellKnownClouds, { placeHolder: localize('vscode-docker.azureUtils.chooseCloud', 'Choose an Azure cloud to log in to') });
-
-    if (choice.data === other) {
-        // The user wants to enter a different cloud name, so prompt with an input box
-        result = await ext.ui.showInputBox({ prompt: localize('vscode-docker.azureUtils.inputCloudName', 'Enter an Azure cloud name') });
-    } else {
-        result = choice.data;
-    }
-
-    context.telemetry.properties.cloudChoice = result;
-    return result;
-}

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -74,6 +74,7 @@ export async function acquireAcrRefreshToken(registryHost: string, subContext: I
 
 export async function promptForAciCloud(context: IActionContext): Promise<string> {
     let result: string;
+    const other = 'Other';
     const wellKnownClouds: IAzureQuickPickItem<string>[] = [
         {
             label: localize('vscode-docker.azureUtils.publicCloud', 'Public'),
@@ -92,16 +93,16 @@ export async function promptForAciCloud(context: IActionContext): Promise<string
             data: 'AzureUSGovernment',
         },
         {
-            label: localize('vscode-docker.azureUtils.otherCloud', 'Other...'),
-            data: 'Other',
+            label: localize('vscode-docker.azureUtils.otherCloud', 'Other (specify)...'),
+            data: other,
         },
     ];
 
-    const choice = await ext.ui.showQuickPick(wellKnownClouds, { placeHolder: localize('vscode-docker.azureUtils.chooseCloud', 'Choose a cloud to log in to') });
+    const choice = await ext.ui.showQuickPick(wellKnownClouds, { placeHolder: localize('vscode-docker.azureUtils.chooseCloud', 'Choose an Azure cloud to log in to') });
 
-    if (choice.data === 'Other') {
+    if (choice.data === other) {
         // The user wants to enter a different cloud name, so prompt with an input box
-        result = await ext.ui.showInputBox({ prompt: localize('vscode-docker.azureUtils.inputCloudName', 'Enter a cloud name') });
+        result = await ext.ui.showInputBox({ prompt: localize('vscode-docker.azureUtils.inputCloudName', 'Enter an Azure cloud name') });
     } else {
         result = choice.data;
     }


### PR DESCRIPTION
Fixes #2775.

In the "Create ACI Context" case, the user must already be signed in to the Azure Account extension--we use it to have them pick a subscription and resource group--so knowing the cloud ID is trivial.

In the "Deploy to ACI" case, the Azure Account extension is not required, simply having an existing ACI context is sufficient. There's not a good way to know what region an ACI context belongs to with any `docker context inspect` / etc. calls. So, if deployment fails due to expired token / not signed in / etc., we will have to prompt the user for which cloud to sign in to.