### PR TITLE
Add missing description for debug config property.

### DIFF
--- a/package.json
+++ b/package.json
@@ -740,6 +740,10 @@
                                         "type": "string",
                                         "description": "%vscode-docker.debug.node.localRoot%"
                                     },
+                                    "package": {
+                                        "type": "string",
+                                        "description": "%vscode-docker.debug.node.package%"
+                                    },
                                     "remoteRoot": {
                                         "type": "string",
                                         "description": "%vscode-docker.debug.node.remoteRoot%"

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,6 +19,7 @@
     "vscode-docker.debug.node.timeout": "When restarting a session, give up after this number of milliseconds.",
     "vscode-docker.debug.node.stopOnEntry": "Break immediately when the program launches.",
     "vscode-docker.debug.node.localRoot": "VS Code's root directory.",
+    "vscode-docker.debug.node.package": "The path to the package.json for the application.",
     "vscode-docker.debug.node.remoteRoot": "Node's root directory within the Docker container.",
     "vscode-docker.debug.node.smartStep": "Try to automatically step over code that doesn't map to source files.",
     "vscode-docker.debug.node.skipFiles": "Automatically skip files covered by these glob patterns.",


### PR DESCRIPTION
Adds the missing description for the `package` property of the `node` options of the Docker debug launch configuration.

<img width="556" alt="Screenshot 2021-05-24 at 09 56 00" src="https://user-images.githubusercontent.com/6402946/119382328-bc861a00-bc76-11eb-864b-570fe4f02960.png">

Resolves #2956.