### PR TITLE
Make volumes accessible on SELinux systems by adding relabel option.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1225,7 +1225,9 @@
                                             "description": "%vscode-docker.tasks.docker-run.dockerRun.volumes.permissions%",
                                             "enum": [
                                                 "rw",
-                                                "ro"
+                                                "ro",
+                                                "rw,z",
+                                                "ro,z"
                                             ]
                                         }
                                     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -82,7 +82,7 @@
     "vscode-docker.tasks.docker-run.dockerRun.volumes.description": "Volumes that are going to be mapped to the container.",
     "vscode-docker.tasks.docker-run.dockerRun.volumes.localPath": "Path on local machine that will be mapped. The folder will be created if it does not exist.",
     "vscode-docker.tasks.docker-run.dockerRun.volumes.containerPath": "Path where the volume will be mapped within the container. The folder will be created if it does not exist.",
-    "vscode-docker.tasks.docker-run.dockerRun.volumes.permissions": "Permissions for the container for the mapped volume, `rw` for read-write or `ro` for read-only.",
+    "vscode-docker.tasks.docker-run.dockerRun.volumes.permissions": "Permissions for the container for the mapped volume, `rw[,z]` for read-write or `ro[,z]` for read-only. The `,z`-suffix relables the content to make it accessible in the container on SELinux-based systems.",
     "vscode-docker.tasks.docker-run.dockerRun.customOptions": "Any other options to add to the `docker run` command.",
     "vscode-docker.tasks.docker-run.platform": "The target platform for the application.",
     "vscode-docker.tasks.docker-run.netCore.description": "Options for running .NET Core projects in Docker.",

--- a/src/tasks/DockerRunTaskDefinitionBase.ts
+++ b/src/tasks/DockerRunTaskDefinitionBase.ts
@@ -21,7 +21,7 @@ export interface DockerContainerPort {
 export interface DockerContainerVolume {
     localPath: string;
     containerPath: string;
-    permissions?: 'ro' | 'rw';
+    permissions?: 'ro' | 'rw' | 'ro,z' | 'rw,z';
 }
 
 export interface DockerRunOptions {

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -102,9 +102,22 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
     }
 
     private getVolumeOptions(volume: DockerContainerVolume, isWindows: boolean): string {
-        return !volume.permissions ? '' :
-            !isWindows ? `:${volume.permissions}` :
-                // for Windows, filter out the unsupported 'z'/'Z' options.
-                `:${volume.permissions.split(',').filter(s => s !== 'z' && s !== 'Z').join(',')}`;
+        if (!volume.permissions) {
+            return '';
+        } else if (!isWindows) {
+            return ':' + volume.permissions;
+        } else {
+            // The 'z' and 'Z' options aren't supported on Windows containers, normalize to simply ro / rw
+            switch (volume.permissions as string) {
+                case 'ro,Z':
+                case 'ro,z':
+                    return ':ro';
+                case 'rw,Z':
+                case 'rw,z':
+                    return ':rw';
+                default:
+                    return ':' + volume.permissions;
+            }
+        }
     }
 }

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -9,7 +9,7 @@ import { localize } from '../localize';
 import { cloneObject } from '../utils/cloneObject';
 import { CommandLineBuilder } from '../utils/commandLineBuilder';
 import { dockerExePath } from '../utils/dockerExePathProvider';
-import { DockerRunOptions } from './DockerRunTaskDefinitionBase';
+import { DockerRunOptions, DockerContainerVolume } from './DockerRunTaskDefinitionBase';
 import { DockerTaskProvider } from './DockerTaskProvider';
 import { NetCoreRunTaskDefinition } from './netcore/NetCoreTaskHelper';
 import { NodeRunTaskDefinition } from './node/NodeTaskHelper';
@@ -91,7 +91,7 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
             .withKeyValueArgs('-e', runOptions.env)
             .withArrayArgs('--env-file', runOptions.envFiles)
             .withKeyValueArgs('--label', getAggregateLabels(runOptions.labels, defaultVsCodeLabels))
