### PR TITLE
Upgrade to language server 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@docker/sdk": "^1.0.3",
                 "@grpc/grpc-js": "^1.2.12",
                 "dayjs": "^1.10.4",
-                "dockerfile-language-server-nodejs": "^0.4.1",
+                "dockerfile-language-server-nodejs": "^0.5.0",
                 "dockerode": "^3.2.1",
                 "fs-extra": "^10.0.0",
                 "glob": "^7.1.6",
@@ -2189,10 +2189,11 @@
             }
         },
         "node_modules/dockerfile-ast": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.2.0.tgz",
-            "integrity": "sha512-iQyp12k1A4tF3sEfLAq2wfFPKdpoiGTJeuiu2Y1bdEqIZu0DfSSL2zm0fk7a/UHeQkngnYaRRGuON+C+2LO1Fw==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.0.tgz",
+            "integrity": "sha512-wEbFtqeHZffyOYP2pMfMLQ0m2wdHUzty0UTDoAMNa6/nvLfDRSEaPkszIWFy86tuWwHucBtcczIHQlFATJ54eA==",
             "dependencies": {
+                "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.16.0"
             },
             "engines": {
@@ -2205,12 +2206,12 @@
             "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.4.1.tgz",
-            "integrity": "sha512-7mB+HdMd4dfjChK1+37++ylA+sy7wFaf0/3HDy6cJDj5dTx4C4vVDmDKQpZgNJU1gIkxDnW6QCLCxpoe5FPyVA==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.5.0.tgz",
+            "integrity": "sha512-aDwANs1c1xIh5lQTbMlsGx8tMDk1k+sjsYbIXYjWvGY9Ff2e40MQ6RgALItVVij1dj1049FkG9MOHLFqekxZoA==",
             "dependencies": {
-                "dockerfile-language-service": "0.3.0",
-                "dockerfile-utils": "0.2.0",
+                "dockerfile-language-service": "0.4.0",
+                "dockerfile-utils": "0.5.0",
                 "vscode-languageserver": "^7.0.0"
             },
             "bin": {
@@ -2221,70 +2222,29 @@
             }
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.3.0.tgz",
-            "integrity": "sha512-BUStimzz1Ozh41o+2AgMfwW8M7KsqzOBllNlLkf7NDe6W9KvcC3d8j4MTc+cU9wfRUoVckK39M2btvRFFDK61w==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.4.0.tgz",
+            "integrity": "sha512-P4yj9in7PMLeN3StBn5e+Ofiju+nfs5ZdDv4EqfK91mYx/+U7wm8QipyP05iUXaVKFh6I9tn9Qmi1tpt5jj2hw==",
             "dependencies": {
-                "dockerfile-ast": "0.2.0",
-                "dockerfile-utils": "0.4.2",
+                "dockerfile-ast": "0.3.0",
+                "dockerfile-utils": "0.5.0",
                 "vscode-languageserver-types": "3.17.0-next.1"
             },
             "engines": {
                 "node": "*"
             }
         },
