### PR TITLE
Infer more default args, show as required correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
                 "ts-loader": "^9.2.3",
                 "typescript": "^4.5.4",
                 "umd-compat-loader": "^2.1.2",
-                "vsce": "^2.5.1",
+                "vsce": "^2.6.4",
                 "webpack": "^5.65.0",
                 "webpack-bundle-analyzer": "^4.4.1",
                 "webpack-cli": "^4.6.0"
@@ -468,9 +468,9 @@
             }
         },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.5.1.tgz",
-            "integrity": "sha512-ItOqQ4ff7JrR9W6KDQm+LdsVjuZtV7Qq64Oy3Hjx8ZPBDDwBx7rD8hOL0Vnde0RbnsqLG86WOgF+tQDzf/nSzQ==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.5.3.tgz",
+            "integrity": "sha512-q0xgaZ3ymUM+ZOhe1hdocVSdKHCnJ6llLSXcP+MqMXMyYPUZ3mzQOCxZ3Zkg+QZ7sZ950sn7hvueQrIJZumPZg==",
             "dependencies": {
                 "@grpc/proto-loader": "^0.6.4",
                 "@types/node": ">=12.12.47"
@@ -657,9 +657,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.2.2.tgz",
-            "integrity": "sha512-nQxgB8/Sg+QKhnV8e0WzPpxjIGT3tuJDDzybkDi8ItE/IgTlHo07U0shaIjzhcvQxlq9SDRE42lsJ23uvEgJ2A==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+            "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -719,15 +719,15 @@
             "dev": true
         },
         "node_modules/@types/mocha": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-            "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
+            "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "14.18.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.7.tgz",
-            "integrity": "sha512-UpLEO1iBG7esNPusSAjoZhWFK5Mfd8QfwWhHRrg5io13POn/stsBgTCba9suQaFflNA4tc0+6AFM3R6BZNng6A=="
+            "version": "14.18.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz",
+            "integrity": "sha512-j11XSuRuAlft6vLDEX4RvhqC0KxNxx6QIyMXNb0vHHSNPXTPeiy3algESWmOOIzEtiEL0qiowPU3ewW9hHVa7Q=="
         },
         "node_modules/@types/node-fetch": {
             "version": "2.5.12",
@@ -758,9 +758,9 @@
             "dev": true
         },
         "node_modules/@types/ssh2": {
-            "version": "0.5.50",
-            "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.50.tgz",
-            "integrity": "sha512-Eu/rzX4L+GhWIKEFQbaeWKECdy8VRdIYOqjMlFp+v4v7tBhvcl30m34BZzVALn/dNXvcB6dmcMtspIW7iPOlPg==",
+            "version": "0.5.51",
+            "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.51.tgz",
+            "integrity": "sha512-aIq7ownezauW/+VWYaeXwd5J1Evnn4EXyeKi7bT3H6ZLBLoqsmhdvkHYPLpnZPM6unKKKsxTHIyQAVOZnPiJBw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -815,14 +815,14 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
-            "integrity": "sha512-XXVKnMsq2fuu9K2KsIxPUGqb6xAImz8MEChClbXmE3VbveFtBUU5bzM6IPVWqzyADIgdkS2Ws/6Xo7W2TeZWjQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
+            "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.10.0",
-                "@typescript-eslint/type-utils": "5.10.0",
-                "@typescript-eslint/utils": "5.10.0",
+                "@typescript-eslint/scope-manager": "5.10.1",
+                "@typescript-eslint/type-utils": "5.10.1",
+                "@typescript-eslint/utils": "5.10.1",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
@@ -848,14 +848,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.0.tgz",
-            "integrity": "sha512-pJB2CCeHWtwOAeIxv8CHVGJhI5FNyJAIpx5Pt72YkK3QfEzt6qAlXZuyaBmyfOdM62qU0rbxJzNToPTVeJGrQw==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
+            "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.10.0",
-                "@typescript-eslint/types": "5.10.0",
-                "@typescript-eslint/typescript-estree": "5.10.0",
+                "@typescript-eslint/scope-manager": "5.10.1",
+                "@typescript-eslint/types": "5.10.1",
+                "@typescript-eslint/typescript-estree": "5.10.1",
                 "debug": "^4.3.2"
             },
             "engines": {
@@ -875,13 +875,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.0.tgz",
-            "integrity": "sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
+            "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.10.0",
-                "@typescript-eslint/visitor-keys": "5.10.0"
+                "@typescript-eslint/types": "5.10.1",
+                "@typescript-eslint/visitor-keys": "5.10.1"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -892,12 +892,12 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.0.tgz",
-            "integrity": "sha512-TzlyTmufJO5V886N+hTJBGIfnjQDQ32rJYxPaeiyWKdjsv2Ld5l8cbS7pxim4DeNs62fKzRSt8Q14Evs4JnZyQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
+            "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/utils": "5.10.0",
+                "@typescript-eslint/utils": "5.10.1",
                 "debug": "^4.3.2",
                 "tsutils": "^3.21.0"
             },
