### PR TITLE
Upgrade to language server 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@docker/sdk": "^1.0.3",
                 "@grpc/grpc-js": "^1.2.6",
                 "dayjs": "^1.10.4",
-                "dockerfile-language-server-nodejs": "^0.3.0",
+                "dockerfile-language-server-nodejs": "^0.4.0",
                 "dockerode": "^3.2.1",
                 "fs-extra": "^9.1.0",
                 "glob": "^7.1.6",
@@ -3930,9 +3930,9 @@
             }
         },
         "node_modules/dockerfile-ast": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.1.0.tgz",
-            "integrity": "sha512-qKftHMVoMliYBaYLkgttm+NXhRISVNkIMfAL4ecmXjiWRElfdfY+xNgITiehG0LpUEDbFUa/UDCByYq/2UZIpQ==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.2.0.tgz",
+            "integrity": "sha512-iQyp12k1A4tF3sEfLAq2wfFPKdpoiGTJeuiu2Y1bdEqIZu0DfSSL2zm0fk7a/UHeQkngnYaRRGuON+C+2LO1Fw==",
             "dependencies": {
                 "vscode-languageserver-types": "^3.16.0"
             },
@@ -3941,11 +3941,11 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.3.0.tgz",
-            "integrity": "sha512-nW0l6S6YZlSGrGu6PBHoLmhwqwxgNTSis1hvjaxpnS3Ohalf/e87HC/pkjg3c+AixytqlXPR7nixzVPDJTkNZQ==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.4.0.tgz",
+            "integrity": "sha512-tfRIVVHzLEFXXiwhLDlNHLQVddnhYpLVOVBU3rYoIbw6Trb+v/p9Ajc80gAwJ97rwi3yfM/976/AP/NgRguenw==",
             "dependencies": {
-                "dockerfile-language-service": "0.2.0",
+                "dockerfile-language-service": "0.3.0",
                 "dockerfile-utils": "0.2.0",
                 "vscode-languageserver": "^7.0.0"
             },
