### PR TITLE
Use fixed ports for .NET in compose files

### DIFF
--- a/resources/templates/netCore/docker-compose.debug.yml.template
+++ b/resources/templates/netCore/docker-compose.debug.yml.template
@@ -13,7 +13,7 @@ services:
 {{#if ports}}
     ports:
 {{#each ports}}
-      - {{ . }}
+      - {{ . }}:{{ . }}
 {{/each}}
 {{/if}}
 {{#if ports}}

--- a/resources/templates/netCore/docker-compose.yml.template
+++ b/resources/templates/netCore/docker-compose.yml.template
@@ -13,6 +13,6 @@ services:
 {{#if ports}}
     ports:
 {{#each ports}}
-      - {{ . }}
+      - {{ . }}:{{ . }}
 {{/each}}
 {{/if}}


### PR DESCRIPTION
Fixes #2825. This is basically reverting #2314. Since .NET now uses ports > 1024 by default, it isn't as important to allow Docker to randomly assign ports.

This now brings .NET to parity with all our other platforms, which also use fixed ports.