### PR TITLE
Upgrade Dockerfile language server to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@grpc/grpc-js": "^1.5.0",
                 "@microsoft/compose-language-service": "^0.0.5-alpha",
                 "dayjs": "^1.10.4",
-                "dockerfile-language-server-nodejs": "^0.7.3",
+                "dockerfile-language-server-nodejs": "^0.8.0",
                 "dockerode": "^3.2.1",
                 "fs-extra": "^10.0.0",
                 "glob": "^7.1.6",
@@ -2260,9 +2260,9 @@
             }
         },
         "node_modules/dockerfile-ast": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.4.1.tgz",
-            "integrity": "sha512-qM5/m+Ez4GOM3ILkG13+cPxwgIcuA/z3LmEPZf4VJ82f7T1DuVbz7ctw4IzWdbiecuXcs+C4fFVbo5priGnIIQ==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.4.2.tgz",
+            "integrity": "sha512-k770mVWaCm3KbyOSPFizP6WB2ucZjfAv8aun4UsKl+IivowK7ItwBixNbziBjN05yNpvCL1/IxBdZiSz6KQIvA==",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
@@ -2272,12 +2272,12 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.3.tgz",
-            "integrity": "sha512-+fY8JCuoL3T698EZKd78SF1RrGBGYZVRzRDLrWHaum3qx5gW8uMDX41rtaehX7/ZNH/WSuwyFtWh3/JWmjEAKw==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.8.0.tgz",
+            "integrity": "sha512-7oxOu3PWDzsTkLbUIm1O61rgdNiM9j9tAt+T0R5m0TFG0NYypYBM77pfzAYmQFpHGHAstCtOaEYzEnp0IkRCnQ==",
             "dependencies": {
-                "dockerfile-language-service": "0.7.4",
-                "dockerfile-utils": "0.9.3",
+                "dockerfile-language-service": "0.8.1",
+                "dockerfile-utils": "0.9.4",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
             "bin": {
@@ -2321,12 +2321,12 @@
             "integrity": "sha512-rHYeCotiabJHgvIYzWjV8g0dHCxyOQtcryTv1Xa1horaQ4jx2V+rjLBstc6zMpCyrnZcjorwEcAvGBDCd6wudw=="
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.4.tgz",
-            "integrity": "sha512-SxKqTMQshN6xr20qTeurUydI432+ZUrkfhMurknjPvhdTc5oheH+WeN1cqKKQrILlcVq7agbFlXH51sdempuGQ==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.8.1.tgz",
+            "integrity": "sha512-bqrZ2FzG45w2Mzmak3oC5ecIl/edStygSFQ0i/8WGabb5k/w6zWwqDaHVgT8dkfogm+swHMQUu4WGTvVu1qLCA==",
             "dependencies": {
-                "dockerfile-ast": "0.4.1",
-                "dockerfile-utils": "0.9.3",
+                "dockerfile-ast": "0.4.2",
+                "dockerfile-utils": "0.9.4",
                 "vscode-languageserver-types": "3.17.0-next.3"
             },
             "engines": {
@@ -2334,11 +2334,11 @@
             }
         },
         "node_modules/dockerfile-utils": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.3.tgz",
-            "integrity": "sha512-tMPdbywzglQh7JieKL1vn7HyJoYwk8J8AyfyLaqkLJ5tRA/TSrOVK6R40C3bwEceYg875crMo8yHSkz09Fc6VA==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.4.tgz",
+            "integrity": "sha512-lqmCxVhaUyCUIz9dhzYVrHZLJG5hzdcwd29JcA/0o7xIx2VwvIctUE6SpK8ugLTNuwMx/oKU2YVLaRIX/CmQPg==",
             "dependencies": {
-                "dockerfile-ast": "0.4.1",
+                "dockerfile-ast": "0.4.2",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
             },
@@ -8841,21 +8841,21 @@
             }
         },
         "dockerfile-ast": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.4.1.tgz",
