### PR TITLE
Convert dev imports to true dev imports only

### DIFF
--- a/src/commands/containers/removeContainer.ts
+++ b/src/commands/containers/removeContainer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import vscode = require('vscode');
+import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';

--- a/src/commands/containers/stopContainer.ts
+++ b/src/commands/containers/stopContainer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import vscode = require('vscode');
+import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';

--- a/src/commands/images/pushImage.ts
+++ b/src/commands/images/pushImage.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import vscode = require('vscode');
+import * as vscode from 'vscode';
 import { IActionContext, NoResourceFoundError } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';

--- a/src/commands/images/removeImage.ts
+++ b/src/commands/images/removeImage.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import vscode = require('vscode');
+import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';

--- a/src/commands/networks/removeNetwork.ts
+++ b/src/commands/networks/removeNetwork.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import vscode = require('vscode');
+import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';

--- a/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
+++ b/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Progress } from "vscode";
-import { IAppServiceWizardContext } from "vscode-azureappservice"; // These are only dev-time imports so don't need to be lazy
+import type { IAppServiceWizardContext } from "vscode-azureappservice"; // These are only dev-time imports so don't need to be lazy
 import { AzureWizardExecuteStep, createAzureClient } from "vscode-azureextensionui";
 import { ext } from "../../../extensionVariables";
 import { localize } from "../../../localize";

--- a/src/commands/registries/azure/DockerSiteCreateStep.ts
+++ b/src/commands/registries/azure/DockerSiteCreateStep.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebSiteManagementClient, WebSiteManagementModels } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
-import { Site } from '@azure/arm-appservice/esm/models'; // These are only dev-time imports so don't need to be lazy
+import type { WebSiteManagementClient, WebSiteManagementModels } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
+import type { Site } from '@azure/arm-appservice/esm/models'; // These are only dev-time imports so don't need to be lazy
 import { Progress } from "vscode";
-import { CustomLocation } from "vscode-azureappservice"; // These are only dev-time imports so don't need to be lazy
+import type { CustomLocation } from "vscode-azureappservice"; // These are only dev-time imports so don't need to be lazy
 import { AzExtLocation, AzureWizardExecuteStep, createAzureClient, LocationListStep } from "vscode-azureextensionui";
 import { ext } from "../../../extensionVariables";
 import { localize } from "../../../localize";

--- a/src/commands/registries/azure/DockerWebhookCreateStep.ts
+++ b/src/commands/registries/azure/DockerWebhookCreateStep.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebSiteManagementModels } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
-import { ContainerRegistryManagementModels as AcrModels } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
+import type { WebSiteManagementModels } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementModels as AcrModels } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
 import * as vscode from "vscode";
-import { IAppServiceWizardContext } from "vscode-azureappservice"; // These are only dev-time imports so don't need to be lazy
+import type { IAppServiceWizardContext } from "vscode-azureappservice"; // These are only dev-time imports so don't need to be lazy
 import { AzureWizardExecuteStep, createAzureClient } from "vscode-azureextensionui";
 import { ext } from "../../../extensionVariables";
 import { localize } from "../../../localize";

--- a/src/commands/registries/azure/deployImageToAzure.ts
+++ b/src/commands/registries/azure/deployImageToAzure.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebSiteManagementModels } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
+import type { WebSiteManagementModels } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
 import { env, Uri, window } from "vscode";
-import { IAppServiceWizardContext } from "vscode-azureappservice"; // These are only dev-time imports so don't need to be lazy
+import type { IAppServiceWizardContext } from "vscode-azureappservice"; // These are only dev-time imports so don't need to be lazy
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, ResourceGroupListStep } from "vscode-azureextensionui";
 import { ext } from "../../../extensionVariables";
 import { localize } from "../../../localize";