@@ -918,9 +918,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.0.tgz",
-            "integrity": "sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
+            "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -931,13 +931,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.0.tgz",
-            "integrity": "sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
+            "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.10.0",
-                "@typescript-eslint/visitor-keys": "5.10.0",
+                "@typescript-eslint/types": "5.10.1",
+                "@typescript-eslint/visitor-keys": "5.10.1",
                 "debug": "^4.3.2",
                 "globby": "^11.0.4",
                 "is-glob": "^4.0.3",
@@ -958,15 +958,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
-            "integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
+            "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
             "dev": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.10.0",
-                "@typescript-eslint/types": "5.10.0",
-                "@typescript-eslint/typescript-estree": "5.10.0",
+                "@typescript-eslint/scope-manager": "5.10.1",
+                "@typescript-eslint/types": "5.10.1",
+                "@typescript-eslint/typescript-estree": "5.10.1",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             },
@@ -982,12 +982,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.0.tgz",
-            "integrity": "sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
+            "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.10.0",
+                "@typescript-eslint/types": "5.10.1",
                 "eslint-visitor-keys": "^3.0.0"
             },
             "engines": {
@@ -1005,9 +1005,9 @@
             "dev": true
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.0.tgz",
-            "integrity": "sha512-nE5ha/V+l4WnS0QS5wJhb2S75Ceamif30UOcURHYw+8FoJJHg2g1xM8/dSpvX2Xk4+04Rbl76/ui/tgI5qia+Q==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.1.tgz",
+            "integrity": "sha512-7G9gFGjJGOJ+hQ1ZgZYEV973pzQBclLZngXOEGMyRyvK4GUkl7XeIOwQN/iMv2ttq7gPUKmIxSKF7YGF5J7DZQ==",
             "dev": true,
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
@@ -1166,9 +1166,9 @@
             }
         },
         "node_modules/@webpack-cli/configtest": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-            "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+            "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
             "dev": true,
             "peerDependencies": {
                 "webpack": "4.x.x || 5.x.x",
@@ -1176,9 +1176,9 @@
             }
         },
         "node_modules/@webpack-cli/info": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-            "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+            "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
             "dev": true,
             "dependencies": {
                 "envinfo": "^7.7.3"
@@ -1188,9 +1188,9 @@
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-            "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+            "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
             "dev": true,
             "peerDependencies": {
                 "webpack-cli": "4.x.x"
@@ -1756,9 +1756,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001300",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-            "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
+            "version": "1.0.30001301",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
+            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -1837,10 +1837,16 @@
             "dev": true
         },
         "node_modules/chokidar": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -1994,9 +2000,9 @@
             "dev": true
         },
         "node_modules/copy-webpack-plugin": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-10.2.0.tgz",
-            "integrity": "sha512-my6iXII95c78w14HzYCNya5TlJYa44lOppAge5GSTMM1SyDxNsVGCJvhP4/ld6snm8lzjn3XOonMZD6s1L86Og==",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-10.2.1.tgz",
+            "integrity": "sha512-nr81NhCAIpAWXGCK5thrKmfCQ6GDY0L5RN0U+BnIn/7Us55+UCex5ANNsNKmIVtDRnk0Ecf+/kzp9SUVrrBMLg==",
             "dev": true,
             "dependencies": {
                 "fast-glob": "^3.2.7",
@@ -2482,9 +2488,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.47",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.47.tgz",
-            "integrity": "sha512-ZHc8i3/cgeCRK/vC7W2htAG6JqUmOUgDNn/f9yY9J8UjfLjwzwOVEt4MWmgJAdvmxyrsR5KIFA/6+kUHGY0eUA==",
+            "version": "1.4.52",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.52.tgz",
+            "integrity": "sha512-JGkh8HEh5PnVrhU4HbpyyO0O791dVY6k7AdqfDeqbcRMeoGxtNHWT77deR2nhvbLe4dKpxjlDEvdEwrvRLGu2Q==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -4065,9 +4071,9 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
             "dev": true,
             "dependencies": {
                 "uc.micro": "^1.0.1"
@@ -4183,14 +4189,14 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-            "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
             "dev": true,
             "dependencies": {
-                "argparse": "^1.0.7",
-                "entities": "~2.0.0",
-                "linkify-it": "^2.0.0",
+                "argparse": "^2.0.1",
+                "entities": "~2.1.0",
+                "linkify-it": "^3.0.1",
                 "mdurl": "^1.0.1",
                 "uc.micro": "^1.0.5"
             },
@@ -4198,20 +4204,14 @@
                 "markdown-it": "bin/markdown-it.js"
             }
         },
-        "node_modules/markdown-it/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
         "node_modules/markdown-it/node_modules/entities": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-            "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