@@ -3957,18 +3957,53 @@
             }
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.2.0.tgz",
-            "integrity": "sha512-Y1JYIDF8F78kNDwyoQoeAPzptJRubIaMJ5q4mATmeDViGVV+mY4m6BjHqw5XtlkHEftljgqMNDvbUORUDIzTHg==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.3.0.tgz",
+            "integrity": "sha512-BUStimzz1Ozh41o+2AgMfwW8M7KsqzOBllNlLkf7NDe6W9KvcC3d8j4MTc+cU9wfRUoVckK39M2btvRFFDK61w==",
             "dependencies": {
-                "dockerfile-ast": "0.1.0",
-                "dockerfile-utils": "0.2.0",
-                "vscode-languageserver-protocol": "^3.16.0",
+                "dockerfile-ast": "0.2.0",
+                "dockerfile-utils": "0.4.2",
+                "vscode-languageserver-types": "3.17.0-next.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/dockerfile-language-service/node_modules/dockerfile-utils": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.4.2.tgz",
+            "integrity": "sha512-WfJEuXWdVdiarhxJgRlZ9bkMO/9un6dZDz+u3z6AYEXfsH2XRwYqdIvyOqFzaDDP0Hc6pR5rb9FJRSKyo+NuxA==",
+            "dependencies": {
+                "dockerfile-ast": "0.2.1",
+                "vscode-languageserver-types": "^3.16.0"
+            },
+            "bin": {
+                "dockerfile-utils": "bin/dockerfile-utils"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/dockerfile-language-service/node_modules/dockerfile-utils/node_modules/dockerfile-ast": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.2.1.tgz",
+            "integrity": "sha512-ut04CVM1G6zIITTcYPDIXhPZk9mCa21m4dfW8FcDDGxwgTQhYyHDu6U7M8klZ7QsjqVcJhryKi+TGOX6bjgKdQ==",
+            "dependencies": {
                 "vscode-languageserver-types": "^3.16.0"
             },
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/dockerfile-language-service/node_modules/dockerfile-utils/node_modules/vscode-languageserver-types": {
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+        },
+        "node_modules/dockerfile-language-service/node_modules/vscode-languageserver-types": {
+            "version": "3.17.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.1.tgz",
+            "integrity": "sha512-VGzh06oynbYa6JbTKUbxOEZN7CYEtWhN7DK5wfzUpeCJl8X8xZX39g2PVfpqXrIEduu7dcJgK007KgnX9tHNKA=="
         },
         "node_modules/dockerfile-utils": {
             "version": "0.2.0",
@@ -3980,6 +4015,17 @@
             },
             "bin": {
                 "dockerfile-utils": "bin/dockerfile-utils"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/dockerfile-utils/node_modules/dockerfile-ast": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.1.0.tgz",
+            "integrity": "sha512-qKftHMVoMliYBaYLkgttm+NXhRISVNkIMfAL4ecmXjiWRElfdfY+xNgITiehG0LpUEDbFUa/UDCByYq/2UZIpQ==",
+            "dependencies": {
+                "vscode-languageserver-types": "^3.16.0"
             },
             "engines": {
                 "node": "*"
@@ -18203,32 +18249,62 @@
             }
         },
         "dockerfile-ast": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.1.0.tgz",
-            "integrity": "sha512-qKftHMVoMliYBaYLkgttm+NXhRISVNkIMfAL4ecmXjiWRElfdfY+xNgITiehG0LpUEDbFUa/UDCByYq/2UZIpQ==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.2.0.tgz",
+            "integrity": "sha512-iQyp12k1A4tF3sEfLAq2wfFPKdpoiGTJeuiu2Y1bdEqIZu0DfSSL2zm0fk7a/UHeQkngnYaRRGuON+C+2LO1Fw==",
             "requires": {
                 "vscode-languageserver-types": "^3.16.0"
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.3.0.tgz",
-            "integrity": "sha512-nW0l6S6YZlSGrGu6PBHoLmhwqwxgNTSis1hvjaxpnS3Ohalf/e87HC/pkjg3c+AixytqlXPR7nixzVPDJTkNZQ==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.4.0.tgz",
+            "integrity": "sha512-tfRIVVHzLEFXXiwhLDlNHLQVddnhYpLVOVBU3rYoIbw6Trb+v/p9Ajc80gAwJ97rwi3yfM/976/AP/NgRguenw==",
             "requires": {
-                "dockerfile-language-service": "0.2.0",
+                "dockerfile-language-service": "0.3.0",
                 "dockerfile-utils": "0.2.0",
                 "vscode-languageserver": "^7.0.0"
             }
         },
         "dockerfile-language-service": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.2.0.tgz",
-            "integrity": "sha512-Y1JYIDF8F78kNDwyoQoeAPzptJRubIaMJ5q4mATmeDViGVV+mY4m6BjHqw5XtlkHEftljgqMNDvbUORUDIzTHg==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.3.0.tgz",
+            "integrity": "sha512-BUStimzz1Ozh41o+2AgMfwW8M7KsqzOBllNlLkf7NDe6W9KvcC3d8j4MTc+cU9wfRUoVckK39M2btvRFFDK61w==",
             "requires": {
-                "dockerfile-ast": "0.1.0",
-                "dockerfile-utils": "0.2.0",
-                "vscode-languageserver-protocol": "^3.16.0",
-                "vscode-languageserver-types": "^3.16.0"
+                "dockerfile-ast": "0.2.0",
+                "dockerfile-utils": "0.4.2",
+                "vscode-languageserver-types": "3.17.0-next.1"
+            },
+            "dependencies": {
+                "dockerfile-utils": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.4.2.tgz",
+                    "integrity": "sha512-WfJEuXWdVdiarhxJgRlZ9bkMO/9un6dZDz+u3z6AYEXfsH2XRwYqdIvyOqFzaDDP0Hc6pR5rb9FJRSKyo+NuxA==",
+                    "requires": {
+                        "dockerfile-ast": "0.2.1",
+                        "vscode-languageserver-types": "^3.16.0"
+                    },
+                    "dependencies": {
+                        "dockerfile-ast": {
+                            "version": "0.2.1",
+                            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.2.1.tgz",
+                            "integrity": "sha512-ut04CVM1G6zIITTcYPDIXhPZk9mCa21m4dfW8FcDDGxwgTQhYyHDu6U7M8klZ7QsjqVcJhryKi+TGOX6bjgKdQ==",
+                            "requires": {
+                                "vscode-languageserver-types": "^3.16.0"
+                            }
+                        },
+                        "vscode-languageserver-types": {
+                            "version": "3.16.0",
+                            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+                            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+                        }
+                    }
+                },
+                "vscode-languageserver-types": {
+                    "version": "3.17.0-next.1",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.1.tgz",
+                    "integrity": "sha512-VGzh06oynbYa6JbTKUbxOEZN7CYEtWhN7DK5wfzUpeCJl8X8xZX39g2PVfpqXrIEduu7dcJgK007KgnX9tHNKA=="
+                }
             }
         },
         "dockerfile-utils": {
@@ -18238,6 +18314,16 @@
             "requires": {
                 "dockerfile-ast": "0.1.0",
                 "vscode-languageserver-types": "^3.16.0"
+            },
+            "dependencies": {
+                "dockerfile-ast": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.1.0.tgz",
+                    "integrity": "sha512-qKftHMVoMliYBaYLkgttm+NXhRISVNkIMfAL4ecmXjiWRElfdfY+xNgITiehG0LpUEDbFUa/UDCByYq/2UZIpQ==",
+                    "requires": {
+                        "vscode-languageserver-types": "^3.16.0"
+                    }
+                }
             }
         },
         "dockerode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@docker/sdk": "^1.0.3",
                 "@grpc/grpc-js": "^1.2.6",
                 "dayjs": "^1.10.4",
