### PR TITLE
Upgrade Dockerfile language server to 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@microsoft/vscode-azext-azureutils": "^0.1.3",
                 "@microsoft/vscode-azext-utils": "^0.1.1",
                 "dayjs": "^1.10.4",
-                "dockerfile-language-server-nodejs": "^0.8.0",
+                "dockerfile-language-server-nodejs": "^0.9.0",
                 "dockerode": "^3.2.1",
                 "fs-extra": "^10.0.0",
                 "glob": "^8.0.1",
@@ -2636,12 +2636,12 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.8.0.tgz",
-            "integrity": "sha512-7oxOu3PWDzsTkLbUIm1O61rgdNiM9j9tAt+T0R5m0TFG0NYypYBM77pfzAYmQFpHGHAstCtOaEYzEnp0IkRCnQ==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.9.0.tgz",
+            "integrity": "sha512-QPWcUxbbNTaWaRQrJKUBmCXI6iE8l7f81bCVaZizCIkVg4py/4o2mho+AKlLUsZcCml5ss8MkJ257SFV2BZWCg==",
             "dependencies": {
-                "dockerfile-language-service": "0.8.1",
-                "dockerfile-utils": "0.9.4",
+                "dockerfile-language-service": "0.9.0",
+                "dockerfile-utils": "0.10.0",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
             "bin": {
@@ -2685,12 +2685,12 @@
             "integrity": "sha512-9/PeDNPYduaoXRUzYpqmu4ZV9L01HGo0wH9FUt+sSHR7IXwA7xoXBfNUlv8gB9H0D2WwEmMomSy1NmhjKQyn3A=="
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.8.1.tgz",
-            "integrity": "sha512-bqrZ2FzG45w2Mzmak3oC5ecIl/edStygSFQ0i/8WGabb5k/w6zWwqDaHVgT8dkfogm+swHMQUu4WGTvVu1qLCA==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.9.0.tgz",
+            "integrity": "sha512-sDUkTR4LUimEAWXDIbUTEx2CytCBlx+XlJkg4B2Ptvak9HkwPD4JpXesaWxXPpp6YHCzxqwsTDY7Gf79ic340g==",
             "dependencies": {
                 "dockerfile-ast": "0.4.2",
-                "dockerfile-utils": "0.9.4",
+                "dockerfile-utils": "0.10.0",
                 "vscode-languageserver-types": "3.17.0-next.3"
             },
             "engines": {
@@ -2698,9 +2698,9 @@
             }
         },
         "node_modules/dockerfile-utils": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.4.tgz",
-            "integrity": "sha512-lqmCxVhaUyCUIz9dhzYVrHZLJG5hzdcwd29JcA/0o7xIx2VwvIctUE6SpK8ugLTNuwMx/oKU2YVLaRIX/CmQPg==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.10.0.tgz",
+            "integrity": "sha512-gnEhxITHpOXNXdlwJgJEq3xnJokm0IZOmrmHlJv8zCB2EDsgZWwdYWuktMMslIywK2YT22gxgZEoFjtEaJqzhQ==",
             "dependencies": {
                 "dockerfile-ast": "0.4.2",
                 "vscode-languageserver-textdocument": "^1.0.1",
@@ -9275,12 +9275,12 @@
             }
         },
         "dockerfile-language-server-nodejs": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.8.0.tgz",
-            "integrity": "sha512-7oxOu3PWDzsTkLbUIm1O61rgdNiM9j9tAt+T0R5m0TFG0NYypYBM77pfzAYmQFpHGHAstCtOaEYzEnp0IkRCnQ==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.9.0.tgz",
+            "integrity": "sha512-QPWcUxbbNTaWaRQrJKUBmCXI6iE8l7f81bCVaZizCIkVg4py/4o2mho+AKlLUsZcCml5ss8MkJ257SFV2BZWCg==",
             "requires": {
-                "dockerfile-language-service": "0.8.1",
-                "dockerfile-utils": "0.9.4",
+                "dockerfile-language-service": "0.9.0",
+                "dockerfile-utils": "0.10.0",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
             "dependencies": {
@@ -9314,19 +9314,19 @@
             }
         },
         "dockerfile-language-service": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.8.1.tgz",
-            "integrity": "sha512-bqrZ2FzG45w2Mzmak3oC5ecIl/edStygSFQ0i/8WGabb5k/w6zWwqDaHVgT8dkfogm+swHMQUu4WGTvVu1qLCA==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.9.0.tgz",
+            "integrity": "sha512-sDUkTR4LUimEAWXDIbUTEx2CytCBlx+XlJkg4B2Ptvak9HkwPD4JpXesaWxXPpp6YHCzxqwsTDY7Gf79ic340g==",
             "requires": {
                 "dockerfile-ast": "0.4.2",
-                "dockerfile-utils": "0.9.4",
+                "dockerfile-utils": "0.10.0",
                 "vscode-languageserver-types": "3.17.0-next.3"
             }
         },
         "dockerfile-utils": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.9.4.tgz",
-            "integrity": "sha512-lqmCxVhaUyCUIz9dhzYVrHZLJG5hzdcwd29JcA/0o7xIx2VwvIctUE6SpK8ugLTNuwMx/oKU2YVLaRIX/CmQPg==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.10.0.tgz",
+            "integrity": "sha512-gnEhxITHpOXNXdlwJgJEq3xnJokm0IZOmrmHlJv8zCB2EDsgZWwdYWuktMMslIywK2YT22gxgZEoFjtEaJqzhQ==",
             "requires": {
                 "dockerfile-ast": "0.4.2",
                 "vscode-languageserver-textdocument": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -3144,7 +3144,7 @@
         "@microsoft/vscode-azext-azureutils": "^0.1.3",
         "@microsoft/vscode-azext-utils": "^0.1.1",
         "dayjs": "^1.10.4",
-        "dockerfile-language-server-nodejs": "^0.8.0",
+        "dockerfile-language-server-nodejs": "^0.9.0",
         "dockerode": "^3.2.1",
         "fs-extra": "^10.0.0",
         "glob": "^8.0.1",


### PR DESCRIPTION
This update includes support for the parsing the new `--link` flag in `ADD` and `COPY` instructions as well as a fix for negative semantic token values that seemed to cause Visual Studio Code to hang and crash (#3450).

To test the `--link` flag validating support, please use the Dockerfile below.
```Dockerfile
FROM scratch
# these are okay
ADD --link . .
ADD --link=true . .
ADD --link=false . .
ADD --link=tRUe . .
ADD --link=FALse . .
COPY --link . .
COPY --link=true . .
COPY --link=false . .
COPY --link=tRUe . .
COPY --link=FALse . .
#these are not okay
ADD --link= . .
ADD --link=abc . .
COPY --link= . .
COPY --link=abc . .
```

To test the semantic tokens crash, please use the Dockerfile provided in https://github.com/microsoft/vscode-docker/issues/3450#issuecomment-1069259251.