-            "dev": true
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/mdurl": {
             "version": "1.0.1",
@@ -4353,32 +4353,32 @@
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "node_modules/mocha": {
-            "version": "9.1.4",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.4.tgz",
-            "integrity": "sha512-+q2aV5VlJZuLgCWoBvGI5zEwPF9eEI0kr/sAA9Jm4xMND7RfIEyF8JE7C0JIg8WXRG+P1sdIAb5ccoHPlXLzcw==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
+            "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
             "dev": true,
             "dependencies": {
                 "@ungap/promise-all-settled": "1.1.2",
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "chokidar": "3.5.2",
-                "debug": "4.3.2",
+                "chokidar": "3.5.3",
+                "debug": "4.3.3",
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.7",
+                "glob": "7.2.0",
                 "growl": "1.10.5",
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
                 "minimatch": "3.0.4",
                 "ms": "2.1.3",
-                "nanoid": "3.1.25",
+                "nanoid": "3.2.0",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
                 "which": "2.0.2",
-                "workerpool": "6.1.5",
+                "workerpool": "6.2.0",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
@@ -4393,49 +4393,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mochajs"
-            }
-        },
-        "node_modules/mocha/node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/mocha/node_modules/debug/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "node_modules/mocha/node_modules/glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-            "dev": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/mocha/node_modules/ms": {
@@ -4486,9 +4443,9 @@
             "optional": true
         },
         "node_modules/nanoid": {
-            "version": "3.1.25",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-            "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
             "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -5292,12 +5249,12 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-            "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.8.0",
+                "is-core-module": "^2.8.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -5645,12 +5602,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
             "integrity": "sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY="
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
         },
         "node_modules/ssh2": {
             "version": "1.5.0",
@@ -6102,9 +6053,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -6286,9 +6237,9 @@
             "dev": true
         },
         "node_modules/vsce": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.3.tgz",
-            "integrity": "sha512-PKfvAtG9rLT1evHiKOJpBHND1hUHOOf4lL7chZFp0KGu+Bpgcx3g3T5eq0d8Hmzd08zd3KJunsaA3iaNSmTU/A==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.4.tgz",
+            "integrity": "sha512-1Zvg2sJA/wFd5KCEWlfefXqiZm47d4ATeVKS2lvas0Lo2eLhPA5KRwxvpNvxTGUM9t9hYmAB9ZWtKQRFa9Q0hg==",
             "dev": true,
             "dependencies": {
                 "azure-devops-node-api": "^11.0.1",
@@ -6299,7 +6250,7 @@
                 "hosted-git-info": "^4.0.2",
                 "keytar": "^7.7.0",
                 "leven": "^3.1.0",
-                "markdown-it": "^10.0.0",
+                "markdown-it": "^12.3.2",
                 "mime": "^1.3.4",
                 "minimatch": "^3.0.3",
                 "parse-semver": "^1.1.1",
@@ -6463,9 +6414,9 @@
             "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
         },
         "node_modules/vscode-azureextensionui": {
-            "version": "0.49.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.1.tgz",
-            "integrity": "sha512-+DxY6iQrbFhG+Vsz0y16VMrM6bHSlQWUDRquD4sLY0HgeSHoB1E+bQqR7UrQKm8mhInz2XvovzRPW3U6UNgzcw==",
+            "version": "0.49.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.3.tgz",
+            "integrity": "sha512-5A5zXsQ3oNqAYNBQcgmMV4djuFgcZV8t0ii8F9E/+rPbHmNmB5whR0IJPUE9WYMFBv44GKC5MKmJkUzilngD1g==",
             "dependencies": {
                 "@azure/arm-resources": "^4.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
@@ -6519,6 +6470,7 @@
             "version": "0.4.5",
             "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
             "integrity": "sha512-YhPiPcelqM5xyYWmD46jIcsxLYWkPZhAxlBkzqmpa218fMtTT17ERdOZVCXcs1S5AjvDHlq43yCgi8TaVQjjEg==",
+            "deprecated": "This package has been renamed to @vscode/extension-telemetry, please update to the new name",
             "engines": {
                 "vscode": "^1.60.0"
             }
@@ -6614,9 +6566,9 @@
             "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "node_modules/webpack": {
-            "version": "5.66.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.66.0.tgz",
-            "integrity": "sha512-NJNtGT7IKpGzdW7Iwpn/09OXz9inIkeIQ/ibY6B+MdV1x6+uReqz/5z1L89ezWnpPDWpXF0TY5PCYKQdWVn8Vg==",
+            "version": "5.67.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.67.0.tgz",
+            "integrity": "sha512-LjFbfMh89xBDpUMgA1W9Ur6Rn/gnr2Cq1jjHFPo4v6a79/ypznSYbAyPgGhwsxBtMIaEmDD1oJoA7BEYw/Fbrw==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.0",
@@ -6642,7 +6594,7 @@
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.3.1",
-                "webpack-sources": "^3.2.2"
+                "webpack-sources": "^3.2.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -6693,15 +6645,15 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-            "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
+            "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.1.0",
-                "@webpack-cli/info": "^1.4.0",
-                "@webpack-cli/serve": "^1.6.0",
+                "@webpack-cli/configtest": "^1.1.1",
+                "@webpack-cli/info": "^1.4.1",
+                "@webpack-cli/serve": "^1.6.1",
                 "colorette": "^2.0.14",
                 "commander": "^7.0.0",
                 "execa": "^5.0.0",
@@ -6867,9 +6819,9 @@
             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         },
         "node_modules/workerpool": {
-            "version": "6.1.5",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-            "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+            "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
             "dev": true
         },
         "node_modules/wrap-ansi": {
@@ -7454,9 +7406,9 @@
             }
         },
         "@grpc/grpc-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.5.1.tgz",
