### PR TITLE
Add compose start/stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
         "onCommand:vscode-docker.containers.stop",
         "onCommand:vscode-docker.containers.viewLogs",
         "onCommand:vscode-docker.containers.composeGroup.logs",
+        "onCommand:vscode-docker.containers.composeGroup.start",
+        "onCommand:vscode-docker.containers.composeGroup.stop",
         "onCommand:vscode-docker.containers.composeGroup.restart",
         "onCommand:vscode-docker.containers.composeGroup.down",
         "onCommand:vscode-docker.debugging.initializeForDebugging",
@@ -162,6 +164,14 @@
                 {
                     "command": "vscode-docker.containers.composeGroup.logs",
                     "when": "config.docker.containers.groupBy == 'Compose Project Name'"
+                },
+                {
+                    "command": "vscode-docker.containers.composeGroup.start",
+                    "when": "never"
+                },
+                {
+                    "command": "vscode-docker.containers.composeGroup.stop",
+                    "when": "never"
                 },
                 {
                     "command": "vscode-docker.containers.composeGroup.restart",
@@ -457,6 +467,16 @@
                     "command": "vscode-docker.containers.composeGroup.logs",
                     "when": "view == dockerContainers && viewItem =~ /composeGroup$/i && !vscode-docker:aciContext",
                     "group": "composeGroup_1_general@1"
+                },
+                {
+                    "command": "vscode-docker.containers.composeGroup.start",
+                    "when": "view == dockerContainers && viewItem =~ /composeGroup$/i && !vscode-docker:aciContext",
+                    "group": "composeGroup_1_general@2"
+                },
+                {
+                    "command": "vscode-docker.containers.composeGroup.stop",
+                    "when": "view == dockerContainers && viewItem =~ /composeGroup$/i && !vscode-docker:aciContext",
+                    "group": "composeGroup_1_general@3"
                 },
                 {
                     "command": "vscode-docker.containers.composeGroup.restart",
@@ -2373,6 +2393,16 @@
             {
                 "command": "vscode-docker.containers.composeGroup.logs",
                 "title": "%vscode-docker.commands.containers.composeGroup.logs%",
+                "category": "%vscode-docker.commands.category.dockerContainers%"
+            },
+            {
+                "command": "vscode-docker.containers.composeGroup.start",
+                "title": "%vscode-docker.commands.containers.composeGroup.start%",
+                "category": "%vscode-docker.commands.category.dockerContainers%"
+            },
+            {
+                "command": "vscode-docker.containers.composeGroup.stop",
+                "title": "%vscode-docker.commands.containers.composeGroup.stop%",
                 "category": "%vscode-docker.commands.category.dockerContainers%"
             },
             {

--- a/package.nls.json
+++ b/package.nls.json
@@ -211,6 +211,8 @@
     "vscode-docker.commands.containers.stop": "Stop",
     "vscode-docker.commands.containers.viewLogs": "View Logs",
     "vscode-docker.commands.containers.composeGroup.logs": "Compose Logs",
+    "vscode-docker.commands.containers.composeGroup.start": "Compose Start",
+    "vscode-docker.commands.containers.composeGroup.stop": "Compose Stop",
     "vscode-docker.commands.containers.composeGroup.restart": "Compose Restart",
     "vscode-docker.commands.containers.composeGroup.down": "Compose Down",
     "vscode-docker.commands.debugging.initializeForDebugging": "Initialize for Docker debugging",

--- a/src/commands/containers/composeGroup.ts
+++ b/src/commands/containers/composeGroup.ts
@@ -17,6 +17,14 @@ export async function composeGroupLogs(context: IActionContext, node: ContainerG
     return composeGroup(context, 'logs', node, '-f --tail 1000');
 }
 
+export async function composeGroupStart(context: IActionContext, node: ContainerGroupTreeItem): Promise<void> {
+    return composeGroup(context, 'start', node);
+}
+
+export async function composeGroupStop(context: IActionContext, node: ContainerGroupTreeItem): Promise<void> {
+    return composeGroup(context, 'stop', node);
+}
+
 export async function composeGroupRestart(context: IActionContext, node: ContainerGroupTreeItem): Promise<void> {
     return composeGroup(context, 'restart', node);
 }
@@ -25,7 +33,7 @@ export async function composeGroupDown(context: IActionContext, node: ContainerG
     return composeGroup(context, 'down', node);
 }
 
-async function composeGroup(context: IActionContext, composeCommand: 'logs' | 'restart' | 'down', node: ContainerGroupTreeItem, additionalArguments?: string): Promise<void> {
+async function composeGroup(context: IActionContext, composeCommand: 'logs' | 'start' | 'stop' | 'restart' | 'down', node: ContainerGroupTreeItem, additionalArguments?: string): Promise<void> {
     if (!node) {
         await ext.containersTree.refresh(context);
         node = await ext.containersTree.showTreeItemPicker<ContainerGroupTreeItem>(/composeGroup$/i, {

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -12,7 +12,7 @@ import { scaffoldDebugConfig } from "../scaffolding/scaffoldDebugConfig";
 import { composeDown, composeRestart, composeUp, composeUpSubset } from "./compose/compose";
 import { attachShellContainer } from "./containers/attachShellContainer";
 import { browseContainer } from "./containers/browseContainer";
-import { composeGroupDown, composeGroupLogs, composeGroupRestart } from "./containers/composeGroup";
+import { composeGroupDown, composeGroupLogs, composeGroupRestart, composeGroupStart, composeGroupStop } from "./containers/composeGroup";
 import { configureContainersExplorer } from "./containers/configureContainersExplorer";
 import { downloadContainerFile } from "./containers/files/downloadContainerFile";
 import { openContainerFile } from "./containers/files/openContainerFile";
@@ -136,6 +136,8 @@ export function registerCommands(): void {
     registerCommand('vscode-docker.containers.stop', stopContainer);
     registerWorkspaceCommand('vscode-docker.containers.viewLogs', viewContainerLogs);
     registerWorkspaceCommand('vscode-docker.containers.composeGroup.logs', composeGroupLogs);
+    registerWorkspaceCommand('vscode-docker.containers.composeGroup.start', composeGroupStart);
+    registerWorkspaceCommand('vscode-docker.containers.composeGroup.stop', composeGroupStop);
     registerWorkspaceCommand('vscode-docker.containers.composeGroup.restart', composeGroupRestart);
     registerWorkspaceCommand('vscode-docker.containers.composeGroup.down', composeGroupDown);
 


### PR DESCRIPTION
Fixes #2895. The options are added on compose groups.

**Note:** I didn't make an effort to hide "Start" when all are started or vise versa; it is probably possible but won't be particularly simple. Additionally, it's _technically_ allowed to run the command anyway, it just doesn't do anything.

![image](https://user-images.githubusercontent.com/36966225/127504671-49652e0a-9ce7-4066-a115-d52913512eb8.png)

As discussed in triage, we opted not to add it to files, as that menu is already pretty crowded and this won't help.
