### PR TITLE
Upgrade to language server 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@docker/sdk": "^1.0.3",
                 "@grpc/grpc-js": "^1.2.12",
                 "dayjs": "^1.10.4",
-                "dockerfile-language-server-nodejs": "^0.5.0",
+                "dockerfile-language-server-nodejs": "^0.6.0",
                 "dockerode": "^3.2.1",
                 "fs-extra": "^10.0.0",
                 "glob": "^7.1.6",
@@ -2117,30 +2117,25 @@
             }
         },
         "node_modules/dockerfile-ast": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.0.tgz",
-            "integrity": "sha512-wEbFtqeHZffyOYP2pMfMLQ0m2wdHUzty0UTDoAMNa6/nvLfDRSEaPkszIWFy86tuWwHucBtcczIHQlFATJ54eA==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.1.tgz",
+            "integrity": "sha512-sxFv+wY4TNC68+JkbZ4kPn3pAfnfvbFBUcvYAA9KFg7Es58FgWr+trskeDRWFkCFeuM1QIXeBC5exMeiAeW96Q==",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.1",
-                "vscode-languageserver-types": "^3.16.0"
+                "vscode-languageserver-types": "^3.17.0-next.3"
             },
             "engines": {
                 "node": "*"
             }
         },
-        "node_modules/dockerfile-ast/node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-        },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.5.0.tgz",
-            "integrity": "sha512-aDwANs1c1xIh5lQTbMlsGx8tMDk1k+sjsYbIXYjWvGY9Ff2e40MQ6RgALItVVij1dj1049FkG9MOHLFqekxZoA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.6.0.tgz",
+            "integrity": "sha512-+5bTaLsYJ+sb9bOzV7i6374Bb61jKlE3eh0mMlaLKwG9ZJO8r/pTMbsRNt9vXipkcJEvc9N8xZJyDs2EYnyfPA==",
             "dependencies": {
-                "dockerfile-language-service": "0.4.0",
-                "dockerfile-utils": "0.5.0",
-                "vscode-languageserver": "^7.0.0"
+                "dockerfile-language-service": "0.5.0",
+                "dockerfile-utils": "0.7.0",
+                "vscode-languageserver": "^8.0.0-next.2"
             },
             "bin": {
                 "docker-langserver": "bin/docker-langserver"
@@ -2150,26 +2145,26 @@
             }
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.4.0.tgz",
-            "integrity": "sha512-P4yj9in7PMLeN3StBn5e+Ofiju+nfs5ZdDv4EqfK91mYx/+U7wm8QipyP05iUXaVKFh6I9tn9Qmi1tpt5jj2hw==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.5.0.tgz",
+            "integrity": "sha512-63B8rASoOz69NI4a3ftC64mVTDnQhd6xXdu5J6PN53+2wEm6vhO+zf6R4A5/ssxB3nSnckV25OtHCdBX2CYluQ==",
             "dependencies": {
-                "dockerfile-ast": "0.3.0",
-                "dockerfile-utils": "0.5.0",
-                "vscode-languageserver-types": "3.17.0-next.1"
+                "dockerfile-ast": "0.3.1",
+                "dockerfile-utils": "0.7.0",
+                "vscode-languageserver-types": "3.17.0-next.3"
             },
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/dockerfile-utils": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.5.0.tgz",
-            "integrity": "sha512-a12B6qAwLpl7D9Y6Zxt0AhW74g0k5NarpWF+NUb66A6la5vs1igI/KfdXZbFoQtpTOsv1T+OfKmhlE982Ars1w==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.7.0.tgz",
+            "integrity": "sha512-27Qh1oT1yjbAPbV/VheDZICoSOYfb9pEgkZSiQMbGQOXw0a4ZObDRNxqYQ2o9udVOTbb/HS4y/hm+reCpz8i9g==",
             "dependencies": {
-                "dockerfile-ast": "0.3.0",
+                "dockerfile-ast": "0.3.1",
                 "vscode-languageserver-textdocument": "^1.0.1",
-                "vscode-languageserver-types": "^3.16.0"
+                "vscode-languageserver-types": "^3.17.0-next.3"
             },
             "bin": {
                 "dockerfile-utils": "bin/dockerfile-utils"
@@ -2177,11 +2172,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/dockerfile-utils/node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
         "node_modules/dockerode": {
             "version": "3.3.0",
@@ -6261,11 +6251,11 @@
             }
         },
         "node_modules/vscode-languageserver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+            "version": "8.0.0-next.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.0-next.2.tgz",