-            "integrity": "sha512-ItOqQ4ff7JrR9W6KDQm+LdsVjuZtV7Qq64Oy3Hjx8ZPBDDwBx7rD8hOL0Vnde0RbnsqLG86WOgF+tQDzf/nSzQ==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.5.3.tgz",
+            "integrity": "sha512-q0xgaZ3ymUM+ZOhe1hdocVSdKHCnJ6llLSXcP+MqMXMyYPUZ3mzQOCxZ3Zkg+QZ7sZ950sn7hvueQrIJZumPZg==",
             "requires": {
                 "@grpc/proto-loader": "^0.6.4",
                 "@types/node": ">=12.12.47"
@@ -7616,9 +7568,9 @@
             }
         },
         "@types/eslint": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.2.2.tgz",
-            "integrity": "sha512-nQxgB8/Sg+QKhnV8e0WzPpxjIGT3tuJDDzybkDi8ItE/IgTlHo07U0shaIjzhcvQxlq9SDRE42lsJ23uvEgJ2A==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+            "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -7678,15 +7630,15 @@
             "dev": true
         },
         "@types/mocha": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.0.0.tgz",
-            "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
+            "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
             "dev": true
         },
         "@types/node": {
-            "version": "14.18.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.7.tgz",
-            "integrity": "sha512-UpLEO1iBG7esNPusSAjoZhWFK5Mfd8QfwWhHRrg5io13POn/stsBgTCba9suQaFflNA4tc0+6AFM3R6BZNng6A=="
+            "version": "14.18.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz",
+            "integrity": "sha512-j11XSuRuAlft6vLDEX4RvhqC0KxNxx6QIyMXNb0vHHSNPXTPeiy3algESWmOOIzEtiEL0qiowPU3ewW9hHVa7Q=="
         },
         "@types/node-fetch": {
             "version": "2.5.12",
@@ -7716,9 +7668,9 @@
             "dev": true
         },
         "@types/ssh2": {
-            "version": "0.5.50",
-            "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.50.tgz",
-            "integrity": "sha512-Eu/rzX4L+GhWIKEFQbaeWKECdy8VRdIYOqjMlFp+v4v7tBhvcl30m34BZzVALn/dNXvcB6dmcMtspIW7iPOlPg==",
+            "version": "0.5.51",
+            "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.51.tgz",
+            "integrity": "sha512-aIq7ownezauW/+VWYaeXwd5J1Evnn4EXyeKi7bT3H6ZLBLoqsmhdvkHYPLpnZPM6unKKKsxTHIyQAVOZnPiJBw==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -7773,14 +7725,14 @@
             }
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
-            "integrity": "sha512-XXVKnMsq2fuu9K2KsIxPUGqb6xAImz8MEChClbXmE3VbveFtBUU5bzM6IPVWqzyADIgdkS2Ws/6Xo7W2TeZWjQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
+            "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.10.0",
-                "@typescript-eslint/type-utils": "5.10.0",
-                "@typescript-eslint/utils": "5.10.0",
+                "@typescript-eslint/scope-manager": "5.10.1",
+                "@typescript-eslint/type-utils": "5.10.1",
+                "@typescript-eslint/utils": "5.10.1",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
@@ -7790,52 +7742,52 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.0.tgz",
-            "integrity": "sha512-pJB2CCeHWtwOAeIxv8CHVGJhI5FNyJAIpx5Pt72YkK3QfEzt6qAlXZuyaBmyfOdM62qU0rbxJzNToPTVeJGrQw==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
+            "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.10.0",
-                "@typescript-eslint/types": "5.10.0",
-                "@typescript-eslint/typescript-estree": "5.10.0",
+                "@typescript-eslint/scope-manager": "5.10.1",
+                "@typescript-eslint/types": "5.10.1",
+                "@typescript-eslint/typescript-estree": "5.10.1",
                 "debug": "^4.3.2"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.0.tgz",
