### PR TITLE
Add support for Workspace Trust

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "@types/semver": "^7.3.4",
                 "@types/tar-stream": "^2.2.0",
                 "@types/uuid": "^8.3.0",
-                "@types/vscode": "1.55.0",
+                "@types/vscode": "1.56.0",
                 "@types/xml2js": "^0.4.8",
                 "@typescript-eslint/eslint-plugin": "^4.28.4",
                 "@typescript-eslint/parser": "^4.28.4",
@@ -62,7 +62,7 @@
                 "webpack-cli": "^4.6.0"
             },
             "engines": {
-                "vscode": "^1.55.0"
+                "vscode": "^1.56.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -769,10 +769,11 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.55.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.55.0.tgz",
-            "integrity": "sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==",
-            "dev": true
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
+            "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/xml2js": {
             "version": "0.4.9",
@@ -7809,9 +7810,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.55.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.55.0.tgz",
-            "integrity": "sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==",
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
+            "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
             "dev": true
         },
         "@types/xml2js": {

--- a/package.json
+++ b/package.json
@@ -2723,10 +2723,14 @@
         }
     },
     "engines": {
-        "vscode": "^1.55.0"
+        "vscode": "^1.56.0"
     },
     "capabilities": {
-        "virtualWorkspaces": false
+        "virtualWorkspaces": false,
+        "untrustedWorkspaces": {
+            "supported": "limited",
+            "description": "%vscode-docker.workspaceTrust.description%"
+        }
     },
     "scripts": {
         "watch": "webpack --watch",
@@ -2753,7 +2757,7 @@
         "@types/semver": "^7.3.4",
         "@types/tar-stream": "^2.2.0",
         "@types/uuid": "^8.3.0",
-        "@types/vscode": "1.55.0",
+        "@types/vscode": "1.56.0",
         "@types/xml2js": "^0.4.8",
         "@typescript-eslint/eslint-plugin": "^4.28.4",
         "@typescript-eslint/parser": "^4.28.4",

--- a/package.json
+++ b/package.json
@@ -174,78 +174,118 @@
                 {
                     "command": "vscode-docker.contexts.use",
                     "when": "!vscode-docker:contextLocked"
+                },
+                {
+                    "command": "vscode-docker.compose.down",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                    "command": "vscode-docker.compose.restart",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                    "command": "vscode-docker.compose.up",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                    "command": "vscode-docker.compose.up.subset",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                    "command": "vscode-docker.configure",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                    "command": "vscode-docker.configureCompose",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                    "command": "vscode-docker.debugging.initializeForDebugging",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                    "command": "vscode-docker.images.build",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                    "command": "vscode-docker.registries.azure.buildImage",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                    "command": "vscode-docker.registries.azure.runFileAsTask",
+                    "when": "isWorkspaceTrusted"
                 }
             ],
             "editor/context": [
                 {
-                    "when": "editorLangId == dockerfile && isAzureAccountInstalled",
+                    "when": "isWorkspaceTrusted && editorLangId == dockerfile && isAzureAccountInstalled",
                     "command": "vscode-docker.registries.azure.buildImage",
                     "group": "docker"
                 },
                 {
-                    "when": "editorLangId == yaml && isAzureAccountInstalled",
+                    "when": "isWorkspaceTrusted && editorLangId == yaml && isAzureAccountInstalled",
                     "command": "vscode-docker.registries.azure.runFileAsTask",
                     "group": "docker"
                 },
                 {
-                    "when": "editorLangId == dockercompose",
+                    "when": "isWorkspaceTrusted && editorLangId == dockercompose",
                     "command": "vscode-docker.compose.down",
                     "group": "docker"
                 },
                 {
-                    "when": "editorLangId == dockercompose",
+                    "when": "isWorkspaceTrusted && editorLangId == dockercompose",
                     "command": "vscode-docker.compose.restart",
                     "group": "docker"
                 },
                 {
-                    "when": "editorLangId == dockercompose",
+                    "when": "isWorkspaceTrusted && editorLangId == dockercompose",
                     "command": "vscode-docker.compose.up",
                     "group": "docker"
                 },
                 {
-                    "when": "editorLangId == dockercompose",
+                    "when": "isWorkspaceTrusted && editorLangId == dockercompose",
                     "command": "vscode-docker.compose.up.subset",
                     "group": "docker"
                 },
                 {
-                    "when": "editorLangId == dockerfile",
+                    "when": "isWorkspaceTrusted && editorLangId == dockerfile",
                     "command": "vscode-docker.images.build",
                     "group": "docker"
                 }
             ],
             "explorer/context": [
                 {
-                    "when": "resourceFilename =~ /dockerfile/i && isAzureAccountInstalled",
+                    "when": "isWorkspaceTrusted && resourceFilename =~ /dockerfile/i && isAzureAccountInstalled",
                     "command": "vscode-docker.registries.azure.buildImage",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceLangId == yaml && isAzureAccountInstalled",
+                    "when": "isWorkspaceTrusted && resourceLangId == yaml && isAzureAccountInstalled",
                     "command": "vscode-docker.registries.azure.runFileAsTask",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceLangId == dockercompose",
+                    "when": "isWorkspaceTrusted && resourceLangId == dockercompose",
                     "command": "vscode-docker.compose.down",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceLangId == dockercompose",
+                    "when": "isWorkspaceTrusted && resourceLangId == dockercompose",
                     "command": "vscode-docker.compose.restart",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceLangId == dockercompose",
+                    "when": "isWorkspaceTrusted && resourceLangId == dockercompose",
                     "command": "vscode-docker.compose.up",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceLangId == dockercompose",
+                    "when": "isWorkspaceTrusted && resourceLangId == dockercompose",
                     "command": "vscode-docker.compose.up.subset",
                     "group": "docker"
                 },
                 {
-                    "when": "resourceFilename =~ /dockerfile/i",
+                    "when": "isWorkspaceTrusted && resourceFilename =~ /dockerfile/i",
                     "command": "vscode-docker.images.build",
                     "group": "docker"
                 }

--- a/package.json
+++ b/package.json
@@ -2769,7 +2769,24 @@
         "virtualWorkspaces": false,
         "untrustedWorkspaces": {
             "supported": "limited",
-            "description": "%vscode-docker.workspaceTrust.description%"
+            "description": "%vscode-docker.workspaceTrust.description%",
+            "restrictedConfigurations": [
+                "docker.commands.build",
+                "docker.commands.run",
+                "docker.commands.runInteractive",
+                "docker.commands.attach",
+                "docker.commands.logs",
+                "docker.commands.composeUp",
+                "docker.commands.composeDown",
+                "docker.dockerodeOptions",
+                "docker.host",
+                "docker.context",
+                "docker.certPath",
+                "docker.tlsVerify",
+                "docker.machineName",
+                "docker.scaffolding.templatePath",
+                "docker.dockerPath"
+            ]
         }
     },
     "scripts": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -292,5 +292,6 @@
     "vscode-docker.views.dockerNetworks": "Networks",
     "vscode-docker.views.dockerVolumes": "Volumes",
     "vscode-docker.views.dockerContexts": "Contexts",
