### PR TITLE
Use `dockerExePath()` for tasks and some others

### DIFF
--- a/resources/python/launcher.py
+++ b/resources/python/launcher.py
@@ -4,9 +4,9 @@
 # This acts as a simple launcher for debugpy that only redirects the args to the actual launcher inside the container
 import os, sys
 
-# Container id is the last arg
-containerId = sys.argv[-1]
-args = sys.argv[1:-1]
+dockerExePath = sys.argv[-2] # Docker EXE path is the second-to-last arg
+containerId = sys.argv[-1] # Container id is the last arg
+args = sys.argv[1:-2] # The remaining args will be given to the launcher
 
 # If the adapterHost is only a port number, then append the default DNS name 'host.docker.internal'
 adapterHost = args[0]
@@ -14,7 +14,7 @@ adapterHost = args[0]
 if adapterHost.isnumeric():
     args[0] = 'host.docker.internal:' + adapterHost
 
-dockerExecArgs = ['docker', 'exec', '-d', containerId, 'python3', '/debugpy/launcher'] + args
+dockerExecArgs = [dockerExePath, 'exec', '-d', containerId, 'python3', '/debugpy/launcher'] + args
 
 command = ' '.join(dockerExecArgs)
 

--- a/src/commands/registries/logInToDockerCli.ts
+++ b/src/commands/registries/logInToDockerCli.ts
@@ -11,6 +11,7 @@ import { localize } from "../../localize";
 import { registryExpectedContextValues } from '../../tree/registries/registryContextValues';
 import { RegistryTreeItemBase } from '../../tree/registries/RegistryTreeItemBase';
 import { CommandLineBuilder } from '../../utils/commandLineBuilder';
