### PR TITLE
Add GitHub action (and update AZDO pipeline to Node 14.x)

### DIFF
--- a/.azure-pipelines/common/setup.yml
+++ b/.azure-pipelines/common/setup.yml
@@ -1,8 +1,8 @@
 steps:
 - task: NodeTool@0
-  displayName: 'Use Node 12.x'
+  displayName: 'Use Node 14.x'
   inputs:
-    versionSpec: 12.x
+    versionSpec: 14.x
 
 - task: Npm@1
   displayName: 'Install Dependencies'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,34 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node CI Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run ci-package
+    - name: Upload VSIX
+      uses: actions/upload-artifact@v2
+      with:
+        name: VSIX # TODO: can we get it to use the file name?
+        path: vscode-docker-*.vsix

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run ci-package
+    - run: xvfb-run -a npm run ci-package
     - name: Upload VSIX
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Part of #2606.

Blocked by https://github.com/microsoft/vscode-test/issues/103 at the moment.