### PR TITLE
Fix "webview is disposed" error

### DIFF
--- a/src/commands/startPage/StartPage.ts
+++ b/src/commands/startPage/StartPage.ts
@@ -31,10 +31,6 @@ class StartPage {
     public async createOrShow(context: IActionContext): Promise<void> {
         const resourcesRoot = vscode.Uri.joinPath(ext.context.extensionUri, 'resources');
 
-        // If we're using the bundled version, the codicons root URI is at <extensionRoot>/dist/node_modules/vscode-codicons/dist
-        // If we're not using the bundled version, the codicons root URI is <extensionRoot>/node_modules/vscode-codicons/dist
-        const codiconsRoot = vscode.Uri.joinPath(ext.context.extensionUri, ...ext.ignoreBundle ? ['node_modules'] : ['dist', 'node_modules'], 'vscode-codicons', 'dist');
-
         if (!this.activePanel) {
             const template = await this.getTemplate(resourcesRoot);
 
@@ -45,41 +41,52 @@ class StartPage {
                 // Best effort
             }
 
-            this.activePanel = vscode.window.createWebviewPanel(
-                'vscode-docker.startPage',
-                localize('vscode-docker.help.startPage.title', 'Docker - Get Started'),
-                vscode.ViewColumn.One,
-                {
-                    enableCommandUris: true,
-                    enableScripts: true,
-                    localResourceRoots: [resourcesRoot, codiconsRoot],
-                }
-            );
-
-            const listener = this.activePanel.webview.onDidReceiveMessage(async (message: WebviewMessage) => this.handleMessage(message));
-
-            this.activePanel.onDidDispose(() => {
-                this.activePanel = undefined;
-                listener.dispose();
-            });
-
-            const webview = this.activePanel.webview;
-
-            const startPageContext: StartPageContext = {
-                cspSource: webview.cspSource,
-                nonce: cryptoUtils.getRandomHexString(8),
-                codiconsFontUri: webview.asWebviewUri(vscode.Uri.joinPath(codiconsRoot, 'codicon.ttf')).toString(),
-                codiconsStyleUri: webview.asWebviewUri(vscode.Uri.joinPath(codiconsRoot, 'codicon.css')).toString(),
-                dockerIconUri: webview.asWebviewUri(vscode.Uri.joinPath(resourcesRoot, 'docker_blue.png')).toString(),
-                showStartPageChecked: vscode.workspace.getConfiguration('docker').get('showStartPage', false) ? 'checked' : '',
-                isMac: isMac(),
-                showWhatsNew: showWhatsNew,
-            };
-
-            this.activePanel.webview.html = template(startPageContext);
+            // createOrShow() might have been called multiple times in short timeframe
+            if (!this.activePanel) {
+                this.doCreatePanel(resourcesRoot, showWhatsNew, template);
+            }
         }
 
         this.activePanel.reveal();
+    }
+
+    private doCreatePanel(resourcesRoot: vscode.Uri, showWhatsNew: boolean, template: HandlebarsTemplateDelegate<unknown>) {
+        // If we're using the bundled version, the codicons root URI is at <extensionRoot>/dist/node_modules/vscode-codicons/dist
+        // If we're not using the bundled version, the codicons root URI is <extensionRoot>/node_modules/vscode-codicons/dist
+        const codiconsRoot = vscode.Uri.joinPath(ext.context.extensionUri, ...ext.ignoreBundle ? ['node_modules'] : ['dist', 'node_modules'], 'vscode-codicons', 'dist');
+
+        this.activePanel = vscode.window.createWebviewPanel(
+            'vscode-docker.startPage',
+            localize('vscode-docker.help.startPage.title', 'Docker - Get Started'),
+            vscode.ViewColumn.One,
+            {
+                enableCommandUris: true,
+                enableScripts: true,
+                localResourceRoots: [resourcesRoot, codiconsRoot],
+            }
+        );
+
+        const listener = this.activePanel.webview.onDidReceiveMessage(async (message: WebviewMessage) => this.handleMessage(message));
+
+        this.activePanel.onDidDispose(() => {
+            this.activePanel = undefined;
+            listener.dispose();
+        });
+
+        const webview = this.activePanel.webview;
+
+        const startPageContext: StartPageContext = {
+            cspSource: webview.cspSource,
+            nonce: cryptoUtils.getRandomHexString(8),
+            codiconsFontUri: webview.asWebviewUri(vscode.Uri.joinPath(codiconsRoot, 'codicon.ttf')).toString(),
+            codiconsStyleUri: webview.asWebviewUri(vscode.Uri.joinPath(codiconsRoot, 'codicon.css')).toString(),
+            dockerIconUri: webview.asWebviewUri(vscode.Uri.joinPath(resourcesRoot, 'docker_blue.png')).toString(),
+            showStartPageChecked: vscode.workspace.getConfiguration('docker').get('showStartPage', false) ? 'checked' : '',
+            isMac: isMac(),
+            showWhatsNew: showWhatsNew,
+        };
+
+        this.activePanel.webview.html = template(startPageContext);
     }
 
     private async handleMessage(message: WebviewMessage): Promise<void> {


### PR DESCRIPTION
Fixes issue https://github.com/microsoft/vscode-docker/issues/2820

The poblem is likely due to a handful of async calls done beteween when the start page view is created and when its content is set. That gives the user an opportunity to close the start page before we attempt to set its content. It is especially tempting since during the time the content is computed the already-visible start page panel is empty.

This change front-loads that async processing so that the webview creation becomes fully synchronous.