### PR TITLE
Use `python:3.8-slim` and bump some `requirements.txt` versions

### DIFF
--- a/resources/templates/python/Dockerfile.template
+++ b/resources/templates/python/Dockerfile.template
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:slim
+FROM python:3.8-slim
 
 {{#if (isRootPort ports)}}
 # Warning: A port below 1024 has been exposed. This requires the image to run as a root user which is not a best practice.

--- a/resources/templates/python/requirements.txt.template
+++ b/resources/templates/python/requirements.txt.template
@@ -1,14 +1,14 @@
 # To ensure app dependencies are ported from your virtual environment/host machine into your container, run 'pip freeze > requirements.txt' in the terminal to overwrite this file
 {{#if (eq platform 'Python: Django')}}
-django==3.1.1
+django==4.0
 {{/if}}
 {{#if (eq platform 'Python: FastAPI')}}
-fastapi[all]==0.63.0
-uvicorn[standard]==0.13.4
+fastapi[all]==0.70.1
+uvicorn[standard]==0.15.0
 {{/if}}
 {{#if (eq platform 'Python: Flask')}}
-flask==1.1.2
+flask==2.0.2
 {{/if}}
 {{#unless (eq platform 'Python: General')}}
-gunicorn==20.0.4
+gunicorn==20.1.0
 {{/unless}}


### PR DESCRIPTION
Fixes #3363. While I was in the area I figured I'd update some of the `requirements.txt` versions as well.

Tested:
- [x] Python: Django
    - [x] Debug (single)
    - [x] Debug (remote attach config) (compose)
    - [x] Run (compose)
- [x] Python: Flask
    - [x] Debug (single)
    - [x] Debug (remote attach config) (compose)
    - [x] Run (compose)
- [x] Python: FastAPI
    - [x] Debug (single)
    - [x] Debug (remote attach config) (compose)
    - [x] Run (compose)
- [x] Python: General
    - [x] Debug (single)
    - [x] Debug (remote attach config) (compose)
    - [x] Run (compose)