### PR TITLE
Upgrade Dockerfile language server to 0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@grpc/grpc-js": "^1.2.12",
                 "@microsoft/compose-language-service": "^0.0.1-alpha",
                 "dayjs": "^1.10.4",
-                "dockerfile-language-server-nodejs": "^0.6.0",
+                "dockerfile-language-server-nodejs": "^0.7.1",
                 "dockerode": "^3.2.1",
                 "fs-extra": "^10.0.0",
                 "glob": "^7.1.6",
@@ -2147,9 +2147,9 @@
             }
         },
         "node_modules/dockerfile-ast": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.1.tgz",
-            "integrity": "sha512-sxFv+wY4TNC68+JkbZ4kPn3pAfnfvbFBUcvYAA9KFg7Es58FgWr+trskeDRWFkCFeuM1QIXeBC5exMeiAeW96Q==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.4.tgz",
+            "integrity": "sha512-QjNH/VnTrWjlDekJtk5GBKbypcFUBdGexd+eOAeivwwSWky6bIJps1cw/qw1jU5K3TDMgtufAHaBh7OV5X/EqA==",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
@@ -2159,12 +2159,12 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.6.0.tgz",
-            "integrity": "sha512-+5bTaLsYJ+sb9bOzV7i6374Bb61jKlE3eh0mMlaLKwG9ZJO8r/pTMbsRNt9vXipkcJEvc9N8xZJyDs2EYnyfPA==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.1.tgz",
+            "integrity": "sha512-mk1FkdckiNi0gxm/KIsgOJRpPROOqq27fF90f8CtetbaqRvL/mwKDTN2umLeRenJ4ayxdz/Gpf7gWOOQz1kZ1Q==",
             "dependencies": {
-                "dockerfile-language-service": "0.5.0",
-                "dockerfile-utils": "0.7.0",
+                "dockerfile-language-service": "0.7.2",
+                "dockerfile-utils": "0.9.2",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
             "bin": {
@@ -2203,12 +2203,12 @@
             }
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.5.0.tgz",
-            "integrity": "sha512-63B8rASoOz69NI4a3ftC64mVTDnQhd6xXdu5J6PN53+2wEm6vhO+zf6R4A5/ssxB3nSnckV25OtHCdBX2CYluQ==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.2.tgz",
+            "integrity": "sha512-kG2/HrdNz4Hp6O9F2akKSODufQ0BTwXE4hd4kCUOp99de47+r8GpWKOyqpJswr+kbvttPmxcnVdV8wT77c2p5g==",
             "dependencies": {
-                "dockerfile-ast": "0.3.1",
-                "dockerfile-utils": "0.7.0",
+                "dockerfile-ast": "0.3.4",
+                "dockerfile-utils": "0.9.2",
                 "vscode-languageserver-types": "3.17.0-next.3"
             },
             "engines": {
@@ -2216,11 +2216,11 @@
             }
         },
         "node_modules/dockerfile-utils": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.7.0.tgz",
-            "integrity": "sha512-27Qh1oT1yjbAPbV/VheDZICoSOYfb9pEgkZSiQMbGQOXw0a4ZObDRNxqYQ2o9udVOTbb/HS4y/hm+reCpz8i9g==",
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.2.tgz",
+            "integrity": "sha512-QgcYXSZFBBbPuiQskEAVnW3qSShSCSisLNt2wQZXupBQ/x1lFIyvVfWXk4OQqWoatHyAfUBiXDNx9eRXkmSALQ==",
             "dependencies": {
-                "dockerfile-ast": "0.3.1",
+                "dockerfile-ast": "0.3.4",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
             },
@@ -8836,21 +8836,21 @@
             }
         },
         "dockerfile-ast": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.1.tgz",
