### PR TITLE
Improve Django scaffolding experience

### DIFF
--- a/src/scaffolding/wizard/python/ChoosePythonArtifactStep.ts
+++ b/src/scaffolding/wizard/python/ChoosePythonArtifactStep.ts
@@ -12,19 +12,26 @@ import { PythonScaffoldingWizardContext } from './PythonScaffoldingWizardContext
 const moduleRegex = /([a-z_]+[.])*([a-z_])/i;
 
 // Exclude Python files in the .venv folder from showing in the pick list
-const excludePattern = '.venv/**';
+const excludePattern = '.[Vv][Ee][Nn][Vv]/**';
+
+// For Django, additionally exclude the WSGI/ASGI files to prevent user confusion
+const djangoExcludePattern = '{.[Vv][Ee][Nn][Vv]/**,**/[AaWw][Ss][Gg][Ii].[Pp][Yy]}';
 
 export class ChoosePythonArtifactStep extends ChooseArtifactStep<PythonScaffoldingWizardContext> {
     public constructor() {
         super(
             localize('vscode-docker.scaffold.choosePythonArtifactStep.promptText', 'Choose the app\'s entry point (e.g. manage.py, app.py)'),
-            ['**/manage.py', '**/app.py', '**/*.{[Pp][Yy]}'], // Including manage.py and app.py here pushes them to the top of the pick list; resolveFilesOfPattern dedupes
+            ['**/manage.py', '**/app.py', '**/*.[Pp][Yy]'], // Including manage.py and app.py here pushes them to the top of the pick list; resolveFilesOfPattern dedupes
             localize('vscode-docker.scaffold.choosePythonArtifactStep.noItemsFound', 'No Python files were found.')
         );
     }
 
     public async prompt(wizardContext: PythonScaffoldingWizardContext): Promise<void> {
-        const items = await resolveFilesOfPattern(wizardContext.workspaceFolder, this.globPatterns, excludePattern) ?? [];
+        const items = await resolveFilesOfPattern(
+            wizardContext.workspaceFolder,
+            this.globPatterns,
+            wizardContext.platform === 'Python: Django' ? djangoExcludePattern : excludePattern
+        ) ?? [];
 
         const pickChoices: IAzureQuickPickItem<Item | undefined>[] = items.map(i => {
             return {


### PR DESCRIPTION
Fixes #3410. Two things in this:

- For Django apps only, when asking for input on the primary artifact we will no longer suggest WSGI/ASGI files.
- When searching for the WSGI file for Django apps, now look in any immediate subfolder from the primary artifact, rather than one of the exact name of the workspace folder.