-            "integrity": "sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
+            "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.10.0",
-                "@typescript-eslint/visitor-keys": "5.10.0"
+                "@typescript-eslint/types": "5.10.1",
+                "@typescript-eslint/visitor-keys": "5.10.1"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.0.tgz",
-            "integrity": "sha512-TzlyTmufJO5V886N+hTJBGIfnjQDQ32rJYxPaeiyWKdjsv2Ld5l8cbS7pxim4DeNs62fKzRSt8Q14Evs4JnZyQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
+            "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/utils": "5.10.0",
+                "@typescript-eslint/utils": "5.10.1",
                 "debug": "^4.3.2",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.0.tgz",
-            "integrity": "sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
+            "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.0.tgz",
-            "integrity": "sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
+            "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.10.0",
-                "@typescript-eslint/visitor-keys": "5.10.0",
+                "@typescript-eslint/types": "5.10.1",
+                "@typescript-eslint/visitor-keys": "5.10.1",
                 "debug": "^4.3.2",
                 "globby": "^11.0.4",
                 "is-glob": "^4.0.3",
@@ -7844,26 +7796,26 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
-            "integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
+            "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.10.0",
-                "@typescript-eslint/types": "5.10.0",
-                "@typescript-eslint/typescript-estree": "5.10.0",
+                "@typescript-eslint/scope-manager": "5.10.1",
+                "@typescript-eslint/types": "5.10.1",
+                "@typescript-eslint/typescript-estree": "5.10.1",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.0.tgz",
-            "integrity": "sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
+            "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.10.0",
+                "@typescript-eslint/types": "5.10.1",
                 "eslint-visitor-keys": "^3.0.0"
             }
         },
@@ -7874,9 +7826,9 @@
             "dev": true
         },
         "@vscode/test-electron": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.0.tgz",
-            "integrity": "sha512-nE5ha/V+l4WnS0QS5wJhb2S75Ceamif30UOcURHYw+8FoJJHg2g1xM8/dSpvX2Xk4+04Rbl76/ui/tgI5qia+Q==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.1.tgz",
+            "integrity": "sha512-7G9gFGjJGOJ+hQ1ZgZYEV973pzQBclLZngXOEGMyRyvK4GUkl7XeIOwQN/iMv2ttq7gPUKmIxSKF7YGF5J7DZQ==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^4.0.1",
@@ -8032,25 +7984,25 @@
             }
         },
         "@webpack-cli/configtest": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-            "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+            "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
             "dev": true,
             "requires": {}
         },
         "@webpack-cli/info": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-            "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+            "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
             "dev": true,
             "requires": {
                 "envinfo": "^7.7.3"
             }
         },
         "@webpack-cli/serve": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-            "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+            "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
             "dev": true,
             "requires": {}
         },
@@ -8471,9 +8423,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001300",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-            "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
+            "version": "1.0.30001301",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
+            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
             "dev": true
         },
         "chainsaw": {
@@ -8532,9 +8484,9 @@
             }
         },
         "chokidar": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "dev": true,
             "requires": {
                 "anymatch": "~3.1.2",
@@ -8658,9 +8610,9 @@
             "dev": true
         },
         "copy-webpack-plugin": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-10.2.0.tgz",
-            "integrity": "sha512-my6iXII95c78w14HzYCNya5TlJYa44lOppAge5GSTMM1SyDxNsVGCJvhP4/ld6snm8lzjn3XOonMZD6s1L86Og==",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-10.2.1.tgz",
+            "integrity": "sha512-nr81NhCAIpAWXGCK5thrKmfCQ6GDY0L5RN0U+BnIn/7Us55+UCex5ANNsNKmIVtDRnk0Ecf+/kzp9SUVrrBMLg==",
             "dev": true,
             "requires": {
                 "fast-glob": "^3.2.7",
@@ -9019,9 +8971,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.47",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.47.tgz",
-            "integrity": "sha512-ZHc8i3/cgeCRK/vC7W2htAG6JqUmOUgDNn/f9yY9J8UjfLjwzwOVEt4MWmgJAdvmxyrsR5KIFA/6+kUHGY0eUA==",
+            "version": "1.4.52",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.52.tgz",
+            "integrity": "sha512-JGkh8HEh5PnVrhU4HbpyyO0O791dVY6k7AdqfDeqbcRMeoGxtNHWT77deR2nhvbLe4dKpxjlDEvdEwrvRLGu2Q==",
             "dev": true
         },
         "emoji-regex": {
@@ -10210,9 +10162,9 @@
             }
         },
         "linkify-it": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
             "dev": true,
             "requires": {
                 "uc.micro": "^1.0.1"
@@ -10304,31 +10256,22 @@
             "integrity": "sha512-sgK2SAzxT19rWU+qxKUcn6PAh/swiIiz2F8C2cZjLc1z4iwYIfdoihqFIDQ8BDzAGtWPYJ6Sr13K1j/DXynDLA=="
         },
         "markdown-it": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-            "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "entities": "~2.0.0",
