### PR TITLE
Fix silly bug in context loading client

### DIFF
--- a/src/docker/ContextLoadingClient/ContextLoadingClient.ts
+++ b/src/docker/ContextLoadingClient/ContextLoadingClient.ts
@@ -8,6 +8,7 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { DockerInfo, PruneResult } from '../Common';
 import { DockerContainer, DockerContainerInspection } from '../Containers';
+import { ContextManager } from '../ContextManager';
 import { DockerApiClient, DockerExecCommandProvider, DockerExecOptions } from '../DockerApiClient';
 import { DockerImage, DockerImageInspection } from '../Images';
 import { DockerNetwork, DockerNetworkInspection, DriverType } from '../Networks';
@@ -21,9 +22,9 @@ import { DockerVolume, DockerVolumeInspection } from '../Volumes';
 export class ContextLoadingClient implements DockerApiClient {
     private readonly contextLoadingPromise: Promise<void>;
 
-    public constructor() {
+    public constructor(ctxMgr: ContextManager) {
         this.contextLoadingPromise = new Promise((resolve) => {
-            const disposable = ext.dockerContextManager.onContextChanged(() => {
+            const disposable = ctxMgr.onContextChanged(() => {
                 disposable.dispose();
                 resolve();
             });

--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -95,7 +95,7 @@ export class DockerContextManager implements ContextManager, Disposable {
         }
 
         // Set the initial DockerApiClient to be the context loading client
-        ext.dockerClient = new ContextLoadingClient();
+        ext.dockerClient = new ContextLoadingClient(this);
     }
 
     public dispose(): void {


### PR DESCRIPTION
Part of #3054, fixes a silly bug I left in #3109.

`ext.dockerContextManager` isn't being set until after is constructor, which was constructing the `ContextLoadingClient`, which in turn references `ext.dockerContextManager`. It was null-ref'ing as a result. Easiest to just pass in the context manager to `ContextLoadingClient`.