-    "vscode-docker.views.help": "Help and Feedback"
+    "vscode-docker.views.help": "Help and Feedback",
+    "vscode-docker.workspaceTrust.description": "Workspace must be trusted in order to perform relevant Docker actions."
 }

--- a/src/commands/compose/compose.ts
+++ b/src/commands/compose/compose.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { IActionContext } from 'vscode-azureextensionui';
+import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { rewriteComposeCommandIfNeeded } from '../../docker/Contexts';
 import { localize } from "../../localize";
 import { executeAsTask } from '../../utils/executeAsTask';
@@ -14,6 +14,10 @@ import { selectComposeCommand } from '../selectCommandTemplate';
 import { getComposeServiceList } from './getComposeServiceList';
 
 async function compose(context: IActionContext, commands: ('up' | 'down' | 'upSubset')[], message: string, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
+    if (!vscode.workspace.isTrusted) {
+        throw new UserCancelledError('enforceTrust');
+    }
+
     // If a file is chosen, get its workspace folder, otherwise, require the user to choose
     // If a file is chosen that is not in a workspace, it will automatically fall back to quickPickWorkspaceFolder
     const folder: vscode.WorkspaceFolder = (dockerComposeFileUri ? vscode.workspace.getWorkspaceFolder(dockerComposeFileUri) : undefined) ||

--- a/src/commands/images/buildImage.ts
+++ b/src/commands/images/buildImage.ts
@@ -5,7 +5,7 @@
 
 import * as path from "path";
 import * as vscode from "vscode";
-import { IActionContext } from "vscode-azureextensionui";
+import { IActionContext, UserCancelledError } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { localize } from '../../localize';
 import { getOfficialBuildTaskForDockerfile } from "../../tasks/TaskHelper";
@@ -20,6 +20,10 @@ import { addImageTaggingTelemetry, getTagFromUserInput } from "./tagImage";
 const tagRegex: RegExp = /\$\{tag\}/i;
 
 export async function buildImage(context: IActionContext, dockerFileUri: vscode.Uri | undefined): Promise<void> {
+    if (!vscode.workspace.isTrusted) {
+        throw new UserCancelledError('enforceTrust');
+    }
+
     const configOptions: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('docker');
     const defaultContextPath = configOptions.get('imageBuildContextPath', '');
 

--- a/src/commands/registries/azure/tasks/buildImageInAzure.ts
+++ b/src/commands/registries/azure/tasks/buildImageInAzure.ts
@@ -3,10 +3,14 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from "vscode";
-import { IActionContext } from 'vscode-azureextensionui';
+import * as vscode from 'vscode';
+import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { scheduleRunRequest } from './scheduleRunRequest';
 
 export async function buildImageInAzure(context: IActionContext, uri?: vscode.Uri | undefined): Promise<void> {
+    if (!vscode.workspace.isTrusted) {
+        throw new UserCancelledError('enforceTrust');
+    }
+
     await scheduleRunRequest(context, "DockerBuildRequest", uri);
 }

--- a/src/commands/registries/azure/tasks/runFileAsAzureTask.ts
+++ b/src/commands/registries/azure/tasks/runFileAsAzureTask.ts
@@ -3,10 +3,14 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri } from "vscode";
-import { IActionContext } from "vscode-azureextensionui";
+import * as vscode from 'vscode';
+import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { scheduleRunRequest } from './scheduleRunRequest';
 
-export async function runFileAsAzureTask(context: IActionContext, uri?: Uri): Promise<void> {
+export async function runFileAsAzureTask(context: IActionContext, uri?: vscode.Uri): Promise<void> {
+    if (!vscode.workspace.isTrusted) {
+        throw new UserCancelledError('enforceTrust');
+    }
+
     await scheduleRunRequest(context, "FileTaskRunRequest", uri);
 }

--- a/src/scaffolding/scaffold.ts
+++ b/src/scaffolding/scaffold.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep } from 'vscode-azureextensionui';
+import * as vscode from 'vscode';
+import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, UserCancelledError } from 'vscode-azureextensionui';
 import { localize } from '../localize';
 import { copyWizardContext } from './copyWizardContext';
 import { ChooseComposeStep } from './wizard/ChooseComposeStep';