-            "integrity": "sha512-qM5/m+Ez4GOM3ILkG13+cPxwgIcuA/z3LmEPZf4VJ82f7T1DuVbz7ctw4IzWdbiecuXcs+C4fFVbo5priGnIIQ==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.4.2.tgz",
+            "integrity": "sha512-k770mVWaCm3KbyOSPFizP6WB2ucZjfAv8aun4UsKl+IivowK7ItwBixNbziBjN05yNpvCL1/IxBdZiSz6KQIvA==",
             "requires": {
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.7.3.tgz",
-            "integrity": "sha512-+fY8JCuoL3T698EZKd78SF1RrGBGYZVRzRDLrWHaum3qx5gW8uMDX41rtaehX7/ZNH/WSuwyFtWh3/JWmjEAKw==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.8.0.tgz",
+            "integrity": "sha512-7oxOu3PWDzsTkLbUIm1O61rgdNiM9j9tAt+T0R5m0TFG0NYypYBM77pfzAYmQFpHGHAstCtOaEYzEnp0IkRCnQ==",
             "requires": {
-                "dockerfile-language-service": "0.7.4",
-                "dockerfile-utils": "0.9.3",
+                "dockerfile-language-service": "0.8.1",
+                "dockerfile-utils": "0.9.4",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
             "dependencies": {
@@ -8889,21 +8889,21 @@
             }
         },
         "dockerfile-language-service": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.7.4.tgz",
-            "integrity": "sha512-SxKqTMQshN6xr20qTeurUydI432+ZUrkfhMurknjPvhdTc5oheH+WeN1cqKKQrILlcVq7agbFlXH51sdempuGQ==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.8.1.tgz",
+            "integrity": "sha512-bqrZ2FzG45w2Mzmak3oC5ecIl/edStygSFQ0i/8WGabb5k/w6zWwqDaHVgT8dkfogm+swHMQUu4WGTvVu1qLCA==",
             "requires": {
-                "dockerfile-ast": "0.4.1",
-                "dockerfile-utils": "0.9.3",
+                "dockerfile-ast": "0.4.2",
+                "dockerfile-utils": "0.9.4",
                 "vscode-languageserver-types": "3.17.0-next.3"
             }
         },
         "dockerfile-utils": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.3.tgz",
-            "integrity": "sha512-tMPdbywzglQh7JieKL1vn7HyJoYwk8J8AyfyLaqkLJ5tRA/TSrOVK6R40C3bwEceYg875crMo8yHSkz09Fc6VA==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.4.tgz",
+            "integrity": "sha512-lqmCxVhaUyCUIz9dhzYVrHZLJG5hzdcwd29JcA/0o7xIx2VwvIctUE6SpK8ugLTNuwMx/oKU2YVLaRIX/CmQPg==",
             "requires": {
-                "dockerfile-ast": "0.4.1",
+                "dockerfile-ast": "0.4.2",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
             }

--- a/package.json
+++ b/package.json
@@ -3079,7 +3079,7 @@
         "@grpc/grpc-js": "^1.5.0",
         "@microsoft/compose-language-service": "^0.0.5-alpha",
         "dayjs": "^1.10.4",
-        "dockerfile-language-server-nodejs": "^0.7.3",
+        "dockerfile-language-server-nodejs": "^0.8.0",
         "dockerode": "^3.2.1",
         "fs-extra": "^10.0.0",
         "glob": "^7.1.6",


### PR DESCRIPTION
This new release improves the semantic highlighting support for variables in addition to correcting a false positive linting error about empty continuation lines on here-documents. Please test these two new changes with the Dockerfile below.

```Dockerfile
FROM node:alpine
# the variables should now
# have symbols in a
# different color
RUN echo ${variable:+word}
RUN echo ${variable:-word}
# there should not be an
# empty continuation line
# error here
RUN <<EOT
    abc

    def
EOT
```

Screenshot taken with the "Tomorrow Night Blue" theme:
![image](https://user-images.githubusercontent.com/15629116/150659857-07683480-4b19-4d7a-bb9e-718afdd02034.png)