-                "linkify-it": "^2.0.0",
+                "argparse": "^2.0.1",
+                "entities": "~2.1.0",
+                "linkify-it": "^3.0.1",
                 "mdurl": "^1.0.1",
                 "uc.micro": "^1.0.5"
             },
             "dependencies": {
-                "argparse": {
-                    "version": "1.0.10",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-                    "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-                    "dev": true,
-                    "requires": {
-                        "sprintf-js": "~1.0.2"
-                    }
-                },
                 "entities": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-                    "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+                    "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
                     "dev": true
                 }
             }
@@ -10431,68 +10374,37 @@
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "mocha": {
-            "version": "9.1.4",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.4.tgz",
-            "integrity": "sha512-+q2aV5VlJZuLgCWoBvGI5zEwPF9eEI0kr/sAA9Jm4xMND7RfIEyF8JE7C0JIg8WXRG+P1sdIAb5ccoHPlXLzcw==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
+            "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "chokidar": "3.5.2",
-                "debug": "4.3.2",
+                "chokidar": "3.5.3",
+                "debug": "4.3.3",
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.7",
+                "glob": "7.2.0",
                 "growl": "1.10.5",
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
                 "minimatch": "3.0.4",
                 "ms": "2.1.3",
-                "nanoid": "3.1.25",
+                "nanoid": "3.2.0",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
                 "which": "2.0.2",
-                "workerpool": "6.1.5",
+                "workerpool": "6.2.0",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    },
-                    "dependencies": {
-                        "ms": {
-                            "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                            "dev": true
-                        }
-                    }
-                },
-                "glob": {
-                    "version": "7.1.7",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-                    "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
                 "ms": {
                     "version": "2.1.3",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -10534,9 +10446,9 @@
             "optional": true
         },
         "nanoid": {
-            "version": "3.1.25",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-            "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
             "dev": true
         },
         "napi-build-utils": {
@@ -11124,12 +11036,12 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-            "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
             "dev": true,
             "requires": {
-                "is-core-module": "^2.8.0",
+                "is-core-module": "^2.8.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             }
@@ -11370,12 +11282,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
             "integrity": "sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY="
-        },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
         },
         "ssh2": {
             "version": "1.5.0",
@@ -11702,9 +11608,9 @@
             }
         },
         "typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true
         },
         "uc.micro": {
@@ -11858,9 +11764,9 @@
             "dev": true
         },
         "vsce": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.3.tgz",
-            "integrity": "sha512-PKfvAtG9rLT1evHiKOJpBHND1hUHOOf4lL7chZFp0KGu+Bpgcx3g3T5eq0d8Hmzd08zd3KJunsaA3iaNSmTU/A==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.4.tgz",
+            "integrity": "sha512-1Zvg2sJA/wFd5KCEWlfefXqiZm47d4ATeVKS2lvas0Lo2eLhPA5KRwxvpNvxTGUM9t9hYmAB9ZWtKQRFa9Q0hg==",
             "dev": true,
             "requires": {
                 "azure-devops-node-api": "^11.0.1",
@@ -11871,7 +11777,7 @@
                 "hosted-git-info": "^4.0.2",
                 "keytar": "^7.7.0",
                 "leven": "^3.1.0",
-                "markdown-it": "^10.0.0",
+                "markdown-it": "^12.3.2",
                 "mime": "^1.3.4",
                 "minimatch": "^3.0.3",
                 "parse-semver": "^1.1.1",
@@ -12009,9 +11915,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.49.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.1.tgz",
-            "integrity": "sha512-+DxY6iQrbFhG+Vsz0y16VMrM6bHSlQWUDRquD4sLY0HgeSHoB1E+bQqR7UrQKm8mhInz2XvovzRPW3U6UNgzcw==",
+            "version": "0.49.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.3.tgz",
+            "integrity": "sha512-5A5zXsQ3oNqAYNBQcgmMV4djuFgcZV8t0ii8F9E/+rPbHmNmB5whR0IJPUE9WYMFBv44GKC5MKmJkUzilngD1g==",
             "requires": {
                 "@azure/arm-resources": "^4.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
@@ -12140,9 +12046,9 @@
             "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "webpack": {
-            "version": "5.66.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.66.0.tgz",
-            "integrity": "sha512-NJNtGT7IKpGzdW7Iwpn/09OXz9inIkeIQ/ibY6B+MdV1x6+uReqz/5z1L89ezWnpPDWpXF0TY5PCYKQdWVn8Vg==",
+            "version": "5.67.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.67.0.tgz",
+            "integrity": "sha512-LjFbfMh89xBDpUMgA1W9Ur6Rn/gnr2Cq1jjHFPo4v6a79/ypznSYbAyPgGhwsxBtMIaEmDD1oJoA7BEYw/Fbrw==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
@@ -12168,7 +12074,7 @@
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.3.1",
-                "webpack-sources": "^3.2.2"
+                "webpack-sources": "^3.2.3"
             },
             "dependencies": {
                 "schema-utils": {
@@ -12210,15 +12116,15 @@
             }
         },
         "webpack-cli": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-            "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
+            "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
             "dev": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.1.0",
-                "@webpack-cli/info": "^1.4.0",
-                "@webpack-cli/serve": "^1.6.0",
+                "@webpack-cli/configtest": "^1.1.1",
+                "@webpack-cli/info": "^1.4.1",
+                "@webpack-cli/serve": "^1.6.1",
                 "colorette": "^2.0.14",
                 "commander": "^7.0.0",
                 "execa": "^5.0.0",
@@ -12326,9 +12232,9 @@
             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         },
         "workerpool": {
-            "version": "6.1.5",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-            "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+            "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
             "dev": true
         },
         "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -1254,10 +1254,7 @@
                                 "type": "string",
                                 "description": "%vscode-docker.tasks.docker-run.dockerRun.customOptions%"
                             }
