### PR TITLE
Upgrade Dockerfile language server to 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@grpc/grpc-js": "^1.2.12",
                 "@microsoft/compose-language-service": "^0.0.4-alpha",
                 "dayjs": "^1.10.4",
-                "dockerfile-language-server-nodejs": "^0.7.2",
+                "dockerfile-language-server-nodejs": "^0.7.3",
                 "dockerode": "^3.2.1",
                 "fs-extra": "^10.0.0",
                 "glob": "^7.1.6",
@@ -2139,9 +2139,9 @@
             }
         },
         "node_modules/dockerfile-ast": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.4.tgz",
-            "integrity": "sha512-QjNH/VnTrWjlDekJtk5GBKbypcFUBdGexd+eOAeivwwSWky6bIJps1cw/qw1jU5K3TDMgtufAHaBh7OV5X/EqA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.4.1.tgz",
+            "integrity": "sha512-qM5/m+Ez4GOM3ILkG13+cPxwgIcuA/z3LmEPZf4VJ82f7T1DuVbz7ctw4IzWdbiecuXcs+C4fFVbo5priGnIIQ==",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
@@ -2151,12 +2151,12 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.2.tgz",
-            "integrity": "sha512-TrUvQ+Mq/R4uODRPHNsDKwFXucGsJBm4cObKENYtwNkXCeT7QmrNBc9d8lQQM0B+Gsc7mDASWKn1Jn+1FwVtIw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.3.tgz",
+            "integrity": "sha512-+fY8JCuoL3T698EZKd78SF1RrGBGYZVRzRDLrWHaum3qx5gW8uMDX41rtaehX7/ZNH/WSuwyFtWh3/JWmjEAKw==",
             "dependencies": {
-                "dockerfile-language-service": "0.7.3",
-                "dockerfile-utils": "0.9.2",
+                "dockerfile-language-service": "0.7.4",
+                "dockerfile-utils": "0.9.3",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
             "bin": {
@@ -2200,12 +2200,12 @@
             "integrity": "sha512-MraVkZDhfqa3ftnKW9rEDeqsV+ji8OrtEjx6mVjzVGm5U2XXT+mdqDWyQ+y0Gvb2/aa2oJJQyTAaDmRTUKiUbg=="
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.3.tgz",
-            "integrity": "sha512-zTDkmeBmafVGDx/34gWAst8tAysx2bUWcSnw+f5SI+b3SzpJNUzoWpgm7xtoNwHoWRuB7xHdiGmvkbrRfA2o8Q==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.4.tgz",
+            "integrity": "sha512-SxKqTMQshN6xr20qTeurUydI432+ZUrkfhMurknjPvhdTc5oheH+WeN1cqKKQrILlcVq7agbFlXH51sdempuGQ==",
             "dependencies": {
-                "dockerfile-ast": "0.3.4",
-                "dockerfile-utils": "0.9.2",
+                "dockerfile-ast": "0.4.1",
+                "dockerfile-utils": "0.9.3",
                 "vscode-languageserver-types": "3.17.0-next.3"
             },
             "engines": {
@@ -2213,11 +2213,11 @@
             }
         },
         "node_modules/dockerfile-utils": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.2.tgz",
-            "integrity": "sha512-QgcYXSZFBBbPuiQskEAVnW3qSShSCSisLNt2wQZXupBQ/x1lFIyvVfWXk4OQqWoatHyAfUBiXDNx9eRXkmSALQ==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.3.tgz",
+            "integrity": "sha512-tMPdbywzglQh7JieKL1vn7HyJoYwk8J8AyfyLaqkLJ5tRA/TSrOVK6R40C3bwEceYg875crMo8yHSkz09Fc6VA==",
             "dependencies": {
-                "dockerfile-ast": "0.3.4",
+                "dockerfile-ast": "0.4.1",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
             },
@@ -8566,21 +8566,21 @@
             }
         },
         "dockerfile-ast": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.3.4.tgz",
