### PR TITLE
Shorten "needs more info" close timer from 21 to 14 days

### DIFF
--- a/.github/needs_more_info.yml
+++ b/.github/needs_more_info.yml
@@ -1,5 +1,5 @@
 {
-    daysUntilClose: 21,
+    daysUntilClose: 14,
     needsMoreInfoLabel: 'needs more info',
     perform: true,
     closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity. See also our [issue reporting](https://aka.ms/azcodeissuereporting) guidelines.\n\nHappy Coding!"


### PR DESCRIPTION
Right now our front page of issues has 13 needs-more-info issues, out of 25 total. It's been getting pretty crowded lately.

Additionally, anecdotally I feel like nothing ever happens between days 14-21; I think almost all the customers who are going to respond do so within 7 days, so I think a 14 day closeout time is reasonable.