--- a/src/commands/registries/azure/tasks/runAzureTask.ts
+++ b/src/commands/registries/azure/tasks/runAzureTask.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import { window } from "vscode";
 import { IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../../../extensionVariables";

--- a/src/commands/registries/azure/tasks/scheduleRunRequest.ts
+++ b/src/commands/registries/azure/tasks/scheduleRunRequest.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerRegistryManagementClient, ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementClient, ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';

--- a/src/commands/volumes/removeVolume.ts
+++ b/src/commands/volumes/removeVolume.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import vscode = require('vscode');
+import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from "../../localize";

--- a/src/docker/DockerodeApiClient/DockerodeApiClient.ts
+++ b/src/docker/DockerodeApiClient/DockerodeApiClient.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import Dockerode = require('dockerode');
+import * as Dockerode from 'dockerode';
 import * as nodepath from 'path';
 import * as stream from 'stream';
 import * as tarstream from 'tar-stream';

--- a/src/docker/DockerodeApiClient/DockerodeUtils.ts
+++ b/src/docker/DockerodeApiClient/DockerodeUtils.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import Dockerode = require('dockerode');
+import * as Dockerode from 'dockerode';
 import { Socket } from 'net';
 import { CancellationTokenSource, env, MessageItem, Uri, window, workspace } from 'vscode';
 import { localize } from '../../localize';

--- a/src/dockerfileCompletionItemProvider.ts
+++ b/src/dockerfileCompletionItemProvider.ts
@@ -7,7 +7,7 @@
 
 import { CancellationToken, CompletionItem, CompletionItemProvider, Position, TextDocument } from 'vscode';
 import { FROM_DIRECTIVE_PATTERN } from './constants';
-import helper = require('./utils/suggestSupportHelper');
+import { SuggestSupportHelper } from './utils/suggestSupportHelper';
 
 // IntelliSense
 export class DockerfileCompletionItemProvider implements CompletionItemProvider {
@@ -15,9 +15,8 @@ export class DockerfileCompletionItemProvider implements CompletionItemProvider 
     public triggerCharacters: string[] = [];
     public excludeTokens: string[] = [];
 
-    /* eslint-disable-next-line @typescript-eslint/promise-function-async */ // Grandfathered in
-    public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Promise<CompletionItem[]> {
-        const dockerSuggestSupport = new helper.SuggestSupportHelper();
+    public async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Promise<CompletionItem[]> {
+        const dockerSuggestSupport = new SuggestSupportHelper();
 
         const textLine = document.lineAt(position.line);
 

--- a/src/test/commands/selectCommandTemplate.test.ts
+++ b/src/test/commands/selectCommandTemplate.test.ts
@@ -7,7 +7,7 @@ import { CommandTemplate, selectCommandTemplate } from '../../commands/selectCom
 import { ContextType, DockerContext, isNewContextType } from '../../docker/Contexts';
 import { ext } from '../../extensionVariables';
 import { IActionContext, IAzureQuickPickItem } from 'vscode-azureextensionui';
-import assert = require('assert');
+import * as assert from 'assert';
 
 const DefaultPickIndex = 0;
 

--- a/src/tree/registries/azure/AzureRegistryTreeItem.ts
+++ b/src/tree/registries/azure/AzureRegistryTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerRegistryManagementClient, ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementClient, ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import { URL } from "url";
 import { AzExtTreeItem, createAzureClient, IActionContext } from "vscode-azureextensionui";
 import { getResourceGroupFromId } from "../../../utils/azureUtils";

--- a/src/tree/registries/azure/AzureTaskRunTreeItem.ts
+++ b/src/tree/registries/azure/AzureTaskRunTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import * as dayjs from 'dayjs';
 import * as relativeTime from 'dayjs/plugin/relativeTime';
 import { ThemeColor, ThemeIcon } from "vscode";

--- a/src/tree/registries/azure/AzureTaskTreeItem.ts
+++ b/src/tree/registries/azure/AzureTaskTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import { ThemeIcon } from "vscode";
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext } from "vscode-azureextensionui";
 import { localize } from '../../../localize';

--- a/src/tree/registries/azure/AzureTasksTreeItem.ts
+++ b/src/tree/registries/azure/AzureTasksTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementModels as AcrModels } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import { ThemeIcon } from "vscode";
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
 import { localize } from '../../../localize';

--- a/src/tree/registries/azure/SubscriptionTreeItem.ts
+++ b/src/tree/registries/azure/SubscriptionTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerRegistryManagementClient, ContainerRegistryManagementModels as AcrModels } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementClient, ContainerRegistryManagementModels as AcrModels } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
 import { window } from 'vscode';
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, createAzureClient, IActionContext, ICreateChildImplContext, ISubscriptionContext, LocationListStep, ResourceGroupListStep, SubscriptionTreeItemBase } from "vscode-azureextensionui";
 import { localize } from '../../../localize';

