### PR TITLE
Fix regex for "Now listening..." in .NET 6

### DIFF
--- a/src/commands/containers/browseContainer.ts
+++ b/src/commands/containers/browseContainer.ts
@@ -10,7 +10,7 @@ import { ext } from "../../extensionVariables";
 import { localize } from '../../localize';
 import { ContainerTreeItem } from "../../tree/containers/ContainerTreeItem";
 
-type BrowseTelemetryProperties = TelemetryProperties & { possiblePorts?: string, selectedPort?: number };
+type BrowseTelemetryProperties = TelemetryProperties & { possiblePorts?: string, selectedPort?: string };
 
 // NOTE: These ports are ordered in order of preference.
 const commonWebPorts = [
@@ -78,7 +78,7 @@ export async function browseContainer(context: IActionContext, node?: ContainerT
         selectedPort = item.port;
     }
 
-    telemetryProperties.selectedPort = selectedPort.PrivatePort;
+    telemetryProperties.selectedPort = selectedPort.PrivatePort.toString();
 
     const protocol = commonSslPorts.some(commonPort => commonPort === selectedPort.PrivatePort) ? 'https' : 'http';
     const host = selectedPort.IP === '0.0.0.0' ? 'localhost' : selectedPort.IP;

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -99,7 +99,7 @@ export class NetCoreDebugHelper implements DebugHelper {
             debugConfiguration,
             {
                 containerName: containerName,
-                pattern: '^\\s*Now listening on:\\s+(https?://\\S+)',
+                pattern: '\\bNow listening on:\\s+(https?://\\S+)',
                 action: 'openExternally',
                 uriFormat: '%s://localhost:%s',
             },


### PR DESCRIPTION
Fixes #3019. Same fix as https://github.com/OmniSharp/omnisharp-vscode/commit/9dd0b0f12f391110520d7b56b9d7f7414b051d8d#diff-001347cc727cf0cda0ccc53a07a92207e342ab83fe88aaa789b752a9e9ea5832L303.

Also fixes unrelated #3091. A telemetry property was set as an integer value which is not allowed. This has gone unnoticed up until this point, but the recent work to add additional telemetry property masking in `vscode-azureextensionui` exposed the problem.