### PR TITLE
Switch back to default .NET images (undo #2996, #3029)

### DIFF
--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -20,7 +20,7 @@ const minCSharpVersionString = '1.23.9';
 const aspNetBaseImage = 'mcr.microsoft.com/dotnet/aspnet';
 const consoleNetBaseImage = 'mcr.microsoft.com/dotnet/runtime';
 const netSdkImage = 'mcr.microsoft.com/dotnet/sdk';
-const linuxTagSuffix = '-focal';
+const linuxTagSuffix = '-jammy';
 
 const cSharpExtensionId = 'ms-dotnettools.csharp';
 const cSharpConfigId = 'csharp';

--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -20,7 +20,6 @@ const minCSharpVersionString = '1.23.9';
 const aspNetBaseImage = 'mcr.microsoft.com/dotnet/aspnet';
 const consoleNetBaseImage = 'mcr.microsoft.com/dotnet/runtime';
 const netSdkImage = 'mcr.microsoft.com/dotnet/sdk';
-const linuxTagSuffix = '-jammy';
 
 const cSharpExtensionId = 'ms-dotnettools.csharp';
 const cSharpConfigId = 'csharp';
@@ -59,9 +58,8 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
 
             // semver.coerce tolerates version strings like "5.0" which is typically what is present in the .NET project file
             const netCoreVersion = semver.coerce(netCoreVersionString);
-            const tagSuffix = wizardContext.netCorePlatformOS === "Linux" ? linuxTagSuffix : '';
-            wizardContext.netCoreRuntimeBaseImage = wizardContext.platform === '.NET: ASP.NET Core' ? `${aspNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}${tagSuffix}` : `${consoleNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}${tagSuffix}`;
-            wizardContext.netCoreSdkBaseImage = `${netSdkImage}:${netCoreVersion.major}.${netCoreVersion.minor}${tagSuffix}`;
+            wizardContext.netCoreRuntimeBaseImage = wizardContext.platform === '.NET: ASP.NET Core' ? `${aspNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}` : `${consoleNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}`;
+            wizardContext.netCoreSdkBaseImage = `${netSdkImage}:${netCoreVersion.major}.${netCoreVersion.minor}`;
         }
 
         if (!wizardContext.serviceName) {


### PR DESCRIPTION
~~With the release of Ubuntu 22.04, the new Ubuntu tag for images is `-jammy` instead of `-focal`. There is no `7.0-focal` at all, only `7.0-jammy`. There is both for 6.0, so we do not need to service a fix.~~

Undoes #2996, #3029. The .NET attach scenario no longer relies on `ps` so we don't need to use Ubuntu-based images by default.

Fixes #3512.