@@ -15,6 +16,10 @@ import { ScaffoldFileStep } from './wizard/ScaffoldFileStep';
 import { ScaffoldingWizardContext } from './wizard/ScaffoldingWizardContext';
 
 export async function scaffold(wizardContext: Partial<ScaffoldingWizardContext>, apiInput?: ScaffoldingWizardContext): Promise<void> {
+    if (!vscode.workspace.isTrusted) {
+        throw new UserCancelledError('enforceTrust');
+    }
+
     copyWizardContext(wizardContext, apiInput);
     wizardContext.scaffoldType = 'all';
 

--- a/src/scaffolding/scaffoldCompose.ts
+++ b/src/scaffolding/scaffoldCompose.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep } from 'vscode-azureextensionui';
+import * as vscode from 'vscode';
+import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, UserCancelledError } from 'vscode-azureextensionui';
 import { localize } from '../localize';
 import { copyWizardContext } from './copyWizardContext';
 import { ChoosePlatformStep } from './wizard/ChoosePlatformStep';
@@ -14,6 +15,10 @@ import { ScaffoldingWizardContext } from './wizard/ScaffoldingWizardContext';
 import { VerifyDockerfileStep } from './wizard/VerifyDockerfileStep';
 
 export async function scaffoldCompose(wizardContext: Partial<ScaffoldingWizardContext>, apiInput?: ScaffoldingWizardContext): Promise<void> {
+    if (!vscode.workspace.isTrusted) {
+        throw new UserCancelledError('enforceTrust');
+    }
+
     copyWizardContext(wizardContext, apiInput);
     wizardContext.scaffoldType = 'compose';
     wizardContext.scaffoldCompose = true;

--- a/src/scaffolding/scaffoldDebugConfig.ts
+++ b/src/scaffolding/scaffoldDebugConfig.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizard, AzureWizardPromptStep } from 'vscode-azureextensionui';
+import * as vscode from 'vscode';
+import { AzureWizard, AzureWizardPromptStep, UserCancelledError } from 'vscode-azureextensionui';
 import { localize } from '../localize';
 import { copyWizardContext } from './copyWizardContext';
 import { ChoosePlatformStep } from './wizard/ChoosePlatformStep';
