### PR TITLE
Support `${userHome}` task variable

### DIFF
--- a/src/utils/resolveVariables.ts
+++ b/src/utils/resolveVariables.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as os from 'os';
 import * as path from 'path';
 import { WorkspaceFolder, window, workspace } from 'vscode';
 import { cloneObject } from '../utils/cloneObject';
@@ -41,6 +42,8 @@ function resolveSingleVariable(variable: string, folder?: WorkspaceFolder, addit
             case '${workspaceFolder}':
             case '${workspaceRoot}':
                 return path.normalize(folder.uri.fsPath);
+            case '${userHome}':
+                return os.homedir();
             case '${relativeFile}':
                 return path.relative(path.normalize(folder.uri.fsPath), getActiveFilePath());
             default:


### PR DESCRIPTION
I saw in the 1.65 release notes that a new [`${userHome}` task variable has been added](https://code.visualstudio.com/updates/v1_65#_tasks). It seems likely this could get used so I'm adding support for it in our variable resolver.