-            "integrity": "sha512-sxFv+wY4TNC68+JkbZ4kPn3pAfnfvbFBUcvYAA9KFg7Es58FgWr+trskeDRWFkCFeuM1QIXeBC5exMeiAeW96Q==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.4.tgz",
+            "integrity": "sha512-QjNH/VnTrWjlDekJtk5GBKbypcFUBdGexd+eOAeivwwSWky6bIJps1cw/qw1jU5K3TDMgtufAHaBh7OV5X/EqA==",
             "requires": {
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.6.0.tgz",
-            "integrity": "sha512-+5bTaLsYJ+sb9bOzV7i6374Bb61jKlE3eh0mMlaLKwG9ZJO8r/pTMbsRNt9vXipkcJEvc9N8xZJyDs2EYnyfPA==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.1.tgz",
+            "integrity": "sha512-mk1FkdckiNi0gxm/KIsgOJRpPROOqq27fF90f8CtetbaqRvL/mwKDTN2umLeRenJ4ayxdz/Gpf7gWOOQz1kZ1Q==",
             "requires": {
-                "dockerfile-language-service": "0.5.0",
-                "dockerfile-utils": "0.7.0",
+                "dockerfile-language-service": "0.7.2",
+                "dockerfile-utils": "0.9.2",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
             "dependencies": {
@@ -8879,21 +8879,21 @@
             }
         },
         "dockerfile-language-service": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.5.0.tgz",
-            "integrity": "sha512-63B8rASoOz69NI4a3ftC64mVTDnQhd6xXdu5J6PN53+2wEm6vhO+zf6R4A5/ssxB3nSnckV25OtHCdBX2CYluQ==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.2.tgz",
+            "integrity": "sha512-kG2/HrdNz4Hp6O9F2akKSODufQ0BTwXE4hd4kCUOp99de47+r8GpWKOyqpJswr+kbvttPmxcnVdV8wT77c2p5g==",
             "requires": {
-                "dockerfile-ast": "0.3.1",
-                "dockerfile-utils": "0.7.0",
+                "dockerfile-ast": "0.3.4",
+                "dockerfile-utils": "0.9.2",
                 "vscode-languageserver-types": "3.17.0-next.3"
             }
         },
         "dockerfile-utils": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.7.0.tgz",
-            "integrity": "sha512-27Qh1oT1yjbAPbV/VheDZICoSOYfb9pEgkZSiQMbGQOXw0a4ZObDRNxqYQ2o9udVOTbb/HS4y/hm+reCpz8i9g==",
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.2.tgz",
+            "integrity": "sha512-QgcYXSZFBBbPuiQskEAVnW3qSShSCSisLNt2wQZXupBQ/x1lFIyvVfWXk4OQqWoatHyAfUBiXDNx9eRXkmSALQ==",
             "requires": {
-                "dockerfile-ast": "0.3.1",
+                "dockerfile-ast": "0.3.4",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
             }

--- a/package.json
+++ b/package.json
@@ -3020,7 +3020,7 @@
         "@grpc/grpc-js": "^1.2.12",
         "@microsoft/compose-language-service": "^0.0.1-alpha",
         "dayjs": "^1.10.4",
-        "dockerfile-language-server-nodejs": "^0.6.0",
+        "dockerfile-language-server-nodejs": "^0.7.1",
         "dockerode": "^3.2.1",
         "fs-extra": "^10.0.0",
         "glob": "^7.1.6",


### PR DESCRIPTION
The 0.7.1 release of the Dockerfile language server has the following improvements:
- updates linter to consider syntax valid in BuildKit
- improve robustness of the parser to not get in invalid loops (inadvertently discovered by https://github.com/microsoft/vscode-docker/issues/3189#issuecomment-913979668)
- ignore valid instructions but to instead only flag the incorrect duplicates

Please use the following Dockerfiles for testing purposes. As always, please just copy/paste the content in to a `Dockerfile` without saving to preserve the formatting (to reproduce the incorrect parsing behaviour).
```Dockerfile
#escape=`
#escape=`
# only the second escape directive above is flagged as the first is valid
FROM node:alpine

# only the first set of instructions will be flagged as they are duplicated and unnecessary
CMD [ "executable" ]
ENTRYPOINT [ "executable" ]
HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "executable" ]
# the second set here is what will be used so they are no longer flagged
CMD [ "executable" ]
ENTRYPOINT [ "executable" ]
HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "executable" ]

# RUN can have no arguments or only flags in BuildKit, these two instructions should not be errors
RUN
RUN --mount=type=cache,target=/var/cache/foo,uid=1,gid=1
```
```Dockerfile
# the Output panel will complain about an infinite loop in
# textDocument/semanticTokens/full when the file is opened, if it does 
# not happen, just edit the comments, the new release fixes this
# https://github.com/microsoft/vscode-docker/issues/3189#issuecomment-913979668
FROM alpine
# hover over the error, it should no longer say RU\NRUN merging two into one,
# it should just say RU\N
RU\N
RUN echo
FROM node:alpine
# this error is merged into RUNRUNRUN, there should be no errors here
RU\
N
RUN
RUN echo

# this should not be an error, the embedded comment should be ignored
FR\
#
OM alpine
```