### PR TITLE
Fix semver comparisons

### DIFF
--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -131,16 +131,15 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
     }
 
     private async getMinimumCSharpExtensionExports(): Promise<CSharpExtensionExports> {
-        const minCSharpVersion = new semver.SemVer(minCSharpVersionString);
         const cSharpExtension: vscode.Extension<CSharpExtensionExports> | undefined = vscode.extensions.getExtension(cSharpExtensionId);
         const cSharpExtensionVersion: semver.SemVer | undefined = cSharpExtension ? new semver.SemVer((<{ version: string }>cSharpExtension.packageJSON).version) : undefined;
 
         if (!cSharpExtension || !cSharpExtensionVersion) {
             throw new Error(localize('vscode-docker.scaffold.netCoreGatherInformationStep.noCSharpExtension', 'Cannot generate Dockerfiles for a .NET project unless the C# extension is installed.'));
-        } else if (cSharpExtensionVersion < minCSharpVersion) {
+        } else if (semver.lt(cSharpExtensionVersion, minCSharpVersionString)) {
             throw new Error(localize('vscode-docker.scaffold.netCoreGatherInformationStep.badVersionCSharpExtension', 'Cannot generate Dockerfiles for a .NET project unless version {0} or higher of the C# extension is installed.', minCSharpVersionString));
         }
 
-        return cSharpExtension.isActive ? await cSharpExtension.activate() : cSharpExtension.exports;
+        return await cSharpExtension.activate();
     }
 }

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -54,7 +54,7 @@ export namespace PythonExtensionHelper {
 
         const version = new semver.SemVer(pyExt.packageJSON.version);
 
-        if (version.compare(minPyExtensionVersion) < 0) {
+        if (semver.lt(version, minPyExtensionVersion)) {
             await vscode.window.showErrorMessage(localize('vscode-docker.tasks.pythonExt.pythonExtensionNotSupported', 'The installed Python extension does not meet the minimum requirements, please update to the latest version and try again.'));
             return undefined;
         }


### PR DESCRIPTION
A fix in main branch for #2867. SemVer comparisons should be using `.lt()`, `.gte()`, etc. I verified the other places.