### PR TITLE
Adjust "Getting started with Docker" link text

### DIFF
--- a/src/commands/images/buildImage.ts
+++ b/src/commands/images/buildImage.ts
@@ -53,7 +53,7 @@ export async function buildImage(context: IActionContext, dockerFileUri: vscode.
         if (tagRegex.test(terminalCommand)) {
             const absFilePath: string = path.join(rootFolder.uri.fsPath, dockerFileItem.relativeFilePath);
             const dockerFileKey = `buildTag_${absFilePath}`;
-            const prevImageName: string | undefined = ext.context.globalState.get(dockerFileKey);
+            const prevImageName: string | undefined = ext.context.workspaceState.get(dockerFileKey);
 
             // Get imageName based previous entries, else on name of subfolder containing the Dockerfile
             const suggestedImageName = prevImageName || getValidImageNameFromPath(dockerFileItem.absoluteFolderPath, 'latest');
@@ -65,7 +65,7 @@ export async function buildImage(context: IActionContext, dockerFileUri: vscode.
             const imageName: string = await getTagFromUserInput(context, suggestedImageName);
             addImageTaggingTelemetry(context, imageName, '.after');
 
-            await ext.context.globalState.update(dockerFileKey, imageName);
+            await ext.context.workspaceState.update(dockerFileKey, imageName);
             terminalCommand = terminalCommand.replace(tagRegex, imageName);
         }
 

--- a/src/commands/registries/azure/tasks/scheduleRunRequest.ts
+++ b/src/commands/registries/azure/tasks/scheduleRunRequest.ts
@@ -90,7 +90,7 @@ export async function scheduleRunRequest(context: IActionContext, requestType: '
 async function quickPickImageName(context: IActionContext, rootFolder: vscode.WorkspaceFolder, dockerFileItem: Item | undefined): Promise<string> {
     const absFilePath: string = path.join(rootFolder.uri.fsPath, dockerFileItem.relativeFilePath);
     const dockerFileKey = `ACR_buildTag_${absFilePath}`;
-    const prevImageName: string | undefined = ext.context.globalState.get(dockerFileKey);
+    const prevImageName: string | undefined = ext.context.workspaceState.get(dockerFileKey);
     let suggestedImageName: string;
 
     if (!prevImageName) {
@@ -112,7 +112,7 @@ async function quickPickImageName(context: IActionContext, rootFolder: vscode.Wo
     const imageName: string = await getTagFromUserInput(context, suggestedImageName);
     addImageTaggingTelemetry(context, imageName, '.after');
 
-    await ext.context.globalState.update(dockerFileKey, imageName);
+    await ext.context.workspaceState.update(dockerFileKey, imageName);
     return imageName;
 }
 

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ThemeIcon } from "vscode";
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
 import { DockerContainer } from "../../docker/Containers";
 import { ext } from "../../extensionVariables";
 import { localize } from '../../localize';
-import { getThemedIconPath } from "../getThemedIconPath";
 import { getImagePropertyValue } from "../images/ImageProperties";
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { OpenUrlTreeItem } from "../OpenUrlTreeItem";
@@ -117,8 +117,8 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInf
 
     protected getTreeItemForEmptyList(): AzExtTreeItem[] {
         if (this.newContainerUser) {
-            const dockerTutorialTreeItem = new OpenUrlTreeItem(this, localize('vscode-docker.tree.container.gettingStarted', 'Get started with Docker containers...'), 'https://aka.ms/getstartedwithdocker');
-            dockerTutorialTreeItem.iconPath = getThemedIconPath('docker');
+            const dockerTutorialTreeItem = new OpenUrlTreeItem(this, localize('vscode-docker.tree.container.gettingStarted', 'Tutorial: Get started with Docker'), 'https://aka.ms/getstartedwithdocker');
+            dockerTutorialTreeItem.iconPath = new ThemeIcon('link-external');
             return [dockerTutorialTreeItem];
         }
         return super.getTreeItemForEmptyList();


### PR DESCRIPTION
Fixes #3396. Here's the new look:
![image](https://user-images.githubusercontent.com/36966225/150544593-a01935ed-d923-453c-9db5-9cf67e7d614d.png)

Once @ucheNkadiCode approves I'll submit.

This PR also contains some minor unrelated changes to use workspace memento instead of global memento.