-                        },
-                        "required": [
-                            "image"
-                        ]
+                        }
                     },
                     "platform": {
                         "type": "string",
@@ -1354,10 +1351,7 @@
                             }
                         ]
                     }
-                },
-                "required": [
-                    "dockerRun"
-                ]
+                }
             },
             {
                 "type": "docker-compose",

--- a/package.json
+++ b/package.json
@@ -1015,11 +1015,13 @@
                             },
                             "context": {
                                 "type": "string",
-                                "description": "%vscode-docker.tasks.docker-build.dockerBuild.context%"
+                                "description": "%vscode-docker.tasks.docker-build.dockerBuild.context%",
+                                "default": "${workspaceFolder}"
                             },
                             "dockerfile": {
                                 "type": "string",
-                                "description": "%vscode-docker.tasks.docker-build.dockerBuild.dockerfile%"
+                                "description": "%vscode-docker.tasks.docker-build.dockerBuild.dockerfile%",
+                                "default": "${workspaceFolder}/Dockerfile"
                             },
                             "labels": {
                                 "type": "object",
@@ -1051,7 +1053,10 @@
                                 "type": "string",
                                 "description": "%vscode-docker.tasks.docker-build.dockerBuild.customOptions%"
                             }
-                        }
+                        },
+                        "required": [
+                            "context"
+                        ]
                     },
                     "platform": {
                         "type": "string",
@@ -1087,7 +1092,10 @@
                         "description": "%vscode-docker.tasks.docker-build.python.description%",
                         "type": "object"
                     }
-                }
+                },
+                "required": [
+                    "dockerBuild"
+                ]
             },
             {
                 "type": "docker-run",
@@ -1246,7 +1254,10 @@
                                 "type": "string",
                                 "description": "%vscode-docker.tasks.docker-run.dockerRun.customOptions%"
                             }
-                        }
+                        },
+                        "required": [
+                            "image"
+                        ]
                     },
                     "platform": {
                         "type": "string",
@@ -1343,7 +1354,10 @@
                             }
                         ]
                     }