+            "integrity": "sha512-7qCEXTeGZKkI8BGvlKh0JPXTY7BaWoiwQYKCcGaUgnMs34wt6F/yaKcxoC3XIouBBVyRxiI6Ml/JdztM3XYEaA==",
             "dependencies": {
-                "vscode-languageserver-protocol": "3.16.0"
+                "vscode-languageserver-protocol": "3.17.0-next.8"
             },
             "bin": {
                 "installServerIntoExtension": "bin/installServerIntoExtension"
@@ -6291,9 +6281,26 @@
             "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.17.0-next.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.1.tgz",
-            "integrity": "sha512-VGzh06oynbYa6JbTKUbxOEZN7CYEtWhN7DK5wfzUpeCJl8X8xZX39g2PVfpqXrIEduu7dcJgK007KgnX9tHNKA=="
+            "version": "3.17.0-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.3.tgz",
+            "integrity": "sha512-VQcXnhKYxUW6OiRMhG++SzmZYMJwusXknJGd+FfdOnS1yHAo734OHyR0e2eEHDlv0/oWc8RZPgx/VKSKyondVg=="
+        },
+        "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
+            "version": "8.0.0-next.2",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.2.tgz",
+            "integrity": "sha512-gxUyTBAjmwGkiHW/UaRScre2s4i98P8M7gnc3VB4DrVQUm3vQ0idi2cN9nbkfcjATx+uEt8C22j+MLN/8UzsJA==",
+            "engines": {
+                "node": ">=8.0.0 || >=10.0.0"
+            }
+        },
+        "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.0-next.8",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.8.tgz",
+            "integrity": "sha512-P89vSuJ+FA5JzFmcOoZN13Ig1yd6LsiPOig0O5m5BSGuO/rplQegCd9J0wKpaTy7trf/SYHRoypnbUBdzy14sg==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.0.0-next.2",
+                "vscode-languageserver-types": "3.17.0-next.3"
+            }
         },
         "node_modules/vscode-nls": {
             "version": "5.0.0",
@@ -8707,56 +8714,42 @@
             }
         },
         "dockerfile-ast": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.0.tgz",
-            "integrity": "sha512-wEbFtqeHZffyOYP2pMfMLQ0m2wdHUzty0UTDoAMNa6/nvLfDRSEaPkszIWFy86tuWwHucBtcczIHQlFATJ54eA==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.1.tgz",
+            "integrity": "sha512-sxFv+wY4TNC68+JkbZ4kPn3pAfnfvbFBUcvYAA9KFg7Es58FgWr+trskeDRWFkCFeuM1QIXeBC5exMeiAeW96Q==",
             "requires": {
                 "vscode-languageserver-textdocument": "^1.0.1",
-                "vscode-languageserver-types": "^3.16.0"
-            },
-            "dependencies": {
-                "vscode-languageserver-types": {
-                    "version": "3.16.0",
-                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-                    "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-                }
+                "vscode-languageserver-types": "^3.17.0-next.3"
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.5.0.tgz",
-            "integrity": "sha512-aDwANs1c1xIh5lQTbMlsGx8tMDk1k+sjsYbIXYjWvGY9Ff2e40MQ6RgALItVVij1dj1049FkG9MOHLFqekxZoA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.6.0.tgz",
+            "integrity": "sha512-+5bTaLsYJ+sb9bOzV7i6374Bb61jKlE3eh0mMlaLKwG9ZJO8r/pTMbsRNt9vXipkcJEvc9N8xZJyDs2EYnyfPA==",
             "requires": {
-                "dockerfile-language-service": "0.4.0",
-                "dockerfile-utils": "0.5.0",
-                "vscode-languageserver": "^7.0.0"
+                "dockerfile-language-service": "0.5.0",
+                "dockerfile-utils": "0.7.0",
+                "vscode-languageserver": "^8.0.0-next.2"
             }
         },
         "dockerfile-language-service": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.4.0.tgz",
-            "integrity": "sha512-P4yj9in7PMLeN3StBn5e+Ofiju+nfs5ZdDv4EqfK91mYx/+U7wm8QipyP05iUXaVKFh6I9tn9Qmi1tpt5jj2hw==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.5.0.tgz",
+            "integrity": "sha512-63B8rASoOz69NI4a3ftC64mVTDnQhd6xXdu5J6PN53+2wEm6vhO+zf6R4A5/ssxB3nSnckV25OtHCdBX2CYluQ==",
             "requires": {
-                "dockerfile-ast": "0.3.0",
-                "dockerfile-utils": "0.5.0",
-                "vscode-languageserver-types": "3.17.0-next.1"
+                "dockerfile-ast": "0.3.1",
+                "dockerfile-utils": "0.7.0",
+                "vscode-languageserver-types": "3.17.0-next.3"
             }
         },
         "dockerfile-utils": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.5.0.tgz",
