### PR TITLE
Use correct base image for Windows containers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-docker",
-    "version": "1.13.1-alpha",
+    "version": "1.15.0-alpha",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-docker",
-    "version": "1.14.0",
+    "version": "1.15.0-alpha",
     "publisher": "ms-azuretools",
     "displayName": "Docker",
     "description": "Makes it easy to create, manage, and debug containerized applications.",

--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -20,7 +20,7 @@ const minCSharpVersionString = '1.23.9';
 const aspNetBaseImage = 'mcr.microsoft.com/dotnet/aspnet';
 const consoleNetBaseImage = 'mcr.microsoft.com/dotnet/runtime';
 const netSdkImage = 'mcr.microsoft.com/dotnet/sdk';
-const tagSuffix = '-focal';
+const linuxTagSuffix = '-focal';
 
 const cSharpExtensionId = 'ms-dotnettools.csharp';
 const cSharpConfigId = 'csharp';
@@ -59,7 +59,7 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
 
             // semver.coerce tolerates version strings like "5.0" which is typically what is present in the .NET project file
             const netCoreVersion = semver.coerce(netCoreVersionString);
-
+            const tagSuffix = wizardContext.netCorePlatformOS === "Linux" ? linuxTagSuffix : '';
             wizardContext.netCoreRuntimeBaseImage = wizardContext.platform === '.NET: ASP.NET Core' ? `${aspNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}${tagSuffix}` : `${consoleNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}${tagSuffix}`;
             wizardContext.netCoreSdkBaseImage = `${netSdkImage}:${netCoreVersion.major}.${netCoreVersion.minor}${tagSuffix}`;
         }


### PR DESCRIPTION
Somehow we did not realize that we explicitly ask the user whether they want Windows or Linux container. That makes it easy to use slightly different base image in these two cases.

Please disregard changes to package files (there is separate PR for these)