### PR TITLE
Try to get port from launch settings

### DIFF
--- a/src/commands/containers/browseContainer.ts
+++ b/src/commands/containers/browseContainer.ts
@@ -20,6 +20,7 @@ const commonWebPorts = [
     3001,   // (Node.js) Sails.js
     5001,   // (.NET Core) ASP.NET SSL
     5000,   // (.NET Core) ASP.NET HTTP and (Python) Flask
+    5002,   // (Python) Flask (newer Flask apps)
     8000,   // (Python) Django and FastAPI
     8080,   // (Node.js)
     8081    // (Node.js)

--- a/src/scaffolding/wizard/ChoosePortsStep.ts
+++ b/src/scaffolding/wizard/ChoosePortsStep.ts
@@ -14,10 +14,13 @@ export class ChoosePortsStep extends TelemetryPromptStep<ScaffoldingWizardContex
     }
 
     public async prompt(wizardContext: ScaffoldingWizardContext): Promise<void> {
+        // If there are random suggested ports, show those, otherwise show the default
+        const suggestedPorts = wizardContext.suggestedRandomPorts?.length ? wizardContext.suggestedRandomPorts : this.defaultPorts;
+
         const opt: vscode.InputBoxOptions = {
-            placeHolder: this.defaultPorts.join(', '),
+            placeHolder: suggestedPorts.join(', '),
             prompt: localize('vscode-docker.scaffold.choosePortsStep.whatPorts', 'What port(s) does your app listen on? Enter a comma-separated list, or empty for no exposed port.'),
-            value: this.defaultPorts.join(', '),
+            value: suggestedPorts.join(', '),
             validateInput: (value: string): string | undefined => {
                 const result = splitPorts(value);
                 if (!result) {

--- a/src/scaffolding/wizard/ScaffoldingWizardContext.ts
+++ b/src/scaffolding/wizard/ScaffoldingWizardContext.ts
@@ -30,6 +30,7 @@ export interface ScaffoldingWizardContext extends IActionContext {
     // These are calculated depending on platform, with defaults
     version?: string;
     serviceName?: string;
+    suggestedRandomPorts?: number[];
 
     // Other properties that get calculated or set later
     overwriteAll?: boolean;

--- a/src/scaffolding/wizard/netCore/NetCoreScaffoldingWizardContext.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreScaffoldingWizardContext.ts
@@ -13,6 +13,7 @@ import { ScaffoldDebuggingStep } from '../ScaffoldDebuggingStep';
 import { ScaffoldingWizardContext } from '../ScaffoldingWizardContext';
 import { NetCoreChooseOsStep } from './NetCoreChooseOsStep';
 import { NetCoreGatherInformationStep } from './NetCoreGatherInformationStep';
+import { NetCoreTryGetRandomPortStep } from './NetCoreTryGetRandomPortStep';
 
 const chooseProjectFile = localize('vscode-docker.scaffold.platforms.netCore.chooseProject', 'Choose a project file');
 const netCoreGlobPatterns = [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN];
@@ -32,6 +33,7 @@ export function getNetCoreSubWizardOptions(wizardContext: ScaffoldingWizardConte
     ];
 
     if (wizardContext.platform === '.NET: ASP.NET Core' && (wizardContext.scaffoldType === 'all' || wizardContext.scaffoldType === 'compose')) {
+        promptSteps.push(new NetCoreTryGetRandomPortStep());
         promptSteps.push(new ChoosePortsStep([5000]));
     }
 

--- a/src/scaffolding/wizard/netCore/NetCoreTryGetRandomPortStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreTryGetRandomPortStep.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as fse from 'fs-extra';
+import { URL } from 'url';
+import { GatherInformationStep } from '../GatherInformationStep';
+import { NetCoreScaffoldingWizardContext } from './NetCoreScaffoldingWizardContext';
+
+interface DotNetProfile {
+    commandName?: string;
+    applicationUrl?: string;
+}
+
+interface DotNetLaunchSettings {
+    profiles?: { [key: string]: DotNetProfile };
+}
+
+export class NetCoreTryGetRandomPortStep extends GatherInformationStep<NetCoreScaffoldingWizardContext> {
+    public async prompt(wizardContext: NetCoreScaffoldingWizardContext): Promise<void> {
+        try {
+            wizardContext.suggestedRandomPorts = await this.tryGetPortFromLaunchSettings(wizardContext.workspaceFolder);
+        } catch {
+            // Best effort
+            wizardContext.suggestedRandomPorts = undefined;
+        }
+    }
+
+    public shouldPrompt(wizardContext: NetCoreScaffoldingWizardContext): boolean {
+        return !(wizardContext.suggestedRandomPorts?.length) && !!wizardContext.workspaceFolder && !!wizardContext.artifact;
+    }
+
+    /**
+     * Tries getting the random port assigned by .NET scaffolding. Adapted from https://github.com/microsoft/vscode-dapr/blob/36a4b9e5bb47784a306009cf5def5fe674b204a8/src/commands/scaffoldDaprTasks.ts#L48-L81
+     * @param workspaceFolder The workspace folder to search for launch settings files within
+     * @returns An array with a random port assigned by .NET scaffolding, or undefined
+     */
+    private async tryGetPortFromLaunchSettings(workspaceFolder: vscode.WorkspaceFolder): Promise<number[] | undefined> {
+        const launchSettingsFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(workspaceFolder, "**/Properties/launchSettings.json"));
+
+        for (const launchSettingsFile of launchSettingsFiles) {
+            const launchSettingsJson = await fse.readJSON(launchSettingsFile.fsPath) as DotNetLaunchSettings;
+
+            if (launchSettingsJson.profiles) {
+                const projectProfile = Object.values(launchSettingsJson.profiles).find(profile => profile.commandName === 'Project');
+
+                if (projectProfile?.applicationUrl) {
+                    const applicationUrls = projectProfile.applicationUrl.split(';');
+
+                    for (const applicationUrl of applicationUrls) {
+                        try {
+                            const url = new URL(applicationUrl);
+
+                            if (url.protocol === 'http:' && url.port) {
+                                return [parseInt(url.port, 10)];
+                            }
+                        }
+                        catch {
+                            // NOTE: Ignore any errors parsing the URL.
+                        }
+                    }
+                }
+            }
+        }
+
+        return undefined;
+    }
+}

--- a/src/utils/pythonUtils.ts
+++ b/src/utils/pythonUtils.ts
@@ -14,7 +14,7 @@ export const PythonDefaultDebugPort: number = 5678;
 export const PythonDefaultPorts = new Map<PythonProjectType, number | undefined>([
     ['django', 8000],
     ['fastapi', 8000],
-    ['flask', 5000],
+    ['flask', 5001],
     ['general', undefined],
 ]);
 

--- a/src/utils/pythonUtils.ts
+++ b/src/utils/pythonUtils.ts
@@ -14,7 +14,7 @@ export const PythonDefaultDebugPort: number = 5678;
 export const PythonDefaultPorts = new Map<PythonProjectType, number | undefined>([
     ['django', 8000],
     ['fastapi', 8000],
-    ['flask', 5001],
+    ['flask', 5002],
     ['general', undefined],
 ]);
 


### PR DESCRIPTION
Fixes #3381.

TODO:

- [x] .NET, uses 5000
- [x] Flask, uses 5000
- ~~Django, FastAPI? Use 8000~~
- ~~Node? Uses 3000~~