### PR TITLE
Add a simple `docker stats` palette command

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "onCommand:vscode-docker.containers.select",
         "onCommand:vscode-docker.containers.start",
         "onCommand:vscode-docker.containers.stop",
+        "onCommand:vscode-docker.containers.stats",
         "onCommand:vscode-docker.containers.viewLogs",
         "onCommand:vscode-docker.containers.composeGroup.logs",
         "onCommand:vscode-docker.containers.composeGroup.start",
@@ -2421,6 +2422,11 @@
                 "command": "vscode-docker.containers.stop",
                 "title": "%vscode-docker.commands.containers.stop%",
                 "category": "%vscode-docker.commands.category.dockerContainers%"
+            },
+            {
+                "command": "vscode-docker.containers.stats",
+                "title": "%vscode-docker.commands.containers.stats%",
+                "category": "%vscode-docker.commands.category.docker%"
             },
             {
                 "command": "vscode-docker.containers.viewLogs",

--- a/package.nls.json
+++ b/package.nls.json
@@ -215,6 +215,7 @@
     "vscode-docker.commands.containers.select": "Select container",
     "vscode-docker.commands.containers.start": "Start",
     "vscode-docker.commands.containers.stop": "Stop",
+    "vscode-docker.commands.containers.stats": "Stats",
     "vscode-docker.commands.containers.viewLogs": "View Logs",
     "vscode-docker.commands.containers.composeGroup.logs": "Compose Logs",
     "vscode-docker.commands.containers.composeGroup.start": "Compose Start",

--- a/src/commands/containers/stats.ts
+++ b/src/commands/containers/stats.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from 'vscode-azureextensionui';
+import { dockerExePath } from '../../utils/dockerExePathProvider';
+import { executeAsTask } from '../../utils/executeAsTask';
+
+export async function stats(context: IActionContext): Promise<void> {
+    // Don't wait
+    void executeAsTask(context, `${dockerExePath(context)} stats`, 'docker stats', { addDockerEnv: true });
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -22,6 +22,7 @@ import { removeContainer } from "./containers/removeContainer";
 import { restartContainer } from "./containers/restartContainer";
 import { selectContainer } from "./containers/selectContainer";
 import { startContainer } from "./containers/startContainer";
+import { stats } from "./containers/stats";
 import { stopContainer } from "./containers/stopContainer";
 import { viewContainerLogs } from "./containers/viewContainerLogs";
 import { createAciContext } from "./context/aci/createAciContext";
@@ -133,6 +134,7 @@ export function registerCommands(): void {
     registerCommand('vscode-docker.containers.select', selectContainer);
     registerCommand('vscode-docker.containers.start', startContainer);
     registerCommand('vscode-docker.containers.stop', stopContainer);
+    registerWorkspaceCommand('vscode-docker.containers.stats', stats);
     registerWorkspaceCommand('vscode-docker.containers.viewLogs', viewContainerLogs);
     registerWorkspaceCommand('vscode-docker.containers.composeGroup.logs', composeGroupLogs);
     registerWorkspaceCommand('vscode-docker.containers.composeGroup.start', composeGroupStart);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,6 +64,7 @@ const config = {
     },
     plugins: [
         // Copy some needed resource files from external sources
+        // @ts-expect-error: Spurious type incompatibility error
         new CopyPlugin({
             patterns: [
                 './node_modules/vscode-azureextensionui/resources/**/*.svg',
@@ -101,15 +102,26 @@ const config = {
             message: /require\.extensions/,
         },
         {
-            // Ignore a warning from vscode-extension-telemetry
+            // Ignore a warning from `vscode-extension-telemetry`
             module: /node_modules\/vscode-extension-telemetry/,
             message: /Can't resolve 'applicationinsights-native-metrics'/
         },
+        {
+            // Ignore a warning for missing optional dependency of `ssh2`
+            module: /node_modules\/ssh2/,
+            message: /Can't resolve 'cpu-features'/
+        },
+        {
+            // Ignore a warning for missing optional dependency of `ssh2`
+            module: /node_modules\/ssh2/,
+            message: /Can't resolve '\.\/crypto\/build\/Release\/sshcrypto.node'/
+        },
         (warning) => false, // No other warnings should be ignored
-    ]
+    ],
 };
 
 if (debugWebpack) {
+    // @ts-expect-error: Spurious type incompatibility error
     config.plugins.push(new BundleAnalyzerPlugin({ analyzerMode: 'static' }));
     console.log('Config:', config);
 }


### PR DESCRIPTION
Fixes #3063.

Unrelatedly, it fixes some warnings in webpack.config.js itself, along with some warnings produced by webpack about `ssh2` that was causing VSCode to think webpack did not finish--and it wouldn't <kbd>F5</kbd> the extension.