### PR TITLE
Have `ContextLoadingClient` listen for any end-of-loading event

### DIFF
--- a/src/docker/ContextLoadingClient/ContextLoadingClient.ts
+++ b/src/docker/ContextLoadingClient/ContextLoadingClient.ts
@@ -23,11 +23,11 @@ export class ContextLoadingClient implements DockerApiClient {
 
     public constructor(onFinishedLoading: Event<unknown | undefined>) {
         this.contextLoadingPromise = new Promise((resolve, reject) => {
-            const disposable = onFinishedLoading((result) => {
+            const disposable = onFinishedLoading((error?: unknown) => {
                 disposable.dispose();
 
-                if (result) {
-                    return reject(result);
+                if (error) {
+                    return reject(error);
                 }
 
                 resolve();

--- a/src/docker/ContextLoadingClient/ContextLoadingClient.ts
+++ b/src/docker/ContextLoadingClient/ContextLoadingClient.ts
@@ -27,7 +27,7 @@ export class ContextLoadingClient implements DockerApiClient {
                 disposable.dispose();
 
                 if (result) {
-                    reject(result);
+                    return reject(result);
                 }
 
                 resolve();

--- a/src/docker/ContextLoadingClient/ContextLoadingClient.ts
+++ b/src/docker/ContextLoadingClient/ContextLoadingClient.ts
@@ -3,12 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken } from 'vscode';
+import { CancellationToken, Event } from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { DockerInfo, PruneResult } from '../Common';
 import { DockerContainer, DockerContainerInspection } from '../Containers';
-import { ContextManager } from '../ContextManager';
 import { DockerApiClient, DockerExecCommandProvider, DockerExecOptions } from '../DockerApiClient';
 import { DockerImage, DockerImageInspection } from '../Images';
 import { DockerNetwork, DockerNetworkInspection, DriverType } from '../Networks';
@@ -22,10 +21,15 @@ import { DockerVolume, DockerVolumeInspection } from '../Volumes';
 export class ContextLoadingClient implements DockerApiClient {
     private readonly contextLoadingPromise: Promise<void>;
 
-    public constructor(ctxMgr: ContextManager) {
-        this.contextLoadingPromise = new Promise((resolve) => {
-            const disposable = ctxMgr.onContextChanged(() => {
+    public constructor(onFinishedLoading: Event<unknown | undefined>) {
+        this.contextLoadingPromise = new Promise((resolve, reject) => {
+            const disposable = onFinishedLoading((result) => {
                 disposable.dispose();
+
+                if (result) {
+                    reject(result);
+                }
+
                 resolve();
             });
         });


### PR DESCRIPTION
Fixes #3132. Pending calls through `ContextLoadingClient` will reject with the same error context loading failed with, if it fails.