### PR TITLE
Match shell terminal name and make localizable

### DIFF
--- a/src/commands/containers/attachShellContainer.ts
+++ b/src/commands/containers/attachShellContainer.ts
@@ -63,5 +63,7 @@ export async function attachShellContainer(context: IActionContext, node?: Conta
         shellCommand
     );
 
-    await executeAsTask(context, terminalCommand, `Shell: ${node.containerName}`, { addDockerEnv: true, alwaysRunNew: true, focus: true });
+    const terminalTitle = localize('vscode-docker.commands.containers.attachShellContainer.terminalTitle', 'Shell: {0}', node.containerName);
+
+    await executeAsTask(context, terminalCommand, terminalTitle, { addDockerEnv: true, alwaysRunNew: true, focus: true });
 }

--- a/src/commands/containers/viewContainerLogs.ts
+++ b/src/commands/containers/viewContainerLogs.ts
@@ -26,5 +26,7 @@ export async function viewContainerLogs(context: IActionContext, node?: Containe
         node.containerId
     );
 
-    await executeAsTask(context, terminalCommand, node.fullTag, { addDockerEnv: true });
+    const terminalTitle = localize('vscode-docker.commands.containers.viewLogs.terminalTitle', 'Logs: {0}', node.containerName);
+
+    await executeAsTask(context, terminalCommand, terminalTitle, { addDockerEnv: true });
 }


### PR DESCRIPTION
Fixes #3340, standardizing on "Action: container_name". Also makes both localizable; they weren't before.

Here's how it looks now:
![image](https://user-images.githubusercontent.com/36966225/144249851-39641102-08c1-42a7-a97d-2c14f4880d66.png)