### PR TITLE
Upgrade Dockerfile language server to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@grpc/grpc-js": "^1.2.12",
                 "@microsoft/compose-language-service": "^0.0.1-alpha",
                 "dayjs": "^1.10.4",
-                "dockerfile-language-server-nodejs": "^0.7.1",
+                "dockerfile-language-server-nodejs": "^0.7.2",
                 "dockerode": "^3.2.1",
                 "fs-extra": "^10.0.0",
                 "glob": "^7.1.6",
@@ -2152,11 +2152,11 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.1.tgz",
-            "integrity": "sha512-mk1FkdckiNi0gxm/KIsgOJRpPROOqq27fF90f8CtetbaqRvL/mwKDTN2umLeRenJ4ayxdz/Gpf7gWOOQz1kZ1Q==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.2.tgz",
+            "integrity": "sha512-TrUvQ+Mq/R4uODRPHNsDKwFXucGsJBm4cObKENYtwNkXCeT7QmrNBc9d8lQQM0B+Gsc7mDASWKn1Jn+1FwVtIw==",
             "dependencies": {
-                "dockerfile-language-service": "0.7.2",
+                "dockerfile-language-service": "0.7.3",
                 "dockerfile-utils": "0.9.2",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
@@ -2196,9 +2196,9 @@
             }
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.2.tgz",
-            "integrity": "sha512-kG2/HrdNz4Hp6O9F2akKSODufQ0BTwXE4hd4kCUOp99de47+r8GpWKOyqpJswr+kbvttPmxcnVdV8wT77c2p5g==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.3.tgz",
+            "integrity": "sha512-zTDkmeBmafVGDx/34gWAst8tAysx2bUWcSnw+f5SI+b3SzpJNUzoWpgm7xtoNwHoWRuB7xHdiGmvkbrRfA2o8Q==",
             "dependencies": {
                 "dockerfile-ast": "0.3.4",
                 "dockerfile-utils": "0.9.2",
@@ -8832,11 +8832,11 @@
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.1.tgz",
-            "integrity": "sha512-mk1FkdckiNi0gxm/KIsgOJRpPROOqq27fF90f8CtetbaqRvL/mwKDTN2umLeRenJ4ayxdz/Gpf7gWOOQz1kZ1Q==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.2.tgz",
+            "integrity": "sha512-TrUvQ+Mq/R4uODRPHNsDKwFXucGsJBm4cObKENYtwNkXCeT7QmrNBc9d8lQQM0B+Gsc7mDASWKn1Jn+1FwVtIw==",
             "requires": {
-                "dockerfile-language-service": "0.7.2",
+                "dockerfile-language-service": "0.7.3",
                 "dockerfile-utils": "0.9.2",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
@@ -8866,9 +8866,9 @@
             }
         },
         "dockerfile-language-service": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.2.tgz",
-            "integrity": "sha512-kG2/HrdNz4Hp6O9F2akKSODufQ0BTwXE4hd4kCUOp99de47+r8GpWKOyqpJswr+kbvttPmxcnVdV8wT77c2p5g==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.3.tgz",
+            "integrity": "sha512-zTDkmeBmafVGDx/34gWAst8tAysx2bUWcSnw+f5SI+b3SzpJNUzoWpgm7xtoNwHoWRuB7xHdiGmvkbrRfA2o8Q==",
             "requires": {
                 "dockerfile-ast": "0.3.4",
                 "dockerfile-utils": "0.9.2",

--- a/package.json
+++ b/package.json
@@ -3041,7 +3041,7 @@
         "@grpc/grpc-js": "^1.2.12",
         "@microsoft/compose-language-service": "^0.0.1-alpha",
         "dayjs": "^1.10.4",
-        "dockerfile-language-server-nodejs": "^0.7.1",
+        "dockerfile-language-server-nodejs": "^0.7.2",
         "dockerode": "^3.2.1",
         "fs-extra": "^10.0.0",
         "glob": "^7.1.6",


### PR DESCRIPTION
This small update prevents two cases of infinite loops from being thrown in a `textDocument/semanticTokens/full` request. One of the two cases is the one reported in #3268.

Open these two files as Dockerfiles and you should see the exception error pop up. Do not save or format the file as the bug is contingent on the second line not having any whitespace in the front.
```Dockerfile
FROM $image\
abc
```
```Dockerfile
R\ 
# abc
```
You can also test with the Dockerfile described in https://github.com/microsoft/vscode-docker/issues/3268#issuecomment-946637035. Opening that file should not cause any problems either.