### PR TITLE
Refactor context lookup logic yet again

### DIFF
--- a/src/commands/compose/compose.ts
+++ b/src/commands/compose/compose.ts
@@ -5,7 +5,8 @@
 
 import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
-import { rewriteComposeCommandIfNeeded } from '../../docker/Contexts';
+import { DockerContext, rewriteComposeCommandIfNeeded } from '../../docker/Contexts';
+import { DockerServeClient } from '../../docker/DockerServeClient/DockerServeClient';
 import { localize } from "../../localize";
 import { executeAsTask } from '../../utils/executeAsTask';
 import { createFileItem, Item, quickPickDockerComposeFileItem } from '../../utils/quickPickFile';
@@ -76,7 +77,19 @@ export async function composeUp(context: IActionContext, dockerComposeFileUri?: 
 }
 
 export async function composeUpSubset(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
-    return await compose(context, ['upSubset'], localize('vscode-docker.commands.compose.chooseUpSubset', 'Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
+    /*return await compose(context, ['upSubset'], localize('vscode-docker.commands.compose.chooseUpSubset', 'Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);*/
+    const dockerServeClient = new DockerServeClient({ Name: 'default' } as DockerContext);
+
+    const startTime = process.hrtime.bigint();
+
+    for (let i = 0; i < 100; i++) {
+        console.log(await dockerServeClient.getContexts(context));
+    }
+
+    const endTime = process.hrtime.bigint();
+
+    const elapsed = endTime - startTime;
+    console.log(`Elapsed ${elapsed / BigInt(1000)} us on 100 runs, for average of ${elapsed / BigInt(100000)} us each.`);
 }
 
 export async function composeDown(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {

--- a/src/commands/compose/compose.ts
+++ b/src/commands/compose/compose.ts
@@ -5,8 +5,7 @@
 
 import * as vscode from 'vscode';
 import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
-import { DockerContext, rewriteComposeCommandIfNeeded } from '../../docker/Contexts';
-import { DockerServeClient } from '../../docker/DockerServeClient/DockerServeClient';
+import { rewriteComposeCommandIfNeeded } from '../../docker/Contexts';
 import { localize } from "../../localize";
 import { executeAsTask } from '../../utils/executeAsTask';
 import { createFileItem, Item, quickPickDockerComposeFileItem } from '../../utils/quickPickFile';
@@ -81,19 +80,7 @@ export async function composeUp(context: IActionContext, dockerComposeFileUri?: 
 }
 
 export async function composeUpSubset(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
-    /*return await compose(context, ['upSubset'], localize('vscode-docker.commands.compose.chooseUpSubset', 'Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);*/
-    const dockerServeClient = new DockerServeClient({ Name: 'default' } as DockerContext);
-
-    const startTime = process.hrtime.bigint();
-
-    for (let i = 0; i < 100; i++) {
-        console.log(await dockerServeClient.getContexts(context));
-    }
-
-    const endTime = process.hrtime.bigint();
-
-    const elapsed = endTime - startTime;
-    console.log(`Elapsed ${elapsed / BigInt(1000)} us on 100 runs, for average of ${elapsed / BigInt(100000)} us each.`);
+    return await compose(context, ['upSubset'], localize('vscode-docker.commands.compose.chooseUpSubset', 'Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
 export async function composeDown(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {

--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -41,7 +41,7 @@ const defaultContext: Partial<DockerContext> = {
     ContextType: 'moby',
 };
 
-const defaultContextNames = ['default', 'desktop-windows', 'desktop-linux'];
+export const defaultContextNames = ['default', 'desktop-windows', 'desktop-linux'];
 
 // These contexts are used by external consumers (e.g. the "Remote - Containers" extension), and should NOT be changed
 type VSCodeContext = 'vscode-docker:aciContext' | 'vscode-docker:newSdkContext' | 'vscode-docker:newCliPresent' | 'vscode-docker:contextLocked';

--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -231,7 +231,7 @@ export class DockerContextManager implements ContextManager, Disposable {
                 contextList = [fixedContext];
             }
 
-            if (!contextList) {
+            if (!contextList || contextList.length === 0) {
                 // If the load is empty, return the default
                 // That way a returned value is ensured by this method
                 // And `setHostProtocolFromContextList` will always have a non-empty input

--- a/src/docker/DockerServeClient/DockerServeClient.ts
+++ b/src/docker/DockerServeClient/DockerServeClient.ts
@@ -236,7 +236,7 @@ export class DockerServeClient extends ContextChangeCancelClient implements Dock
 
         // Workaround for <INSERT BUG LINK>: if no context is marked as Current=true, that means the environment has a fixed context or otherwise the default context is selected, so overwrite that property
         if (contextsList.every(ctx => !ctx.Current)) {
-            contextsList.find(ctx => ctx.Name === this.fixedContextName ?? 'default').Current = true;
+            contextsList.find(ctx => ctx.Name === (this.fixedContextName ?? 'default')).Current = true;
         }
 
         return contextsList;

--- a/src/docker/DockerServeClient/DockerServeClient.ts
+++ b/src/docker/DockerServeClient/DockerServeClient.ts
@@ -234,7 +234,7 @@ export class DockerServeClient extends ContextChangeCancelClient implements Dock
             };
         });
 
-        // Workaround for <INSERT BUG LINK>: if no context is marked as Current=true, that means the environment has a fixed context or otherwise the default context is selected, so overwrite that property
+        // Workaround for https://github.com/docker/compose-cli/issues/1960: if no context is marked as Current=true, that means the environment has a fixed context or otherwise the default context is selected, so overwrite that property
         if (contextsList.every(ctx => !ctx.Current)) {
             contextsList.find(ctx => ctx.Name === (this.fixedContextName || 'default')).Current = true;
         }

--- a/src/docker/DockerServeClient/DockerServeClient.ts
+++ b/src/docker/DockerServeClient/DockerServeClient.ts
@@ -32,6 +32,8 @@ export class DockerServeClient extends ContextChangeCancelClient implements Dock
     private readonly contextsClient: ContextsClient;
     private readonly callMetadata: Metadata;
 
+    private readonly fixedContextName: string;
+
     public constructor(currentContext?: DockerContext) {
         super();
 
@@ -41,7 +43,7 @@ export class DockerServeClient extends ContextChangeCancelClient implements Dock
         this.callMetadata = new Metadata();
 
         if (currentContext?.Name) {
-            this.callMetadata.add('context_key', currentContext.Name);
+            this.callMetadata.add('context_key', (this.fixedContextName = currentContext.Name)); // Assignment is intentional
         }
     }
 
@@ -232,9 +234,9 @@ export class DockerServeClient extends ContextChangeCancelClient implements Dock
             };
         });
 
-        // Workaround for <INSERT BUG LINK>: if no context is marked as Current=true, that means the default context is selected, so overwrite that property
+        // Workaround for <INSERT BUG LINK>: if no context is marked as Current=true, that means the environment has a fixed context or otherwise the default context is selected, so overwrite that property
         if (contextsList.every(ctx => !ctx.Current)) {
-            contextsList.find(ctx => ctx.Name === 'default').Current = true;
+            contextsList.find(ctx => ctx.Name === this.fixedContextName ?? 'default').Current = true;
         }
 
         return contextsList;

--- a/src/docker/DockerServeClient/DockerServeClient.ts
+++ b/src/docker/DockerServeClient/DockerServeClient.ts
@@ -32,7 +32,7 @@ export class DockerServeClient extends ContextChangeCancelClient implements Dock
     private readonly contextsClient: ContextsClient;
     private readonly callMetadata: Metadata;
 
-    private readonly fixedContextName: string;
+    private readonly fixedContextName: string | undefined;
 
     public constructor(currentContext?: DockerContext) {
         super();
@@ -236,7 +236,7 @@ export class DockerServeClient extends ContextChangeCancelClient implements Dock
 
         // Workaround for <INSERT BUG LINK>: if no context is marked as Current=true, that means the environment has a fixed context or otherwise the default context is selected, so overwrite that property
         if (contextsList.every(ctx => !ctx.Current)) {
-            contextsList.find(ctx => ctx.Name === (this.fixedContextName ?? 'default')).Current = true;
+            contextsList.find(ctx => ctx.Name === (this.fixedContextName || 'default')).Current = true;
         }
 
         return contextsList;

--- a/src/docker/DockerServeClient/DockerServeUtils.ts
+++ b/src/docker/DockerServeClient/DockerServeUtils.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Container } from '@docker/sdk/containers';
+import { Container } from '@docker/sdk/containers.d'; // Imports from the containers.d.ts file to prevent a tsc error (workaround for https://github.com/docker/node-sdk/issues/71)
 import { DockerContainer, InspectionPort } from '../Containers';
 
 // Group 1 is container group name; group 2 is container name

--- a/src/tree/contexts/ContextTreeItem.ts
+++ b/src/tree/contexts/ContextTreeItem.ts
@@ -5,6 +5,7 @@
 
 import { MarkdownString, ThemeIcon } from "vscode";
 import { AzExtParentTreeItem, IActionContext } from "vscode-azureextensionui";
+import { defaultContextNames } from "../../docker/ContextManager";
 import { DockerContext, DockerContextInspection } from "../../docker/Contexts";
 import { ext } from "../../extensionVariables";
 import { getTreeId } from "../LocalRootTreeItemBase";
@@ -25,7 +26,7 @@ export class ContextTreeItem extends ToolTipTreeItem {
     public get contextValue(): string {
         let result: string;
 
-        if (this.name === 'default') {
+        if (defaultContextNames.indexOf(this.name) >= 0) {
             result = 'defaultContext;';
         } else if (this.current) {
             result = 'currentCustomContext;';


### PR DESCRIPTION
Partially fixes #3054; in most cases on Docker Desktop (Mac and Windows) we will be able to use the gRPC daemon for the context lookup which is quite a bit faster than the CLI.