-        "node_modules/dockerfile-language-service/node_modules/dockerfile-utils": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.4.2.tgz",
-            "integrity": "sha512-WfJEuXWdVdiarhxJgRlZ9bkMO/9un6dZDz+u3z6AYEXfsH2XRwYqdIvyOqFzaDDP0Hc6pR5rb9FJRSKyo+NuxA==",
-            "dependencies": {
-                "dockerfile-ast": "0.2.1",
-                "vscode-languageserver-types": "^3.16.0"
-            },
-            "bin": {
-                "dockerfile-utils": "bin/dockerfile-utils"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/dockerfile-language-service/node_modules/dockerfile-utils/node_modules/dockerfile-ast": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.2.1.tgz",
-            "integrity": "sha512-ut04CVM1G6zIITTcYPDIXhPZk9mCa21m4dfW8FcDDGxwgTQhYyHDu6U7M8klZ7QsjqVcJhryKi+TGOX6bjgKdQ==",
-            "dependencies": {
-                "vscode-languageserver-types": "^3.16.0"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/dockerfile-language-service/node_modules/dockerfile-utils/node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-        },
         "node_modules/dockerfile-utils": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.2.0.tgz",
-            "integrity": "sha512-B8tEGwLd3w0dWALshXS0gkAwDYdqFKAKm9zIyp/nCFkx8+BOhbz5CiAFlVU+WRvv6kd6AP/YtYVOzSL54MJlmQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.5.0.tgz",
+            "integrity": "sha512-a12B6qAwLpl7D9Y6Zxt0AhW74g0k5NarpWF+NUb66A6la5vs1igI/KfdXZbFoQtpTOsv1T+OfKmhlE982Ars1w==",
             "dependencies": {
-                "dockerfile-ast": "0.1.0",
+                "dockerfile-ast": "0.3.0",
+                "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.16.0"
             },
             "bin": {
                 "dockerfile-utils": "bin/dockerfile-utils"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/dockerfile-utils/node_modules/dockerfile-ast": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.1.0.tgz",
-            "integrity": "sha512-qKftHMVoMliYBaYLkgttm+NXhRISVNkIMfAL4ecmXjiWRElfdfY+xNgITiehG0LpUEDbFUa/UDCByYq/2UZIpQ==",
-            "dependencies": {
-                "vscode-languageserver-types": "^3.16.0"
             },
             "engines": {
                 "node": "*"
@@ -6424,6 +6384,11 @@
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
             "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
+        "node_modules/vscode-languageserver-textdocument": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+            "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
+        },
         "node_modules/vscode-languageserver-types": {
             "version": "3.17.0-next.1",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.1.tgz",
@@ -8894,10 +8859,11 @@
             }
         },
         "dockerfile-ast": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.2.0.tgz",
-            "integrity": "sha512-iQyp12k1A4tF3sEfLAq2wfFPKdpoiGTJeuiu2Y1bdEqIZu0DfSSL2zm0fk7a/UHeQkngnYaRRGuON+C+2LO1Fw==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.0.tgz",
+            "integrity": "sha512-wEbFtqeHZffyOYP2pMfMLQ0m2wdHUzty0UTDoAMNa6/nvLfDRSEaPkszIWFy86tuWwHucBtcczIHQlFATJ54eA==",
             "requires": {
+                "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.16.0"
             },
             "dependencies": {
@@ -8909,68 +8875,35 @@
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.4.1.tgz",
-            "integrity": "sha512-7mB+HdMd4dfjChK1+37++ylA+sy7wFaf0/3HDy6cJDj5dTx4C4vVDmDKQpZgNJU1gIkxDnW6QCLCxpoe5FPyVA==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.5.0.tgz",
+            "integrity": "sha512-aDwANs1c1xIh5lQTbMlsGx8tMDk1k+sjsYbIXYjWvGY9Ff2e40MQ6RgALItVVij1dj1049FkG9MOHLFqekxZoA==",
             "requires": {
-                "dockerfile-language-service": "0.3.0",
-                "dockerfile-utils": "0.2.0",
+                "dockerfile-language-service": "0.4.0",
+                "dockerfile-utils": "0.5.0",
                 "vscode-languageserver": "^7.0.0"
             }
         },
         "dockerfile-language-service": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.3.0.tgz",
-            "integrity": "sha512-BUStimzz1Ozh41o+2AgMfwW8M7KsqzOBllNlLkf7NDe6W9KvcC3d8j4MTc+cU9wfRUoVckK39M2btvRFFDK61w==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.4.0.tgz",
+            "integrity": "sha512-P4yj9in7PMLeN3StBn5e+Ofiju+nfs5ZdDv4EqfK91mYx/+U7wm8QipyP05iUXaVKFh6I9tn9Qmi1tpt5jj2hw==",
             "requires": {
-                "dockerfile-ast": "0.2.0",
-                "dockerfile-utils": "0.4.2",
+                "dockerfile-ast": "0.3.0",
+                "dockerfile-utils": "0.5.0",
                 "vscode-languageserver-types": "3.17.0-next.1"
-            },
-            "dependencies": {
-                "dockerfile-utils": {
-                    "version": "0.4.2",
-                    "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.4.2.tgz",
-                    "integrity": "sha512-WfJEuXWdVdiarhxJgRlZ9bkMO/9un6dZDz+u3z6AYEXfsH2XRwYqdIvyOqFzaDDP0Hc6pR5rb9FJRSKyo+NuxA==",
-                    "requires": {
-                        "dockerfile-ast": "0.2.1",
-                        "vscode-languageserver-types": "^3.16.0"
-                    },
-                    "dependencies": {
-                        "dockerfile-ast": {
-                            "version": "0.2.1",
-                            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.2.1.tgz",
-                            "integrity": "sha512-ut04CVM1G6zIITTcYPDIXhPZk9mCa21m4dfW8FcDDGxwgTQhYyHDu6U7M8klZ7QsjqVcJhryKi+TGOX6bjgKdQ==",
-                            "requires": {
-                                "vscode-languageserver-types": "^3.16.0"
-                            }
-                        },
-                        "vscode-languageserver-types": {
-                            "version": "3.16.0",
-                            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-                            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-                        }
-                    }
-                }
             }
         },
         "dockerfile-utils": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.2.0.tgz",
