### PR TITLE
Remove experiment for context lookup

### DIFF
--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -228,12 +228,9 @@ export class DockerContextManager implements ContextManager, Disposable {
             // If the result is undefined, there are (probably) multiple contexts and none is chosen by `docker.context` or `DOCKER_CONTEXT`, so we will need to do a context listing
             // If the result is a string, that means `docker.context` or `DOCKER_CONTEXT` are set, so we will also need to do a context listing
             if (typeof (fixedContext) === 'undefined' || typeof (fixedContext) === 'string') {
-                if (await ext.experimentationService.getCachedTreatmentVariable<boolean>('vscode-docker.contextLookup.api')) {
-                    // Experiment: try lookup via the API first, falling back if needed to the CLI
-                    contextList = await this.tryGetContextsFromApi(actionContext, fixedContext);
-                }
-
-                contextList = contextList || (await this.tryGetContextsFromCli(actionContext, fixedContext));
+                contextList =
+                    (await this.tryGetContextsFromApi(actionContext, fixedContext)) ||
+                    (await this.tryGetContextsFromCli(actionContext, fixedContext));
             } else {
                 contextList = [fixedContext];
             }


### PR DESCRIPTION
Early results show that the API lookup is a clear winner. It is much faster on Windows, marginally faster on Mac, and a teeny bit slower on Linux but not enough to care (especially since, over time, Linux should be getting the daemon more broadly).

I expected the context load to be slower in cases where the API was not present--it adds the time to load that code and call the API. This does appear to be the case from the data, but is less prevalent than I expected--Mac is faster even up through the 90th percentile (as in, for at least 90% of users, this change helps) and Windows is faster up through the 95th percentile. Linux is a bit slower at the 90th percentile, but is just as fast at the 75th percentile.

This code removes the experimentation component and will always try the API lookup before a CLI lookup. Reverts part of #3102. Related to #3054.