### PR TITLE
Use `adduser` instead of `useradd`

### DIFF
--- a/resources/templates/netCore/Dockerfile.template
+++ b/resources/templates/netCore/Dockerfile.template
@@ -14,7 +14,7 @@ ENV ASPNETCORE_URLS=http://+:{{ ports.[0] }}
 {{#if (eq netCorePlatformOS 'Linux')}}
 # Creates a non-root user with an explicit UID and adds permission to access the /app folder
 # For more info, please refer to https://aka.ms/vscode-docker-dotnet-configure-containers
-RUN useradd -u 5678 appuser && chown -R appuser /app
+RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
 {{/if}}

--- a/resources/templates/python/Dockerfile.template
+++ b/resources/templates/python/Dockerfile.template
@@ -27,7 +27,7 @@ COPY . /app
 {{#unless (isRootPort ports)}}
 # Creates a non-root user with an explicit UID and adds permission to access the /app folder
 # For more info, please refer to https://aka.ms/vscode-docker-python-configure-containers
-RUN useradd -u 5678 appuser && chown -R appuser /app
+RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
 {{/unless}}


### PR DESCRIPTION
Fixes #2821 using a command that works on both Alpine and Buster images, for both .NET and Python. However I think it's kind of ugly. Alternatively, we could won't-fix or use documentation. @ucheNkadiCode @karolz-ms what do you think? Personally I'd say just live with the ugliness but I'm interested to hear what you think.