### PR TITLE
[remote] sync version across different machines

### DIFF
--- a/src/commands/startPage/openStartPage.ts
+++ b/src/commands/startPage/openStartPage.ts
@@ -10,7 +10,7 @@ import { extensionVersion } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { startPage } from './StartPage';
 
-const lastVersionKey = 'vscode-docker.startPage.lastVersionShown';
+export const lastVersionKey = 'vscode-docker.startPage.lastVersionShown';
 
 export async function openStartPage(context: IActionContext): Promise<void> {
     await startPage.createOrShow(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { callWithTelemetryAndErrorHandling, createAzExtOutputChannel, createExpe
 import { ConfigurationParams, DidChangeConfigurationNotification, DocumentSelector, LanguageClient, LanguageClientOptions, Middleware, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 import * as tas from 'vscode-tas-client';
 import { registerCommands } from './commands/registerCommands';
+import { lastVersionKey } from './commands/startPage/openStartPage';
 import { extensionVersion } from './constants';
 import { registerDebugProvider } from './debugging/DebugHelper';
 import { DockerContextManager } from './docker/ContextManager';
@@ -54,6 +55,8 @@ function initializeExtensionVariables(ctx: vscode.ExtensionContext): void {
 
 export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: { loadStartTime: number, loadEndTime: number | undefined }): Promise<unknown | undefined> {
     perfStats.loadEndTime = Date.now();
+
+    ctx.globalState.setKeysForSync([lastVersionKey]);
 
     initializeExtensionVariables(ctx);
 


### PR DESCRIPTION
to avoid showing the same update page to the same user on different machines over and over again

It happens in context of remote development, see for instance gitpod-io/gitpod#4566 (comment)
Also see https://github.com/microsoft/vscode-docs/issues/4699