--- a/src/tree/registries/azure/createWizard/AzureRegistryNameStep.ts
+++ b/src/tree/registries/azure/createWizard/AzureRegistryNameStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerRegistryManagementClient } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementClient } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
 import { AzureNameStep, createAzureClient, ResourceGroupListStep, resourceGroupNamingRules } from 'vscode-azureextensionui';
 import { localize } from '../../../../localize';
 import { IAzureRegistryWizardContext } from './IAzureRegistryWizardContext';

--- a/src/tree/registries/azure/createWizard/AzureRegistrySkuStep.ts
+++ b/src/tree/registries/azure/createWizard/AzureRegistrySkuStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerRegistryManagementModels as AcrModels } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementModels as AcrModels } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
 import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { localize } from '../../../../localize';
 import { IAzureRegistryWizardContext } from './IAzureRegistryWizardContext';

--- a/src/tree/registries/azure/createWizard/IAzureRegistryWizardContext.ts
+++ b/src/tree/registries/azure/createWizard/IAzureRegistryWizardContext.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerRegistryManagementModels as AcrModels } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementModels as AcrModels } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
 import { IResourceGroupWizardContext } from 'vscode-azureextensionui';
 
 export interface IAzureRegistryWizardContext extends IResourceGroupWizardContext {

--- a/src/utils/getHandlebarsWithHelpers.ts
+++ b/src/utils/getHandlebarsWithHelpers.ts
@@ -5,14 +5,15 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
+import type * as Handlebars from 'handlebars'; // These are only dev-time imports so don't need to be lazy
 import { ScaffoldingWizardContext } from '../scaffolding/wizard/ScaffoldingWizardContext';
 import { DockerExtensionKind, getVSCodeRemoteInfo } from './getVSCodeRemoteInfo';
 import { isWindows } from './osUtils';
 import { pathNormalize } from './pathNormalize';
 import { PlatformOS } from './platform';
 
-let handlebars: typeof import('handlebars') | undefined;
-export async function getHandlebarsWithHelpers(): Promise<typeof import('handlebars')> {
+let handlebars: typeof Handlebars | undefined;
+export async function getHandlebarsWithHelpers(): Promise<typeof Handlebars> {
     if (!handlebars) {
         handlebars = await import('handlebars');
 

--- a/src/utils/quickPickFile.ts
+++ b/src/utils/quickPickFile.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from "path";
-import vscode = require('vscode');
+import * as vscode from 'vscode';
 import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
 import { COMPOSE_FILE_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, DOCKERFILE_GLOB_PATTERN, FILE_SEARCH_MAX_RESULT, FSPROJ_GLOB_PATTERN, YAML_GLOB_PATTERN } from "../constants";
 import { localize } from '../localize';

--- a/src/utils/suggestSupportHelper.ts
+++ b/src/utils/suggestSupportHelper.ts
@@ -5,13 +5,13 @@
 
 'use strict';
 
-import vscode = require('vscode');
-import hub = require('../dockerHubSearch');
+import * as vscode from 'vscode';
+import { searchImagesInRegistryHub, tagsForImage } from '../dockerHubSearch';
 
 export class SuggestSupportHelper {
     /* eslint-disable-next-line @typescript-eslint/promise-function-async */ // Grandfathered in
     public suggestImages(word: string): Promise<vscode.CompletionItem[]> {
-        return hub.searchImagesInRegistryHub(word, true).then((results) => {
+        return searchImagesInRegistryHub(word, true).then((results) => {
             return results.map((image) => {
                 let stars = '';
                 if (image.star_count > 0) {
@@ -21,7 +21,7 @@ export class SuggestSupportHelper {
                 return {
                     label: image.name,
                     kind: vscode.CompletionItemKind.Value,
-                    detail: hub.tagsForImage(image) + stars,
+                    detail: tagsForImage(image) + stars,
                     insertText: image.name,
                     documentation: image.description,
                 };


### PR DESCRIPTION
Fixes #3319. Using `import type` will prevent these dev-time imports from accidentally becoming runtime imports. Also turns some `require`s into `import`s.