### PR TITLE
Prompt for port during custom location deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,7 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "vscode-docker",
-            "version": "1.13.1-alpha",
+            "version": "1.15.0-alpha",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appservice": "^6.1.0",

--- a/src/commands/registries/azure/WebSitesPortPromptStep.ts
+++ b/src/commands/registries/azure/WebSitesPortPromptStep.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep } from "vscode-azureextensionui";
+import { localize } from '../../../localize';
+import { ext } from "../../../extensionVariables";
+import { IAppServiceContainerWizardContext } from './deployImageToAzure';
+
+export class WebSitesPortPromptStep extends AzureWizardPromptStep<IAppServiceContainerWizardContext> {
+
+    public async prompt(context: IAppServiceContainerWizardContext): Promise<void> {
+        const prompt: string = localize('vscode-docker.deployAppService.WebSitesPortPromptStep.whatPort', 'What port does your app listen on? Leave it empty for app listening on port 80.');
+        const portString: string = await ext.ui.showInputBox({ prompt, validateInput });
+        context.webSitesPort = parseInt(portString, 10) || null;
+    }
+
+    public shouldPrompt(context: IAppServiceContainerWizardContext): boolean {
+        return !!context.customLocation;
+    }
+}
+
+function validateInput(value: string | undefined): string | undefined {
+    if (!value || value === '') {
+        return undefined;
+    }
+    if (Number(value)) {
+        const port: number = parseInt(value, 10);
+        if (port >= 1 && port <= 65535) {
+            return undefined;
+        }
+    }
+
+    return localize('vscode-docker.deployAppService.WebSitesPortPromptStep.InvalidPort', 'Port must be a positive integer (1 to 65535), or empty for container listening on port 80.');
+}
+

--- a/src/commands/registries/azure/WebSitesPortPromptStep.ts
+++ b/src/commands/registries/azure/WebSitesPortPromptStep.ts
@@ -11,9 +11,11 @@ import { IAppServiceContainerWizardContext } from './deployImageToAzure';
 export class WebSitesPortPromptStep extends AzureWizardPromptStep<IAppServiceContainerWizardContext> {
 
     public async prompt(context: IAppServiceContainerWizardContext): Promise<void> {
-        const prompt: string = localize('vscode-docker.deployAppService.WebSitesPortPromptStep.whatPort', 'What port does your app listen on? Leave it empty for app listening on port 80.');
-        const portString: string = await ext.ui.showInputBox({ prompt, validateInput });
-        context.webSitesPort = parseInt(portString, 10) || null;
+        const prompt: string = localize('vscode-docker.deployAppService.WebSitesPortPromptStep.whatPort', 'What port does your app listen on?');
+        const placeHolder: string = '80';
+        const value: string = '80';
+        const portString: string = await ext.ui.showInputBox({ prompt, placeHolder, value, validateInput });
+        context.webSitesPort = parseInt(portString, 10);
     }
 
     public shouldPrompt(context: IAppServiceContainerWizardContext): boolean {
@@ -22,9 +24,6 @@ export class WebSitesPortPromptStep extends AzureWizardPromptStep<IAppServiceCon
 }
 
 function validateInput(value: string | undefined): string | undefined {
-    if (!value || value === '') {
-        return undefined;
-    }
     if (Number(value)) {
         const port: number = parseInt(value, 10);
         if (port >= 1 && port <= 65535) {
@@ -32,6 +31,6 @@ function validateInput(value: string | undefined): string | undefined {
         }
     }
 
-    return localize('vscode-docker.deployAppService.WebSitesPortPromptStep.InvalidPort', 'Port must be a positive integer (1 to 65535), or empty for container listening on port 80.');
+    return localize('vscode-docker.deployAppService.WebSitesPortPromptStep.InvalidPort', 'Port must be a positive integer (1 to 65535).');
 }
 


### PR DESCRIPTION
When deploying the app service in custom location, now provide an option for user to specify the web site port, which is needed if the app is listening on any port other than 80.
fixes #2972 #2973 