### PR TITLE
Fix unhelpful error from GitLab registry provider

### DIFF
--- a/src/tree/registries/gitLab/GitLabAccountTreeItem.ts
+++ b/src/tree/registries/gitLab/GitLabAccountTreeItem.ts
@@ -64,6 +64,8 @@ export class GitLabAccountTreeItem extends AzExtParentTreeItem implements IRegis
             const errorType: string = parseError(err).errorType.toLowerCase();
             if (errorType === '401' || errorType === 'unauthorized') {
                 return [new RegistryConnectErrorTreeItem(this, err, this.cachedProvider)];
+            } else {
+                throw err;
             }
         }
     }

--- a/src/tree/registries/gitLab/gitLabRegistryProvider.ts
+++ b/src/tree/registries/gitLab/gitLabRegistryProvider.ts
@@ -17,7 +17,7 @@ export const gitLabRegistryProvider: IRegistryProvider = {
         wizardTitle: localize('vscode-docker.tree.registries.gitlab.signIn', 'Sign in to GitLab'),
         includeUsername: true,
         includePassword: true,
-        passwordPrompt: localize('vscode-docker.tree.registries.gitlab.pat', 'GitLab Personal Access Token'),
+        passwordPrompt: localize('vscode-docker.tree.registries.gitlab.pat', 'GitLab Personal Access Token (requires `api` or `read_api` scope)'),
     },
     treeItemFactory: (parent, cachedProvider) => new GitLabAccountTreeItem(parent, cachedProvider),
     persistAuth: async (cachedProvider, secret) => await setRegistryPassword(cachedProvider, secret),


### PR DESCRIPTION
Fixes #3199 (the unhelpful error message, that is--we still require an `api` or `read_api` token, I updated the prompt text to indicate that)