### PR TITLE
Refactor app service deployment code

### DIFF
--- a/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
+++ b/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
@@ -76,7 +76,7 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
             );
         }
 
-        config.linuxFxVersion = `DOCKER|${registryTreeItem.baseImagePath}/${this.tagTreeItem.repoNameAndTag}`;
+        config.linuxFxVersion = `DOCKER|${this.tagTreeItem.fullTag}`;
         await appSvcClient.webApps.updateConfiguration(context.site.resourceGroup, context.site.name, config);
     }
 

--- a/src/commands/registries/azure/DockerSiteCreateStep.ts
+++ b/src/commands/registries/azure/DockerSiteCreateStep.ts
@@ -11,6 +11,10 @@ import { AzExtLocation, AzureWizardExecuteStep, createAzureClient, LocationListS
 import { ext } from "../../../extensionVariables";
 import { localize } from "../../../localize";
 import { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
+import { DockerHubNamespaceTreeItem } from '../../../tree/registries/dockerHub/DockerHubNamespaceTreeItem';
+import { DockerV2RegistryTreeItemBase } from '../../../tree/registries/dockerV2/DockerV2RegistryTreeItemBase';
+import { GenericDockerV2RegistryTreeItem } from '../../../tree/registries/dockerV2/GenericDockerV2RegistryTreeItem';
+import { getRegistryPassword } from '../../../tree/registries/registryPasswords';
 import { RegistryTreeItemBase } from '../../../tree/registries/RegistryTreeItemBase';
 import { RemoteTagTreeItem } from '../../../tree/registries/RemoteTagTreeItem';
 import { nonNullProp, nonNullValueAndProp } from "../../../utils/nonNull";
@@ -19,7 +23,7 @@ import { IAppServiceContainerWizardContext } from './deployImageToAzure';
 export class DockerSiteCreateStep extends AzureWizardExecuteStep<IAppServiceContainerWizardContext> {
     public priority: number = 140;
 
-    public constructor(private readonly siteConfig: WebSiteManagementModels.SiteConfig, private readonly node: RemoteTagTreeItem) {
+    public constructor(private readonly node: RemoteTagTreeItem) {
         super();
     }
 
@@ -27,7 +31,7 @@ export class DockerSiteCreateStep extends AzureWizardExecuteStep<IAppServiceCont
         const creatingNewApp: string = localize('vscode-docker.commands.registries.azure.deployImage.creatingWebApp', 'Creating web app "{0}"...', context.newSiteName);
         ext.outputChannel.appendLine(creatingNewApp);
         progress.report({ message: creatingNewApp });
-        const siteConfig = await this.getSiteConfig(context);
+        const siteConfig = await this.getNewSiteConfig(context);
         const location: AzExtLocation = await LocationListStep.getLocation(context);
         const locationName: string = nonNullProp(location, 'name');
 
@@ -44,8 +48,7 @@ export class DockerSiteCreateStep extends AzureWizardExecuteStep<IAppServiceCont
             // deploying to Azure Arc
             siteEnvelope.kind = 'app,linux,kubernetes,container';
             await this.addCustomLocationProperties(siteEnvelope, context.customLocation);
-        }
-        else {
+        } else {
             siteEnvelope.identity = {
                 type: 'SystemAssigned'
             };
@@ -54,33 +57,76 @@ export class DockerSiteCreateStep extends AzureWizardExecuteStep<IAppServiceCont
         context.site = await client.webApps.createOrUpdate(nonNullValueAndProp(context.resourceGroup, 'name'), nonNullProp(context, 'newSiteName'), siteEnvelope);
     }
 
-    private async getSiteConfig(context: IAppServiceContainerWizardContext): Promise<WebSiteManagementModels.SiteConfig> {
-        // Temporary workaround until Arc adds support for managed identity, so use usename and password instead.
-        // When customLocation is set, then user is deploying to Arc.
-        const registryTreeItem: RegistryTreeItemBase = this.node.parent.parent;
-        if (registryTreeItem instanceof AzureRegistryTreeItem && context.customLocation) {
-            const appSettings: WebSiteManagementModels.NameValuePair[] = [];
-            const cred = await registryTreeItem.tryGetAdminCredentials(context);
-            if (!cred) {
+    private async getNewSiteConfig(context: IAppServiceContainerWizardContext): Promise<WebSiteManagementModels.SiteConfig> {
+        const registryTI: RegistryTreeItemBase = this.node.parent.parent;
+
+        let username: string | undefined;
+        let password: string | undefined;
+        let registryUrl: string | undefined;
+        const appSettings: WebSiteManagementModels.NameValuePair[] = [];
+
+        // Scenarios:
+        // ACR -> App Service, NOT Arc App Service. Use managed service identity.
+        if (registryTI instanceof AzureRegistryTreeItem && !context.customLocation) {
+            appSettings.push({ name: 'DOCKER_ENABLE_CI', value: 'true' });
+
+            // Don't need an image, username, or password--just create an empty web app to assign permissions and then configure with an image
+            // `DockerAssignAcrPullRoleStep` handles it after that
+            return {
+                acrUseManagedIdentityCreds: true,
+                appSettings
+            };
+        }
+        // ACR -> Arc App Service. Use regular auth. Same as any V2 registry but different way of getting auth.
+        else if (registryTI instanceof AzureRegistryTreeItem && context.customLocation) {
+            const cred = await registryTI.tryGetAdminCredentials(context);
+            if (!cred?.username || !cred?.passwords?.[0]?.value) {
                 throw new Error(localize('vscode-docker.commands.registries.azure.dockersitecreatestep.notAdminEnabled', 'Azure App service deployment on Azure Arc only supports running images from Azure Container Registries with admin enabled'));
-            } else {
-                appSettings.push({ name: "DOCKER_REGISTRY_SERVER_URL", value: registryTreeItem.baseUrl });
-                appSettings.push({ name: "DOCKER_REGISTRY_SERVER_USERNAME", value: cred.username });
-                appSettings.push({ name: "DOCKER_REGISTRY_SERVER_PASSWORD", value: nonNullProp(cred, 'passwords')[0].value });
-                appSettings.push({ name: "DOCKER_ENABLE_CI", value: 'true' });
-                if (context.webSitesPort) {
-                    appSettings.push({ name: "WEBSITES_PORT", value: context.webSitesPort.toString() });
-                }
-                const linuxFxVersion = `DOCKER|${registryTreeItem.baseImagePath}/${this.node.repoNameAndTag}`;
-                return {
-                    linuxFxVersion,
-                    appSettings
-                };
             }
+
+            username = cred.username;
+            password = cred.passwords[0].value;
+            registryUrl = registryTI.baseUrl;
         }
-        else {
-            return this.siteConfig;
+        // Docker Hub -> App Service *OR* Arc App Service
+        else if (registryTI instanceof DockerHubNamespaceTreeItem) {
+            username = registryTI.parent.username;
+            password = await registryTI.parent.getPassword();
+            registryUrl = 'https://index.docker.io';
         }
+        // Generic registry -> App Service *OR* Arc App Service
+        else if (registryTI instanceof DockerV2RegistryTreeItemBase) {
+            if (registryTI instanceof GenericDockerV2RegistryTreeItem) {
+                username = registryTI.cachedProvider.username;
+                password = await getRegistryPassword(registryTI.cachedProvider);
+            } else {
+                throw new RangeError(localize('vscode-docker.commands.registries.azure.deployImage.unrecognizedNodeTypeA', 'Unrecognized node type "{0}"', registryTI.constructor.name));
+            }
+
+            registryUrl = registryTI.baseUrl;
+        } else {
+            throw new RangeError(localize('vscode-docker.commands.registries.azure.deployImage.unrecognizedNodeTypeB', 'Unrecognized node type "{0}"', registryTI.constructor.name));
+        }
+
+        if (username && password) {
+            appSettings.push({ name: "DOCKER_REGISTRY_SERVER_USERNAME", value: username });
+            appSettings.push({ name: "DOCKER_REGISTRY_SERVER_PASSWORD", value: password });
+        }
+
+        if (registryUrl) {
+            appSettings.push({ name: 'DOCKER_REGISTRY_SERVER_URL', value: registryUrl });
+        }
+
+        if (context.webSitesPort) {
+            appSettings.push({ name: "WEBSITES_PORT", value: context.webSitesPort.toString() });
+        }
+
+        const linuxFxVersion = `DOCKER|${this.node.fullTag}`;
+
+        return {
+            linuxFxVersion,
+            appSettings
+        };
     }
 
     private async addCustomLocationProperties(site: Site, customLocation: CustomLocation): Promise<void> {


### PR DESCRIPTION
Fixes #3129.

This does three things:

1. Refactors the site config code to all be within `DockerSiteCreateStep`. It was difficult to follow, being split in two places. Ravi was right to put it in `DockerSiteCreateStep`, this just moves the rest.
1. For all Docker Hub deployments, it adds the `DOCKER_REGISTRY_SERVER_URL` value `https://index.docker.io`. This seems unnecessary but harmless on non-Arc deployments, but was necessary for Arc deployments.
1. Includes the `WEBSITES_PORT` on Docker Hub deployments to Arc. Previously it was prompting for that port but not actually applying the configuration.