### PR TITLE
Enable formatter to skip instructions that span multiple lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -2166,6 +2166,12 @@
                     ],
                     "description": "%vscode-docker.config.docker.languageserver.diagnostics.instructionWorkdirRelative%"
                 },
+                "docker.languageserver.formatter.ignoreMultilineInstructions": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%vscode-docker.config.docker.languageserver.formatter.ignoreMultilineInstructions%"
+                },
                 "docker.dockerComposeBuild": {
                     "type": "boolean",
                     "default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -182,6 +182,7 @@
     "vscode-docker.config.docker.languageserver.diagnostics.instructionHealthcheckMultiple": "Controls the diagnostic severity for flagging a Dockerfile with multiple HEALTHCHECK instructions",
     "vscode-docker.config.docker.languageserver.diagnostics.instructionJsonInSingleQuotes": "Controls the diagnostic severity for JSON instructions that are written incorrectly with single quotes",
     "vscode-docker.config.docker.languageserver.diagnostics.instructionWorkdirRelative": "Controls the diagnostic severity for WORKDIR instructions that do not point to an absolute path",
+    "vscode-docker.config.docker.languageserver.formatter.ignoreMultilineInstructions": "Controls whether the Dockerfile formatter should ignore instructions that span multiple lines when formatting",
     "vscode-docker.config.docker.dockerComposeBuild": "Set to true to include --build option when docker-compose command is invoked",
     "vscode-docker.config.docker.dockerComposeDetached": "Set to true to include --d (detached) option when docker-compose command is invoked",
     "vscode-docker.config.docker.showRemoteWorkspaceWarning": "Set to true to prompt to switch from \"UI\" extension mode to \"Workspace\" extension mode if an operation is not supported in UI mode.",


### PR DESCRIPTION
Some users want to format instructions that span multiple lines in Dockerfiles themselves. The new setting added here will allow users to decide whether instructions that span multiple lines should be ignored by the formatter or not.

```Dockerfile
FROM scratch
RUN echo && \
            echo && \
                echo && \
        echo
```

1. Create the Dockerfile above.
2. Format the document. The lines in the `RUN` instruction will be formatted.
3. Undo the change so that it's back to its original form.
4. Open the `settings.json` file and add the following setting.
```JSON
{
    "docker.languageserver.formatter.ignoreMultilineInstructions": true
}
```
5. Format the document again. The `RUN` instruction should not be formatted.

This fixes #992 and #2004.