-                }
+                },
+                "required": [
+                    "dockerRun"
+                ]
             },
             {
                 "type": "docker-compose",
@@ -3065,7 +3079,7 @@
         "ts-loader": "^9.2.3",
         "typescript": "^4.5.4",
         "umd-compat-loader": "^2.1.2",
-        "vsce": "^2.5.1",
+        "vsce": "^2.6.4",
         "webpack": "^5.65.0",
         "webpack-bundle-analyzer": "^4.4.1",
         "webpack-cli": "^4.6.0"

--- a/src/tasks/DockerBuildTaskProvider.ts
+++ b/src/tasks/DockerBuildTaskProvider.ts
@@ -17,7 +17,7 @@ import { DockerTaskProvider } from './DockerTaskProvider';
 import { NetCoreBuildTaskDefinition } from './netcore/NetCoreTaskHelper';
 import { NodeBuildTaskDefinition } from './node/NodeTaskHelper';
 import { defaultVsCodeLabels, getAggregateLabels } from './TaskDefinitionBase';
-import { DockerBuildTaskContext, TaskHelper, throwIfCancellationRequested } from './TaskHelper';
+import { DockerBuildTaskContext, getDefaultImageName, TaskHelper, throwIfCancellationRequested } from './TaskHelper';
 
 export interface DockerBuildTaskDefinition extends NetCoreBuildTaskDefinition, NodeBuildTaskDefinition {
     label?: string;
@@ -48,6 +48,13 @@ export class DockerBuildTaskProvider extends DockerTaskProvider {
             definition.dockerBuild = await helper.getDockerBuildOptions(context, definition);
             throwIfCancellationRequested(context);
         }
+
+        // Fill in some obvious default values
+        /* eslint-disable no-template-curly-in-string */
+        definition.dockerBuild.context = definition.dockerBuild.context || '${workspaceFolder}';
+        definition.dockerBuild.dockerfile = definition.dockerBuild.dockerfile || path.join('${workspaceFolder}', 'Dockerfile');
+        /* eslint-enable no-template-curly-in-string */
+        definition.dockerBuild.tag = definition.dockerBuild.tag || getDefaultImageName(context.folder.name);
 
         await this.validateResolvedDefinition(context, definition.dockerBuild);
 

--- a/src/tasks/TaskHelper.ts
+++ b/src/tasks/TaskHelper.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import { CancellationToken, ConfigurationTarget, ExtensionContext, QuickPickItem, Task, tasks, workspace, WorkspaceFolder } from 'vscode';
 import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { DebugConfigurationBase } from '../debugging/DockerDebugConfigurationBase';
@@ -10,7 +11,7 @@ import { DockerDebugConfiguration } from '../debugging/DockerDebugConfigurationP
 import { DockerPlatform } from '../debugging/DockerPlatformHelper';
 import { localize } from '../localize';
 import { getValidImageName, getValidImageNameWithTag } from '../utils/getValidImageName';
-import { pathNormalize } from '../utils/pathNormalize';
+import { makeAbsolute, pathNormalize } from '../utils/pathNormalize';
 import { resolveVariables } from '../utils/resolveVariables';
 import { DockerBuildOptions } from './DockerBuildTaskDefinitionBase';
 import { DockerBuildTask, DockerBuildTaskDefinition, DockerBuildTaskProvider } from './DockerBuildTaskProvider';
@@ -156,6 +157,8 @@ export async function getOfficialBuildTaskForDockerfile(context: IActionContext,
     let buildTasks: DockerBuildTask[] = await tasks.fetchTasks({ type: 'docker-build' }) || [];
     buildTasks =
         buildTasks.filter(buildTask => {
+            const taskDockerfilePath = makeAbsolute();
+
             return pathNormalize(resolveVariables(buildTask.definition?.dockerBuild?.dockerfile ?? '', folder)) === resolvedDockerfile &&
                 buildTask.scope === folder;
         });

--- a/src/utils/pathNormalize.ts
+++ b/src/utils/pathNormalize.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
-import { WorkspaceFolder } from 'vscode';
 import { isWindows } from './osUtils';
 import { PlatformOS } from "./platform";
 
@@ -14,17 +13,4 @@ export function pathNormalize(targetPath: string, platformOS?: PlatformOS): stri
     return platformOS === 'Windows' ?
         path.win32.normalize(targetPath).replace(/\//g, '\\') :
         path.posix.normalize(targetPath).replace(/\\/g, '/');
-}
-
-export function makeAbsolute(targetPath: string, maybeRelativeTo: string | WorkspaceFolder, platformOS?: PlatformOS): string {
-    if (path.isAbsolute(targetPath)) {
-        return targetPath;
-    }
-
-    const base = typeof maybeRelativeTo === 'string' ? maybeRelativeTo : maybeRelativeTo.uri.fsPath;
-    platformOS = platformOS || (isWindows() ? 'Windows' : 'Linux');
-
-    return platformOS === 'Windows' ?
-        path.win32.join(base, targetPath) :
-        path.posix.join(base, targetPath);
 }

--- a/src/utils/pathNormalize.ts
+++ b/src/utils/pathNormalize.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
+import { WorkspaceFolder } from 'vscode';
 import { isWindows } from './osUtils';
 import { PlatformOS } from "./platform";
 
@@ -13,4 +14,17 @@ export function pathNormalize(targetPath: string, platformOS?: PlatformOS): stri
     return platformOS === 'Windows' ?
         path.win32.normalize(targetPath).replace(/\//g, '\\') :
         path.posix.normalize(targetPath).replace(/\\/g, '/');
+}
+
+export function makeAbsolute(targetPath: string, maybeRelativeTo: string | WorkspaceFolder, platformOS?: PlatformOS): string {
+    if (path.isAbsolute(targetPath)) {
+        return targetPath;
+    }
+
+    const base = typeof maybeRelativeTo === 'string' ? maybeRelativeTo : maybeRelativeTo.uri.fsPath;
+    platformOS = platformOS || (isWindows() ? 'Windows' : 'Linux');
+
+    return platformOS === 'Windows' ?
+        path.win32.join(base, targetPath) :
+        path.posix.join(base, targetPath);
 }


### PR DESCRIPTION
Fixes #3400. Additionally, this includes an `npm audit fix` and `npm update` to clear some more alerts.

There's a few changes encompassed in this.

- I tried to make the task's required properties equivalent to the CLI's required properties--namely, context for `docker build` needed to be the only required parameter. Tag and Dockerfile should be optional.
- Required properties should show up in `tasks.json` now.
- I changed the logic for official build task resolution to consider default arguments better.