### PR TITLE
chore: replace deprecated vscode-test with @vscode/test-electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
                 "@types/xml2js": "^0.4.8",
                 "@typescript-eslint/eslint-plugin": "^4.21.0",
                 "@typescript-eslint/parser": "^4.21.0",
+                "@vscode/test-electron": "^1.6.1",
                 "copy-webpack-plugin": "^8.1.1",
                 "eslint": "^7.24.0",
                 "mocha": "^8.2.1",
@@ -57,7 +58,6 @@
                 "vsce": "^1.93.0",
                 "vscode-codicons": "^0.0.16",
                 "vscode-nls-dev": "^3.3.2",
-                "vscode-test": "^1.5.2",
                 "webpack": "^5.31.2",
                 "webpack-bundle-analyzer": "^4.4.1",
                 "webpack-cli": "^4.6.0"
@@ -920,6 +920,21 @@
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
+        },
+        "node_modules/@vscode/test-electron": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.1.tgz",
+            "integrity": "sha512-WTs+OK9YrKSVJNZ9IjytNibHSJG2YslZXuS3pw9gedF25TgYF/+FQhQYL0ZPX4uupS0SGAPKzMnhYDkjPDxowA==",
+            "dev": true,
+            "dependencies": {
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "rimraf": "^3.0.2",
+                "unzipper": "^0.10.11"
+            },
+            "engines": {
+                "node": ">=8.9.3"
+            }
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -6750,21 +6765,6 @@
                 "vscode": "^1.19.1"
             }
         },
-        "node_modules/vscode-test": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.5.2.tgz",
-            "integrity": "sha512-x9PVfKxF6EInH9iSFGQi0V8H5zIW1fC7RAer6yNQR6sy3WyOwlWkuT3I+wf75xW/cO53hxMi1aj/EvqQfDFOAg==",
-            "dev": true,
-            "dependencies": {
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "rimraf": "^3.0.2",
-                "unzipper": "^0.10.11"
-            },
-            "engines": {
-                "node": ">=8.9.3"
-            }
-        },
         "node_modules/watchpack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
@@ -7976,6 +7976,18 @@
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
+        },
+        "@vscode/test-electron": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.1.tgz",
+            "integrity": "sha512-WTs+OK9YrKSVJNZ9IjytNibHSJG2YslZXuS3pw9gedF25TgYF/+FQhQYL0ZPX4uupS0SGAPKzMnhYDkjPDxowA==",
+            "dev": true,
+            "requires": {
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "rimraf": "^3.0.2",
+                "unzipper": "^0.10.11"
+            }
         },
         "@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -12498,18 +12510,6 @@
             "integrity": "sha512-1sYH73nhiSRVQgfZkLQNJW7VzhKM9qNbCe8QyXgiKkLhH4GflDXRPAK4yy4P41jUgula+Fc9G7i5imj1dlKfaw==",
             "requires": {
                 "tas-client": "0.1.21"
-            }
-        },
-        "vscode-test": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.5.2.tgz",
-            "integrity": "sha512-x9PVfKxF6EInH9iSFGQi0V8H5zIW1fC7RAer6yNQR6sy3WyOwlWkuT3I+wf75xW/cO53hxMi1aj/EvqQfDFOAg==",
-            "dev": true,
-            "requires": {
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "rimraf": "^3.0.2",
-                "unzipper": "^0.10.11"
             }
         },
         "watchpack": {

--- a/package.json
+++ b/package.json
@@ -2758,6 +2758,7 @@
         "@types/xml2js": "^0.4.8",
         "@typescript-eslint/eslint-plugin": "^4.21.0",
         "@typescript-eslint/parser": "^4.21.0",
+        "@vscode/test-electron": "^1.6.1",
         "copy-webpack-plugin": "^8.1.1",
         "eslint": "^7.24.0",
         "mocha": "^8.2.1",
@@ -2767,7 +2768,6 @@
         "vsce": "^1.93.0",
         "vscode-codicons": "^0.0.16",
         "vscode-nls-dev": "^3.3.2",
-        "vscode-test": "^1.5.2",
         "webpack": "^5.31.2",
         "webpack-bundle-analyzer": "^4.4.1",
         "webpack-cli": "^4.6.0"

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -6,8 +6,8 @@
 // Adapted from https://code.visualstudio.com/api/working-with-extensions/testing-extension
 
 import * as path from 'path';
-import { runTests } from 'vscode-test';
-import { TestOptions } from 'vscode-test/out/runTest';
+import { runTests } from '@vscode/test-electron';
+import { TestOptions } from '@vscode/test-electron/out/runTest';
 
 async function main(): Promise<void> {
     // The folder containing the Extension Manifest package.json


### PR DESCRIPTION
![2021-07-18 15 55 53](https://user-images.githubusercontent.com/14012511/126060080-8d671595-14c2-43d2-8daa-e8ee579140c3.png)

vscode-test be marked as [deprecated](https://www.npmjs.com/package/vscode-test) on npmjs.org(yarnpkg.com), so just replace vscode-test with latest @vscode/test-electron for `vscode-docker`'s CI. cc @karolz-ms @bwateratmsft