### PR TITLE
Move back to `macOS-latest`

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -18,7 +18,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macOS-10.14
+    vmImage: macOS-latest
   steps:
   - template: common/setup.yml
   - template: common/governance.yml   # Force governance before test to avoid false-positives.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
         "dbaeumer.vscode-eslint",
-        "eamodio.tsl-problem-matcher"
+        "amodio.tsl-problem-matcher"
     ]
 }


### PR DESCRIPTION
This moves the Mac pipeline back to `macOS-latest`, effectively reverting #2754. https://github.com/microsoft/vscode/issues/118253 is no longer an issue.

Also fixes an unrelated issue, the `eamodio.tsl-problem-matcher` workspace extension recommendation was re-ID'd to `amodio.tsl-problem-matcher`.