@@ -11,6 +12,10 @@ import { ChooseWorkspaceFolderStep } from './wizard/ChooseWorkspaceFolderStep';
 import { ScaffoldingWizardContext } from './wizard/ScaffoldingWizardContext';
 
 export async function scaffoldDebugConfig(wizardContext: Partial<ScaffoldingWizardContext>, apiInput?: ScaffoldingWizardContext): Promise<void> {
+    if (!vscode.workspace.isTrusted) {
+        throw new UserCancelledError('enforceTrust');
+    }
+
     copyWizardContext(wizardContext, apiInput);
     wizardContext.scaffoldType = 'debugging';
 


### PR DESCRIPTION
Fixes #2829. Please let me know if you think of any other actions or settings that should require trust!

**Actions that will not be enabled in an untrusted workspace**
- Building images and compose up/down/etc.
- Scaffolding
- Building images in Azure or running files as tasks in Azure
- Running tasks (disabled by VSCode entirely, no additional work for us)
- Debugging (disabled by VSCode entirely, no additional work for us)

Note, actions are disabled both by visibility (`when` clauses in package.json) and programmatically (checks to `vscode.workspace.isTrusted`).

**Settings that will not be enabled in an untrusted workspace**
- Anything pertaining to Docker target host--`docker.host`, `docker.context`, `docker.dockerodeOptions`, `docker.certPath`, `docker.tlsVerify`, `docker.machineName`
- Anything pertaining to command customization--`docker.commands.build`, `docker.commands.run`, `docker.commands.runInteractive`, `docker.commands.attach`, `docker.commands.logs`, `docker.commands.composeUp`, `docker.commands.composeDown`
- Scaffolding template path--`docker.scaffolding.templatePath`
- Docker EXE location--`docker.dockerPath`

**Things _allowed_ in an untrusted workspace**
- Working with local/remote Docker server, e.g. with explorer (this is not something the workspace itself provides, after all)
- Working with registries
- Language server. @rcjsuen do you have any thoughts about this? There's obviously denial-of-service potential with massive or somehow-maliciously-busted Dockerfiles, but that's probably something I'm least concerned about...