### PR TITLE
Mark some files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Stop git from breaking this script by putting CRLF in place of LF
 resources/netCore/vsdbg text eol=lf
 
-# Mark some files as generated
+# Mark some files as generated to prevent them from showing in the repo's language stats
 NOTICE.html linguist-vendored=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Stop git from breaking this script by putting CRLF in place of LF
 resources/netCore/vsdbg text eol=lf
+
+# Mark some files as generated
+NOTICE.html linguist-vendored=true


### PR DESCRIPTION
Learned about this from https://github.com/microsoft/vscode-azurestaticwebapps/pull/576. Marking this file as generated means it will no longer appear as part of the repo's language, here:
![image](https://user-images.githubusercontent.com/36966225/141315238-79adfdb8-e2f7-43e4-ae85-edc8ba7aeb6d.png)

I chose specifically to use `linguist-vendored` instead of `linguist-generated`, because I still want this file to appear in PRs by default when it is altered.