### PR TITLE
Add LICENSE to `.dockerignore`

### DIFF
--- a/resources/templates/.dockerignore.template
+++ b/resources/templates/.dockerignore.template
@@ -27,4 +27,5 @@
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
+LICENSE
 README.md


### PR DESCRIPTION
Be more compatible with `.dockerignore` created by Visual Studio 2022