+import { dockerExePath } from '../../utils/dockerExePathProvider';
 import { execAsync } from '../../utils/spawnAsync';
 
 export async function logInToDockerCli(context: IActionContext, node?: RegistryTreeItemBase): Promise<void> {
@@ -39,7 +40,7 @@ export async function logInToDockerCli(context: IActionContext, node?: RegistryT
         };
 
         await vscode.window.withProgress(progressOptions, async () => {
-            let command = CommandLineBuilder.create('docker', 'login');
+            let command = CommandLineBuilder.create(dockerExePath(context), 'login');
 
             if (creds.registryPath) {
                 command = command.withQuotedArg(creds.registryPath);

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -13,6 +13,7 @@ import { localize } from '../../localize';
 import { NetCoreTaskHelper, NetCoreTaskOptions } from '../../tasks/netcore/NetCoreTaskHelper';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { CommandLineBuilder } from '../../utils/commandLineBuilder';
+import { dockerExePath } from '../../utils/dockerExePathProvider';
 import { getNetCoreProjectInfo } from '../../utils/netCoreUtils';
 import { getDockerOSType, isArm64Mac } from '../../utils/osUtils';
 import { pathNormalize } from '../../utils/pathNormalize';
@@ -119,7 +120,7 @@ export class NetCoreDebugHelper implements DebugHelper {
                 removeContainerAfterDebug: debugConfiguration.removeContainerAfterDebug
             },
             pipeTransport: {
-                pipeProgram: 'docker',
+                pipeProgram: dockerExePath(context.actionContext),
                 /* eslint-disable no-template-curly-in-string */
                 pipeArgs: ['exec', '-i', containerName, '${debuggerCommand}'],
                 pipeCwd: '${workspaceFolder}',
@@ -164,7 +165,7 @@ export class NetCoreDebugHelper implements DebugHelper {
             // and processName will be undefined.
             processName: debugConfiguration.processId ? undefined : debugConfiguration.processName || 'dotnet',
             pipeTransport: {
-                pipeProgram: 'docker',
+                pipeProgram: dockerExePath(context.actionContext),
                 pipeArgs: ['exec', '-i', containerName],
                 // eslint-disable-next-line no-template-curly-in-string
                 pipeCwd: '${workspaceFolder}',
@@ -296,7 +297,7 @@ export class NetCoreDebugHelper implements DebugHelper {
             title: localize('vscode-docker.debug.netcore.copyDebugger', 'Copying the .NET Core debugger to the container ({0} --> {1})...', vsDbgInstallBasePath, containerDebuggerDirectory),
         }, async () => {
             const command = CommandLineBuilder
-                .create('docker', 'cp')
+                .create(dockerExePath(context), 'cp')
                 .withQuotedArg(vsDbgInstallBasePath)
                 .withQuotedArg(containerDebuggerPath)
                 .build();
@@ -306,7 +307,7 @@ export class NetCoreDebugHelper implements DebugHelper {
 
     private async isDebuggerInstalled(containerName: string, debuggerPath: string, containerOS: DockerOSType): Promise<boolean> {
         const command = CommandLineBuilder
-            .create('docker', 'exec', '-i')
+            .create(dockerExePath(), 'exec', '-i')
             .withQuotedArg(containerName)
             .withArg(containerOS === 'windows' ? 'cmd /C' : '/bin/sh -c')
             .withQuotedArg(containerOS === 'windows' ? `IF EXIST "${debuggerPath}" (echo true) else (echo false)` : `if [ -f ${debuggerPath} ]; then echo true; fi;`)

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { ext } from '../../extensionVariables';
 import { PythonExtensionHelper } from '../../tasks/python/PythonExtensionHelper';
 import { PythonRunTaskDefinition } from '../../tasks/python/PythonTaskHelper';
+import { dockerExePath } from '../../utils/dockerExePathProvider';
 import { getVSCodeRemoteInfo, RemoteKind } from '../../utils/getVSCodeRemoteInfo';
 import { isLinux } from '../../utils/osUtils';
 import { PythonProjectType } from '../../utils/pythonUtils';
@@ -79,7 +80,7 @@ export class PythonDebugHelper implements DebugHelper {
                 },
                 true);
 
-        const args = [...debugConfiguration.python.args || pythonRunTaskOptions.args || [], containerName];
+        const args = [...(debugConfiguration.python.args || pythonRunTaskOptions.args || []), dockerExePath(context.actionContext), containerName];
         const launcherPath = path.join(ext.context.asAbsolutePath('resources'), 'python', 'launcher.py');
 
         return {

--- a/src/docker/Contexts.ts
+++ b/src/docker/Contexts.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ext } from '../extensionVariables';
+import { dockerExePath } from '../utils/dockerExePathProvider';
 import { DockerObject } from './Common';
 
 export type ContextType = 'aci' | 'moby';
@@ -35,7 +36,7 @@ export function isNewContextType(contextType: ContextType): boolean {
 }
 
 export async function getComposeCliCommand(): Promise<string> {
-    return isNewContextType(await ext.dockerContextManager.getCurrentContextType()) ? 'docker compose' : 'docker-compose';
+    return isNewContextType(await ext.dockerContextManager.getCurrentContextType()) ? `${dockerExePath()} compose` : 'docker-compose';
 }
 
 // This method is needed because in certain scenarios--e.g. command customization--the compose command is defined by the user

--- a/src/docker/DockerodeApiClient/DockerodeApiClient.ts
+++ b/src/docker/DockerodeApiClient/DockerodeApiClient.ts
@@ -12,6 +12,7 @@ import { IActionContext, parseError } from 'vscode-azureextensionui';
 import { localize } from '../../localize';
 import { addDockerSettingsToEnv } from '../../utils/addDockerSettingsToEnv';
 import { cloneObject } from '../../utils/cloneObject';
+import { dockerExePath } from '../../utils/dockerExePathProvider';
 import { isWindows } from '../../utils/osUtils';
 import { bufferToString, execStreamAsync } from '../../utils/spawnAsync';
 import { DockerInfo, PruneResult } from '../Common';
@@ -75,7 +76,7 @@ export class DockerodeApiClient extends ContextChangeCancelClient implements Doc
         const commandProvider = Array.isArray(command) ? () => command : command;
 
         if (isWindows()) {
-            let dockerCommand = 'docker exec ';
+            let dockerCommand = `${dockerExePath(context)} exec `;
 
             if (options?.user) {
                 dockerCommand += `--user "${options.user}" `;

--- a/src/tasks/DockerBuildTaskProvider.ts
+++ b/src/tasks/DockerBuildTaskProvider.ts
@@ -10,6 +10,7 @@ import { DockerPlatform } from '../debugging/DockerPlatformHelper';
 import { localize } from '../localize';
 import { cloneObject } from '../utils/cloneObject';
 import { CommandLineBuilder } from '../utils/commandLineBuilder';
+import { dockerExePath } from '../utils/dockerExePathProvider';
 import { resolveVariables } from '../utils/resolveVariables';
 import { DockerBuildOptions } from './DockerBuildTaskDefinitionBase';
 import { DockerTaskProvider } from './DockerTaskProvider';
@@ -90,7 +91,7 @@ export class DockerBuildTaskProvider extends DockerTaskProvider {
 
     private async resolveCommandLine(options: DockerBuildOptions): Promise<CommandLineBuilder> {
         return CommandLineBuilder
-            .create('docker', 'build', '--rm')
+            .create(dockerExePath(), 'build', '--rm')
             .withFlagArg('--pull', options.pull)
             .withNamedArg('-f', options.dockerfile)
             .withKeyValueArgs('--build-arg', options.buildArgs)

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -8,6 +8,7 @@ import { DockerPlatform } from '../debugging/DockerPlatformHelper';
 import { localize } from '../localize';
 import { cloneObject } from '../utils/cloneObject';
 import { CommandLineBuilder } from '../utils/commandLineBuilder';
+import { dockerExePath } from '../utils/dockerExePathProvider';
 import { DockerRunOptions } from './DockerRunTaskDefinitionBase';
 import { DockerTaskProvider } from './DockerTaskProvider';
 import { NetCoreRunTaskDefinition } from './netcore/NetCoreTaskHelper';
@@ -82,7 +83,7 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
 
     private async resolveCommandLine(runOptions: DockerRunOptions): Promise<CommandLineBuilder> {
         return CommandLineBuilder
-            .create('docker', 'run', '-dt')
+            .create(dockerExePath(), 'run', '-dt')
             .withFlagArg('-P', runOptions.portsPublishAll || (runOptions.portsPublishAll === undefined && (runOptions.ports === undefined || runOptions.ports.length < 1)))
             .withNamedArg('--name', runOptions.containerName)
             .withNamedArg('--network', runOptions.network)


### PR DESCRIPTION
Fixes #3281. Scenarios I've tested:

- [x] Build tasks: https://github.com/microsoft/vscode-docker/blob/main/src/tasks/DockerBuildTaskProvider.ts#L93
- [x] Run tasks: https://github.com/microsoft/vscode-docker/blob/main/src/tasks/DockerRunTaskProvider.ts#L85
- [x] New compose CLI under an ACI context: https://github.com/microsoft/vscode-docker/blob/main/src/docker/Contexts.ts#L38
- [x] Login to Docker registries: https://github.com/microsoft/vscode-docker/blob/main/src/commands/registries/logInToDockerCli.ts#L42
- [x] .NET debug launch: https://github.com/microsoft/vscode-docker/blob/main/src/debugging/netcore/NetCoreDebugHelper.ts#L122
- [x] .NET attach launch: https://github.com/microsoft/vscode-docker/blob/main/src/debugging/netcore/NetCoreDebugHelper.ts#L167, https://github.com/microsoft/vscode-docker/blob/main/src/debugging/netcore/NetCoreDebugHelper.ts#L299, https://github.com/microsoft/vscode-docker/blob/main/src/debugging/netcore/NetCoreDebugHelper.ts#L309
- [x] Python debugging: https://github.com/microsoft/vscode-docker/blob/main/resources/python/launcher.py#L17, https://github.com/microsoft/vscode-docker/blob/main/src/debugging/python/PythonDebugHelper.ts#L82
- [x] Windows container files: https://github.com/microsoft/vscode-docker/blob/main/src/docker/DockerodeApiClient/DockerodeApiClient.ts#L78