### PR TITLE
Move the What's New section to the bottom of the page

### DIFF
--- a/resources/startPage.html.template
+++ b/resources/startPage.html.template
@@ -83,25 +83,6 @@
             </div>
         </div>
         <hr />
-        {{#if showWhatsNew}}
-        <div class="row">
-            <div class="icon">
-                <i class="codicon codicon-star-empty" alt=""></i>
-            </div>
-            <div>
-                <div>
-                    <h2>What's New</h2>
-                </div>
-                <div>
-                    <ul>
-                        <li>The <a href="command:workbench.view.extension.dockerView">Docker Explorer</a> now has advanced tooltips! Hover your mouse over an item to see useful info.</li>
-                        <li>You can now open and download the files in a running container! Expand a container node to get started.</li>
-                        <li>Right-click on a Docker Compose file to try our new <a href="command:vscode-docker.compose.up.subset?%7B%22commandReason%22%3A%22startPage%22%7D">Docker: Compose Up - Select Services</a> command!</li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-        {{/if}}
         <div class="row">
             <div class="icon">
                 <i class="codicon codicon-new-file" alt=""></i>
@@ -181,6 +162,25 @@
                 </div>
             </div>
         </div>
+        {{#if showWhatsNew}}
+        <div class="row">
+            <div class="icon">
+                <i class="codicon codicon-star-empty" alt=""></i>
+            </div>
+            <div>
+                <div>
+                    <h2>What's New</h2>
+                </div>
+                <div>
+                    <ul>
+                        <li>The <a href="command:workbench.view.extension.dockerView">Docker Explorer</a> now has advanced tooltips! Hover your mouse over an item to see useful info.</li>
+                        <li>You can now open and download the files in a running container! Expand a container node to get started.</li>
+                        <li>Right-click on a Docker Compose file to try our new <a href="command:vscode-docker.compose.up.subset?%7B%22commandReason%22%3A%22startPage%22%7D">Docker: Compose Up - Select Services</a> command!</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        {{/if}}
         <div class="row footer">
             <div>
                 Visit the extension's <a href="https://github.com/microsoft/vscode-docker">GitHub repository</a>,

--- a/src/commands/startPage/StartPage.ts
+++ b/src/commands/startPage/StartPage.ts
@@ -63,6 +63,11 @@ class StartPage {
         const webview = this.activePanel.webview;
         const templatePath = vscode.Uri.joinPath(resourcesRoot, 'startPage.html.template');
 
+        let showWhatsNew = false;
+        try {
+            showWhatsNew = !!(await ext.experimentationService.isLiveFlightEnabled('vscode-docker.whatsNew'));
+        } catch { } // Best effort
+
         const startPageContext: StartPageContext = {
             cspSource: webview.cspSource,
             nonce: cryptoUtils.getRandomHexString(8),
@@ -71,7 +76,7 @@ class StartPage {
             dockerIconUri: webview.asWebviewUri(vscode.Uri.joinPath(resourcesRoot, 'docker_blue.png')).toString(),
             showStartPageChecked: vscode.workspace.getConfiguration('docker').get('showStartPage', false) ? 'checked' : '',
             isMac: isMac(),
-            showWhatsNew: !!(await ext.experimentationService.isLiveFlightEnabled('vscode-docker.whatsNew')),
+            showWhatsNew: showWhatsNew,
         };
 
         const template = Handlebars.compile(await fse.readFile(templatePath.fsPath, 'utf-8'));


### PR DESCRIPTION
Text is unchanged, but moves the What's New blurb to the bottom. Looks like this now:

![image](https://user-images.githubusercontent.com/36966225/112376261-9960dd80-8cba-11eb-9392-c3410a2fcac2.png)