-            "integrity": "sha512-B8tEGwLd3w0dWALshXS0gkAwDYdqFKAKm9zIyp/nCFkx8+BOhbz5CiAFlVU+WRvv6kd6AP/YtYVOzSL54MJlmQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.5.0.tgz",
+            "integrity": "sha512-a12B6qAwLpl7D9Y6Zxt0AhW74g0k5NarpWF+NUb66A6la5vs1igI/KfdXZbFoQtpTOsv1T+OfKmhlE982Ars1w==",
             "requires": {
-                "dockerfile-ast": "0.1.0",
+                "dockerfile-ast": "0.3.0",
+                "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.16.0"
             },
             "dependencies": {
-                "dockerfile-ast": {
-                    "version": "0.1.0",
-                    "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.1.0.tgz",
-                    "integrity": "sha512-qKftHMVoMliYBaYLkgttm+NXhRISVNkIMfAL4ecmXjiWRElfdfY+xNgITiehG0LpUEDbFUa/UDCByYq/2UZIpQ==",
-                    "requires": {
-                        "vscode-languageserver-types": "^3.16.0"
-                    }
-                },
                 "vscode-languageserver-types": {
                     "version": "3.16.0",
                     "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
@@ -12151,6 +12084,11 @@
                     "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
                 }
             }
+        },
+        "vscode-languageserver-textdocument": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+            "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
         },
         "vscode-languageserver-types": {
             "version": "3.17.0-next.1",

--- a/package.json
+++ b/package.json
@@ -2918,7 +2918,7 @@
         "@docker/sdk": "^1.0.3",
         "@grpc/grpc-js": "^1.2.12",
         "dayjs": "^1.10.4",
-        "dockerfile-language-server-nodejs": "^0.4.1",
+        "dockerfile-language-server-nodejs": "^0.5.0",
         "dockerode": "^3.2.1",
         "fs-extra": "^10.0.0",
         "glob": "^7.1.6",


### PR DESCRIPTION
The latest 0.5.0 release of the Dockerfile language server introduces rudimentary support for heredoc syntax (https://github.com/moby/buildkit/pull/2132). `RUN` has some barebones support but `ADD` and `COPY` will require some further work.

Issues reported in this repository that have now been fixed:
- support heredoc syntax so we do not flag false positives when linting (#3087)
- semantic tokens fix for handling backslashes in strings (https://github.com/microsoft/vscode-docker/issues/3107#issuecomment-890417312)

Please use the Dockerfiles below for testing. Due to the nature of the parser bugs that have been fixed, please do not format the file and simply copy and paste the content into a Dockerfile editor.

Lastly, I have not forgotten about https://github.com/microsoft/vscode-docker/pull/2866#issuecomment-817821008. I've unified my different libraries' dependencies on each other but have not unified the `vscode-languageserver*` bits. I hope to address that in the next release. Thank you for your understanding.
```Dockerfile
FROM node:alpine
# the semi-colon at the end will no longer be highlighted as a string
# https://github.com/microsoft/vscode-docker/issues/3107#issuecomment-890417312
RUN 'C:\path\';

# heredoc syntax support should now stop the following lines from being
# reported as errors
# https://github.com/microsoft/vscode-docker/issues/3087
RUN <<EOF
    echo "Hello world"
EOF

# add a new line after 17 and then invoke Intellisense immediately after
# on line 18, no regular Dockerfile instructions should be suggested,
# previously all instructions will be prompted as it did not consider
# the heredoc syntax and believed new instructions should go here
RUN <<eof
```
```Dockerfile
FROM node:alpine
# the 3 on line 6 does not have proper syntax highlighting
RUN 1\
#
2#\
3\
4
# line 10 suddenly switches to a comment when comments must be declared
# at the front
RUN 1\
2#\
3\
4
```