### PR TITLE
Updating README with guidance to use rootless Docker for linux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Docker extension makes it easy to build, manage, and deploy containerized ap
 
 [Install Docker](https://docs.docker.com/install/) on your machine and add it to the system path.
 
-On Linux, you should also [enable Docker CLI for the non-root user account](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) that will be used to run VS Code.
+On Linux, you should [enable rootless Docker](https://docs.docker.com/engine/security/rootless/) (most secure) or [enable Docker CLI for the non-root user account](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) (less secure) that will be used to run VS Code.
 
 To install the extension, open the Extensions view, search for `docker` to filter results and select Docker extension authored by Microsoft.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Docker extension makes it easy to build, manage, and deploy containerized ap
 
 [Install Docker](https://docs.docker.com/install/) on your machine and add it to the system path.
 
-On Linux, you should [enable rootless Docker](https://docs.docker.com/engine/security/rootless/) (most secure) or [enable Docker CLI for the non-root user account](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) (less secure) that will be used to run VS Code.
+On Linux, you should [enable rootless Docker](https://docs.docker.com/engine/security/rootless/) (more secure) or [enable Docker CLI for the non-root user account](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) (less secure) that will be used to run VS Code.
 
 To install the extension, open the Extensions view, search for `docker` to filter results and select Docker extension authored by Microsoft.
 


### PR DESCRIPTION
I noticed on the installation page in vscode that linux users are recommended to enable the Docker CLI for non-root users, but this can have some significant security considerations. I am proposing to add a section before this that recommends a rootless Docker configuration. I am running Ubuntu Desktop 20.04 and rootless Docker appears to work well with the extension. 