-            "integrity": "sha512-QjNH/VnTrWjlDekJtk5GBKbypcFUBdGexd+eOAeivwwSWky6bIJps1cw/qw1jU5K3TDMgtufAHaBh7OV5X/EqA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.4.1.tgz",
+            "integrity": "sha512-qM5/m+Ez4GOM3ILkG13+cPxwgIcuA/z3LmEPZf4VJ82f7T1DuVbz7ctw4IzWdbiecuXcs+C4fFVbo5priGnIIQ==",
             "requires": {
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.2.tgz",
-            "integrity": "sha512-TrUvQ+Mq/R4uODRPHNsDKwFXucGsJBm4cObKENYtwNkXCeT7QmrNBc9d8lQQM0B+Gsc7mDASWKn1Jn+1FwVtIw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.3.tgz",
+            "integrity": "sha512-+fY8JCuoL3T698EZKd78SF1RrGBGYZVRzRDLrWHaum3qx5gW8uMDX41rtaehX7/ZNH/WSuwyFtWh3/JWmjEAKw==",
             "requires": {
-                "dockerfile-language-service": "0.7.3",
-                "dockerfile-utils": "0.9.2",
+                "dockerfile-language-service": "0.7.4",
+                "dockerfile-utils": "0.9.3",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
             "dependencies": {
@@ -8614,21 +8614,21 @@
             }
         },
         "dockerfile-language-service": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.3.tgz",
-            "integrity": "sha512-zTDkmeBmafVGDx/34gWAst8tAysx2bUWcSnw+f5SI+b3SzpJNUzoWpgm7xtoNwHoWRuB7xHdiGmvkbrRfA2o8Q==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.4.tgz",
+            "integrity": "sha512-SxKqTMQshN6xr20qTeurUydI432+ZUrkfhMurknjPvhdTc5oheH+WeN1cqKKQrILlcVq7agbFlXH51sdempuGQ==",
             "requires": {
-                "dockerfile-ast": "0.3.4",
-                "dockerfile-utils": "0.9.2",
+                "dockerfile-ast": "0.4.1",
+                "dockerfile-utils": "0.9.3",
                 "vscode-languageserver-types": "3.17.0-next.3"
             }
         },
         "dockerfile-utils": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.2.tgz",
-            "integrity": "sha512-QgcYXSZFBBbPuiQskEAVnW3qSShSCSisLNt2wQZXupBQ/x1lFIyvVfWXk4OQqWoatHyAfUBiXDNx9eRXkmSALQ==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.3.tgz",
+            "integrity": "sha512-tMPdbywzglQh7JieKL1vn7HyJoYwk8J8AyfyLaqkLJ5tRA/TSrOVK6R40C3bwEceYg875crMo8yHSkz09Fc6VA==",
             "requires": {
-                "dockerfile-ast": "0.3.4",
+                "dockerfile-ast": "0.4.1",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
             }

--- a/package.json
+++ b/package.json
@@ -3077,7 +3077,7 @@
         "@grpc/grpc-js": "^1.2.12",
         "@microsoft/compose-language-service": "^0.0.4-alpha",
         "dayjs": "^1.10.4",
-        "dockerfile-language-server-nodejs": "^0.7.2",
+        "dockerfile-language-server-nodejs": "^0.7.3",
         "dockerode": "^3.2.1",
         "fs-extra": "^10.0.0",
         "glob": "^7.1.6",


### PR DESCRIPTION
This update to the Dockerfile language server fixes three issues that have been raised by the community:
- the formatter will now ignore heredocs (https://github.com/microsoft/vscode-docker/issues/3327)
- the server will no longer enter an infinite loop when using Intellisense in `ADD` or `COPY` instructions (https://github.com/microsoft/vscode-docker/issues/3347)
- errors will no longer be thrown when using Intellisense after a `--chown` or `--from` flag in `ADD` or `COPY` instructions (https://github.com/microsoft/vscode-docker/issues/3349)

```Dockerfile
FROM alpine as alpine
# invoke Intellisense at the end of COPY, the CPU usage of the
# Dockerfile language server should not jump to 99% (issue #3347)
COPY . . 
```
```Dockerfile
FROM node:alpine
# invoke Intellisense at the end of this ADD instruction,
# there should be no more errors (issue #3349)
ADD --chown=user:group
# invoke Intellisense at the end of this COPY instruction,
# there should be no more errors (issue #3349)
COPY --chown=user:group

# issue #3327
# 1. format the document, these three lines should not change
# 2. highlight and select the three lines and use format selection,
# the three lines should not change
# 3. add a backslash (\) after "cat", the EOT line should not move
RUN <<EOT
    cat
EOT
```