### PR TITLE
support extensionKind ui and workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -2724,7 +2724,11 @@
     },
     "engines": {
         "vscode": "^1.55.0"
-    },
+    },  
+    "extensionKind": [
+        "ui",
+        "workspace"
+    ],
     "capabilities": {
         "virtualWorkspaces": false
     },

--- a/package.json
+++ b/package.json
@@ -2724,7 +2724,7 @@
     },
     "engines": {
         "vscode": "^1.55.0"
-    },  
+    },
     "extensionKind": [
         "ui",
         "workspace"


### PR DESCRIPTION
### What

Indicate to VSCode that the extension can run in `ui` mode or in `workspace` mode.

### Why

When using VSCode with remote containers support VSCode can run extensions locally where the UI is being displayed or remotely where the files live. Many extension can run in either location, although some extension can only run on the ui side and some can only run on the workspace side.

When an extension doesn't indicate where it can be run it always runs at the workspace side.

The docker extension can run either on the UI or on the workspace and I think it should really be up to the user to choose. The advantage of changing this and indicating it can run in both places is that when using remote dev containers the developer doesn't have to manually install the extension in the container to use it to control their local docker setup.