-            "integrity": "sha512-a12B6qAwLpl7D9Y6Zxt0AhW74g0k5NarpWF+NUb66A6la5vs1igI/KfdXZbFoQtpTOsv1T+OfKmhlE982Ars1w==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.7.0.tgz",
+            "integrity": "sha512-27Qh1oT1yjbAPbV/VheDZICoSOYfb9pEgkZSiQMbGQOXw0a4ZObDRNxqYQ2o9udVOTbb/HS4y/hm+reCpz8i9g==",
             "requires": {
-                "dockerfile-ast": "0.3.0",
+                "dockerfile-ast": "0.3.1",
                 "vscode-languageserver-textdocument": "^1.0.1",
-                "vscode-languageserver-types": "^3.16.0"
-            },
-            "dependencies": {
-                "vscode-languageserver-types": {
-                    "version": "3.16.0",
-                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-                    "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-                }
+                "vscode-languageserver-types": "^3.17.0-next.3"
             }
         },
         "dockerode": {
@@ -11878,11 +11871,27 @@
             }
         },
         "vscode-languageserver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+            "version": "8.0.0-next.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.0-next.2.tgz",
+            "integrity": "sha512-7qCEXTeGZKkI8BGvlKh0JPXTY7BaWoiwQYKCcGaUgnMs34wt6F/yaKcxoC3XIouBBVyRxiI6Ml/JdztM3XYEaA==",
             "requires": {
-                "vscode-languageserver-protocol": "3.16.0"
+                "vscode-languageserver-protocol": "3.17.0-next.8"
+            },
+            "dependencies": {
+                "vscode-jsonrpc": {
+                    "version": "8.0.0-next.2",
+                    "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.2.tgz",
+                    "integrity": "sha512-gxUyTBAjmwGkiHW/UaRScre2s4i98P8M7gnc3VB4DrVQUm3vQ0idi2cN9nbkfcjATx+uEt8C22j+MLN/8UzsJA=="
+                },
+                "vscode-languageserver-protocol": {
+                    "version": "3.17.0-next.8",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.8.tgz",
+                    "integrity": "sha512-P89vSuJ+FA5JzFmcOoZN13Ig1yd6LsiPOig0O5m5BSGuO/rplQegCd9J0wKpaTy7trf/SYHRoypnbUBdzy14sg==",
+                    "requires": {
+                        "vscode-jsonrpc": "8.0.0-next.2",
+                        "vscode-languageserver-types": "3.17.0-next.3"
+                    }
+                }
             }
         },
         "vscode-languageserver-protocol": {
@@ -11907,9 +11916,9 @@
             "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
         },
         "vscode-languageserver-types": {
-            "version": "3.17.0-next.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.1.tgz",
-            "integrity": "sha512-VGzh06oynbYa6JbTKUbxOEZN7CYEtWhN7DK5wfzUpeCJl8X8xZX39g2PVfpqXrIEduu7dcJgK007KgnX9tHNKA=="
+            "version": "3.17.0-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.3.tgz",
+            "integrity": "sha512-VQcXnhKYxUW6OiRMhG++SzmZYMJwusXknJGd+FfdOnS1yHAo734OHyR0e2eEHDlv0/oWc8RZPgx/VKSKyondVg=="
         },
         "vscode-nls": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -2911,7 +2911,7 @@
         "@docker/sdk": "^1.0.3",
         "@grpc/grpc-js": "^1.2.12",
         "dayjs": "^1.10.4",
-        "dockerfile-language-server-nodejs": "^0.5.0",
+        "dockerfile-language-server-nodejs": "^0.6.0",
         "dockerode": "^3.2.1",
         "fs-extra": "^10.0.0",
         "glob": "^7.1.6",


### PR DESCRIPTION
The new 0.6.0 release of the language server adds support for heredocs in `ADD` and `COPY` as well as allowing multiple heredocs to be defined in a single instruction. There is also a small change to flag relevant linting issues as being "unnecessary". I'm not sure how VS Code renders this and if it takes the theme into consideration at all.
```Dockerfile
#escape=`
#escape=`
FROM node:alpine
# the linting issues above and below will now be slightly faded
# (depending on your theme?) to note that they are "unnecessary" given
# that there are duplicates and one of them should be removed
CMD [ "executable" ]
CMD [ "executable" ]
ENTRYPOINT [ "executable" ]
ENTRYPOINT [ "executable" ]
HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "executable" ]
HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "executable" ]

# multiple heredocs can now be defined in a single instruction without
# being reported as errors
RUN <<FILE1 cat > file1 && <<FILE2 cat > file2
first heredoc
FILE1
second heredoc
FILE2

# heredoc syntax support is available for ADD and COPY so the following
# lines will no longer be reported as errors
ADD <<EOF /test.txt
echo "Hello world"
EOF

COPY <<EOF /test.txt
echo "Hello world"
EOF

# invoke Intellisense on lines 36 and 40, nothing should be prompted,
# previously all instructions would be prompted as the system was not
# aware that it was in a heredoc
ADD <<eof test.txt

eof

COPY <<eof test.txt

eof
```