### PR TITLE
Fix unit tests failing in new VSCode version

### DIFF
--- a/src/telemetry/ActivityMeasurementService.ts
+++ b/src/telemetry/ActivityMeasurementService.ts
@@ -29,7 +29,7 @@ export class ActivityMeasurementService implements IActivityMeasurementService {
     private readonly lazySetterMap: Map<ActivityType, AsyncLazy<void>> = new Map<ActivityType, AsyncLazy<void>>();
     private readonly values: Map<ActivityType, ActivityMeasurement> = new Map<ActivityType, ActivityMeasurement>();
 
-    public constructor(private readonly memento: vscode.Memento) {
+    public constructor(private readonly memento: vscode.Memento, private readonly requireTelemetryEnabled = true) {
     }
 
     /**
@@ -38,7 +38,7 @@ export class ActivityMeasurementService implements IActivityMeasurementService {
      * @param type The activity type to record measurements for
      */
     public async recordActivity(type: ActivityType): Promise<void> {
-        if (!vscode.env.isTelemetryEnabled && !process.env.DEBUGTELEMETRY) {
+        if (this.requireTelemetryEnabled && !vscode.env.isTelemetryEnabled) {
             return;
         }
 
@@ -85,7 +85,7 @@ export class ActivityMeasurementService implements IActivityMeasurementService {
      * @param type The activity type to get measurements for
      */
     public getActivityMeasurement(type: ActivityType): ActivityMeasurement {
-        if (!vscode.env.isTelemetryEnabled && !process.env.DEBUGTELEMETRY) {
+        if (this.requireTelemetryEnabled && !vscode.env.isTelemetryEnabled) {
             return defaultMeasurement;
         }
 

--- a/src/telemetry/ActivityMeasurementService.ts
+++ b/src/telemetry/ActivityMeasurementService.ts
@@ -38,7 +38,7 @@ export class ActivityMeasurementService implements IActivityMeasurementService {
      * @param type The activity type to record measurements for
      */
     public async recordActivity(type: ActivityType): Promise<void> {
-        if (!vscode.env.isTelemetryEnabled) {
+        if (!vscode.env.isTelemetryEnabled && !process.env.DEBUGTELEMETRY) {
             return;
         }
 
@@ -85,7 +85,7 @@ export class ActivityMeasurementService implements IActivityMeasurementService {
      * @param type The activity type to get measurements for
      */
     public getActivityMeasurement(type: ActivityType): ActivityMeasurement {
-        if (!vscode.env.isTelemetryEnabled) {
+        if (!vscode.env.isTelemetryEnabled && !process.env.DEBUGTELEMETRY) {
             return defaultMeasurement;
         }
 

--- a/src/test/telemetry/ActivityMeasurementService.test.ts
+++ b/src/test/telemetry/ActivityMeasurementService.test.ts
@@ -18,7 +18,7 @@ function assertSameDate(a: number, b: number): void {
 
 suite('(unit) telemetry/ActivityMeasurementService', async () => {
     test('Default data returned', async () => {
-        const ams = new ActivityMeasurementService(new TestMemento());
+        const ams = new ActivityMeasurementService(new TestMemento(), false);
 
         const overallData = ams.getActivityMeasurement('overall');
         const overallNoEditData = ams.getActivityMeasurement('overallnoedit');
@@ -31,7 +31,7 @@ suite('(unit) telemetry/ActivityMeasurementService', async () => {
     });
 
     test('overall increments overall only', async () => {
-        const ams = new ActivityMeasurementService(new TestMemento());
+        const ams = new ActivityMeasurementService(new TestMemento(), false);
 
         await ams.recordActivity('overall');
 
@@ -46,7 +46,7 @@ suite('(unit) telemetry/ActivityMeasurementService', async () => {
     });
 
     test('overallnoedit increments both', async () => {
-        const ams = new ActivityMeasurementService(new TestMemento());
+        const ams = new ActivityMeasurementService(new TestMemento(), false);
 
         await ams.recordActivity('overallnoedit');
 
@@ -63,7 +63,7 @@ suite('(unit) telemetry/ActivityMeasurementService', async () => {
     });
 
     test('Record is once per day', async () => {
-        const ams = new ActivityMeasurementService(new TestMemento());
+        const ams = new ActivityMeasurementService(new TestMemento(), false);
 
         await ams.recordActivity('overall');
         await ams.recordActivity('overall');
@@ -77,11 +77,11 @@ suite('(unit) telemetry/ActivityMeasurementService', async () => {
 
     test('Loading from storage', async () => {
         const memento = new TestMemento();
-        const ams1 = new ActivityMeasurementService(memento);
+        const ams1 = new ActivityMeasurementService(memento, false);
         await ams1.recordActivity('overallnoedit');
 
         // Get a new object without memory
-        const ams2 = new ActivityMeasurementService(memento);
+        const ams2 = new ActivityMeasurementService(memento, false);
 
         const overallData = ams2.getActivityMeasurement('overall');
         const overallNoEditData = ams2.getActivityMeasurement('overallnoedit');


### PR DESCRIPTION
In VSCode 1.64, `vscode.env.isTelemetryEnabled` is now `false` in test sessions and extension debug sessions. For our unit tests, we do not need to enforce telemetry being enabled.