### PR TITLE
Normalize container status to mitigate excessive refresh

### DIFF
--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -87,7 +87,7 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInf
             case 'State':
                 return item.State;
             case 'Status':
-                return item.Status;
+                return getNormalizedStatus(item.Status);
             case 'Compose Project Name':
                 return getComposeProjectName(item);
             default:
@@ -172,4 +172,12 @@ export function getComposeProjectName(container: DockerContainer): string {
     } else {
         return NonComposeGroupName;
     }
+}
+
+// The rapidly-refreshing status during a container's first minute causes a lot of problems with excessive refreshing
+// This normalizes things like "10 seconds" to "less than a minute", meaning the refreshes don't happen constantly
+function getNormalizedStatus(status: string): string {
+    const secondsRegex = /\d+ seconds?/i;
+
+    return status.replace(secondsRegex, localize('vscode-docker.tree.containers.lessThanMinute', 'Less than a minute'));
 }

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -87,7 +87,9 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInf
             case 'State':
                 return item.State;
             case 'Status':
-                return getNormalizedStatus(item.Status);
+                // The rapidly-refreshing status during a container's first minute causes a lot of problems with excessive refreshing
+                // This normalizes things like "10 seconds" to "Less than a minute", meaning the refreshes don't happen constantly
+                return item.Status?.replace(/\d+ seconds?/i, localize('vscode-docker.tree.containers.lessThanMinute', 'Less than a minute'));
             case 'Compose Project Name':
                 return getComposeProjectName(item);
             default:
@@ -172,12 +174,4 @@ export function getComposeProjectName(container: DockerContainer): string {
     } else {
         return NonComposeGroupName;
     }
-}
-
-// The rapidly-refreshing status during a container's first minute causes a lot of problems with excessive refreshing
-// This normalizes things like "10 seconds" to "less than a minute", meaning the refreshes don't happen constantly
-function getNormalizedStatus(status: string): string {
-    const secondsRegex = /\d+ seconds?/i;
-
-    return status.replace(secondsRegex, localize('vscode-docker.tree.containers.lessThanMinute', 'Less than a minute'));
 }


### PR DESCRIPTION
This (mostly) fixes #2983. It's not a perfect fix but it's probably about the best we can do given the limitations of the framework and VSCode's tree views, while still showing the container status in the tree node.

To summarize, the problem is happening because during the first minute of a container's life, the text for the `Status` property is rapidly changing (i.e. "Up 2 seconds", "Up 4 seconds", "Up 6 seconds"...). VSCode, or at least our tree view framework, doesn't really offer a good way to do UI-only refreshes. Consequently, the entire tree is getting refreshed, including the files node. For most of the tree this isn't really a big deal, but file ops are *far* slower due to needing to use the CLI. If a user right clicks before a refresh, then clicks a command (e.g. open file) after a refresh, they'll hit the error in #2983.

This fix works by normalizing things like "2 seconds" to "Less than a minute". Thus, this error will happen far less frequently (though unfortunately it will still happen at minute boundaries).

This is what it looks like--note the "Less than a minute" on the first container, next to the green hash mark:
![image](https://user-images.githubusercontent.com/36966225/126640191-7de17d50-fb01-4a7f-b273-c635afdf467b.png)

Also, note--I intentionally capitalized "Less" here even though it comes after "Up" and shouldn't be capitalized. This is actually also what Docker does in its `Status` property--see the "Up **A**bout a minute" just below, next to the blue hash. I thought consistency looked best despite being grammatically incorrect.