### PR TITLE
Detect GHCR images in tagging telemetry

### DIFF
--- a/src/commands/images/tagImage.ts
+++ b/src/commands/images/tagImage.ts
@@ -50,6 +50,7 @@ const KnownRegistries: { type: string, regex: RegExp }[] = [
     { type: 'dockerhub-namespace', regex: /^[^.:]+\/[^.:]+$/ },
 
     { type: 'dockerhub-dockerio', regex: /^docker.io.*\// },
+    { type: 'github', regex: /ghcr\.io.*\// },
     { type: 'gitlab', regex: /gitlab.*\// },
     { type: 'ACR', regex: /azurecr\.io.*\// },
     { type: 'GCR', regex: /gcr\.io.*\// },


### PR DESCRIPTION
Request from @ucheNkadiCode. In our telemetry for image tagging this adds support for GitHub Container Registry, so it doesn't all go into the "Other" category.

Related to #3506. Fixes #3510.