-                "dockerfile-language-server-nodejs": "^0.4.0",
+                "dockerfile-language-server-nodejs": "^0.4.1",
                 "dockerode": "^3.2.1",
                 "fs-extra": "^9.1.0",
                 "glob": "^7.1.6",
@@ -3941,9 +3941,9 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.4.0.tgz",
-            "integrity": "sha512-tfRIVVHzLEFXXiwhLDlNHLQVddnhYpLVOVBU3rYoIbw6Trb+v/p9Ajc80gAwJ97rwi3yfM/976/AP/NgRguenw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.4.1.tgz",
+            "integrity": "sha512-7mB+HdMd4dfjChK1+37++ylA+sy7wFaf0/3HDy6cJDj5dTx4C4vVDmDKQpZgNJU1gIkxDnW6QCLCxpoe5FPyVA==",
             "dependencies": {
                 "dockerfile-language-service": "0.3.0",
                 "dockerfile-utils": "0.2.0",
@@ -18257,9 +18257,9 @@
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.4.0.tgz",
-            "integrity": "sha512-tfRIVVHzLEFXXiwhLDlNHLQVddnhYpLVOVBU3rYoIbw6Trb+v/p9Ajc80gAwJ97rwi3yfM/976/AP/NgRguenw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.4.1.tgz",
+            "integrity": "sha512-7mB+HdMd4dfjChK1+37++ylA+sy7wFaf0/3HDy6cJDj5dTx4C4vVDmDKQpZgNJU1gIkxDnW6QCLCxpoe5FPyVA==",
             "requires": {
                 "dockerfile-language-service": "0.3.0",
                 "dockerfile-utils": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -2761,7 +2761,7 @@
         "@docker/sdk": "^1.0.3",
         "@grpc/grpc-js": "^1.2.6",
         "dayjs": "^1.10.4",
-        "dockerfile-language-server-nodejs": "^0.4.0",
+        "dockerfile-language-server-nodejs": "^0.4.1",
         "dockerode": "^3.2.1",
         "fs-extra": "^9.1.0",
         "glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -2761,7 +2761,7 @@
         "@docker/sdk": "^1.0.3",
         "@grpc/grpc-js": "^1.2.6",
         "dayjs": "^1.10.4",
-        "dockerfile-language-server-nodejs": "^0.3.0",
+        "dockerfile-language-server-nodejs": "^0.4.0",
         "dockerode": "^3.2.1",
         "fs-extra": "^9.1.0",
         "glob": "^7.1.6",


### PR DESCRIPTION
This release comes with a few fixes for some false positives in the linter and an infinite loop fix for semantic tokens. It also comes with some very rudimentary support for code completion based on `WORKDIR` instructions.

Please use the Dockerfiles below for testing.

```Dockerfile
# ARG now supports multiple arguments
# https://github.com/microsoft/vscode-docker/issues/2760
FROM scratch
ARG a=b b

# ${env:variable} is no longer flagged as an error
# https://github.com/microsoft/vscode-docker/issues/2738
ENTRYPOINT powershell -Command \
    kubectl port-forward --address ${env:address} pod/${env:podname} ${env:source}:${env:dest} -n ${env:namespace}
CMD powershell -Command \
    kubectl port-forward --address ${env:address} pod/${env:podname} ${env:source}:${env:dest} -n ${env:namespace}

# ? modifiers will no longer be flagged as an error
ENV FOO=${FOO:?}

# labels will no longer be incorrectly flagged as missing names
# https://github.com/microsoft/vscode-docker/issues/2865
LABEL "com.github.actions.name"="Spell Checker"\
 "com.github.actions.description"="Check repository for spelling errors"\
 "com.github.actions.icon"="edit-3"\
 "com.github.actions.color"="red"\
 "repository"="http://github.com/check-spelling/check-spelling"\
 "homepage"="http://github.com/check-spelling/check-spelling/tree/master/README.md"\
 "maintainer"="Josh Soref <jsoref@noreply.users.github.com>"
```
```Dockerfile
# this Dockerfile will no longer cause an infinite loop when calculating semantic. tokens
# https://github.com/microsoft/vscode-docker/issues/2055#issuecomment-663295938
FROM alpine
ENV kkk \
        vvv \
        # comment
        # comment
        # comment
        # comment
        vvv2
```
```Dockerfile
FROM alpine
WORKDIR /a/b/c
WORKDIR d
# add "a" to the end of the next line to get some rudimentary code completion support
# part of a multi-phased work needed for https://github.com/microsoft/vscode-docker/issues/2537
COPY test.txt /
```
![image](https://user-images.githubusercontent.com/15629116/114312553-fe8d3f00-9ac0-11eb-8118-5b5195f0824c.png)