-            .withArrayArgs('-v', runOptions.volumes, volume => `${volume.localPath}:${volume.containerPath}${volume.permissions ? ':' + volume.permissions : ''}`)
+            .withArrayArgs('-v', runOptions.volumes, volume => `${volume.localPath}:${volume.containerPath}${this.getVolumeOptions(volume, runOptions.os === 'Windows')}`)
             .withArrayArgs('-p', runOptions.ports, port => `${port.hostPort ? port.hostPort + ':' : ''}${port.containerPort}${port.protocol ? '/' + port.protocol : ''}`)
             .withArrayArgs('--add-host', runOptions.extraHosts, extraHost => `${extraHost.hostname}:${extraHost.ip}`)
             .withNamedArg('--entrypoint', runOptions.entrypoint)
@@ -99,5 +99,12 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
             .withArg(runOptions.customOptions)
             .withQuotedArg(runOptions.image)
             .withArgs(runOptions.command);
+    }
+
+    private getVolumeOptions(volume: DockerContainerVolume, isWindows: boolean): string {
+        return !volume.permissions ? '' :
+            !isWindows ? `:${volume.permissions}` :
+                // for Windows, filter out the unsupported 'z'/'Z' options.
+                `:${volume.permissions.split(',').filter(s => s !== 'z' && s !== 'Z').join(',')}`;
     }
 }

--- a/src/tasks/netcore/NetCoreTaskHelper.ts
+++ b/src/tasks/netcore/NetCoreTaskHelper.ts
@@ -204,31 +204,31 @@ export class NetCoreTaskHelper implements TaskHelper {
             const appVolume: DockerContainerVolume = {
                 localPath: path.dirname(helperOptions.appProject),
                 containerPath: runOptions.os === 'Windows' ? 'C:\\app' : '/app',
-                permissions: 'rw'
+                permissions: 'rw,z'
             };
 
             const srcVolume: DockerContainerVolume = {
                 localPath: folder.uri.fsPath,
                 containerPath: runOptions.os === 'Windows' ? 'C:\\src' : '/src',
-                permissions: 'rw'
+                permissions: 'rw,z'
             };
 
             const debuggerVolume: DockerContainerVolume = {
                 localPath: vsDbgInstallBasePath,
                 containerPath: runOptions.os === 'Windows' ? 'C:\\remote_debugger' : '/remote_debugger',
-                permissions: 'ro'
+                permissions: 'ro,z'
             };
 
             const nugetRootVolume: DockerContainerVolume = {
                 localPath: path.join(os.homedir(), '.nuget', 'packages'),
                 containerPath: runOptions.os === 'Windows' ? 'C:\\.nuget\\packages' : '/root/.nuget/packages',
-                permissions: 'ro'
+                permissions: 'ro,z'
             };
 
             const nugetUserVolume: DockerContainerVolume = {
                 localPath: nugetRootVolume.localPath, // Same local path as the root one
                 containerPath: runOptions.os === 'Windows' ? 'C:\\Users\\ContainerUser\\.nuget\\packages' : '/home/appuser/.nuget/packages',
-                permissions: 'ro'
+                permissions: 'ro,z'
             };
 
             addVolumeWithoutConflicts(volumes, appVolume);
@@ -254,7 +254,7 @@ export class NetCoreTaskHelper implements TaskHelper {
             const userSecretsVolume: DockerContainerVolume = {
                 localPath: hostSecretsFolders.hostUserSecretsFolder,
                 containerPath: containerSecretsFolders.containerUserSecretsFolder,
-                permissions: 'ro'
+                permissions: 'ro,z'
             };
 
             addVolumeWithoutConflicts(volumes, userSecretsVolume);
@@ -263,7 +263,7 @@ export class NetCoreTaskHelper implements TaskHelper {
                 const certVolume: DockerContainerVolume = {
                     localPath: hostSecretsFolders.hostCertificateFolder,
                     containerPath: containerSecretsFolders.containerCertificateFolder,
-                    permissions: 'ro'
+                    permissions: 'ro,z'
                 };
 
                 addVolumeWithoutConflicts(volumes, certVolume);

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -126,7 +126,7 @@ export class PythonTaskHelper implements TaskHelper {
         const dbgVolume: DockerContainerVolume = {
             localPath: launcherFolder,
             containerPath: '/debugpy',
-            permissions: 'ro'
+            permissions: 'ro,z'
         };
 
         addVolumeWithoutConflicts(volumes, dbgVolume);


### PR DESCRIPTION
The volumes mounted by the plugin are not accessible in the container on SELinux systems like Fedora and RHEL.
They need to be relabeled.

For more info see the _Labeling Volume Mounts_ section in https://docs.podman.io/en/latest/markdown/podman-run.1.html.

@bwateratmsft ptal.