### PR TITLE
Clarify install instructions for Linux rootless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Docker extension makes it easy to build, manage, and deploy containerized ap
 
 [Install Docker](https://docs.docker.com/install/) on your machine and add it to the system path.
 
-On Linux, you should [enable rootless Docker](https://docs.docker.com/engine/security/rootless/) (more secure) or [enable Docker CLI for the non-root user account](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) (less secure) that will be used to run VS Code.
+On Linux, you should [enable rootless Docker](https://docs.docker.com/engine/security/rootless/) and set the generated Docker context to "rootless" (more secure) or [enable Docker CLI for the non-root user account](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) (less secure) that will be used to run VS Code.
 
 To install the extension, open the Extensions view, search for `docker` to filter results and select Docker extension authored by Microsoft.
 


### PR DESCRIPTION
Brief clarification to note that Docker rootless mode needs to have the generated context enabled before the vscode-docker extension will see it. Partial fix for issue #3257