### PR TITLE
Use `debugAdapterHost: localhost` on Docker Desktop for Linux

### DIFF
--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -144,7 +144,13 @@ export class PythonDebugHelper implements DebugHelper {
             return 'localhost';
         }
 
-        // For Linux, 'host.docker.internal' doesn't work, so we ask debugpy to listen
+        // For Docker Desktop on Linux, we also use 'localhost'
+        const dockerInfo = await ext.dockerClient.info(context.actionContext, context.cancellationToken);
+        if (/Docker Desktop/i.test(dockerInfo.OperatingSystem)) {
+            return 'localhost';
+        }
+
+        // For other Docker setups on Linux, 'host.docker.internal' doesn't work, so we ask debugpy to listen
         // on the bridge network's ip address (predefined network).
         const networkInspection = await ext.dockerClient.inspectNetwork(context.actionContext, 'bridge', context.cancellationToken);
 

--- a/src/docker/Common.ts
+++ b/src/docker/Common.ts
@@ -7,6 +7,7 @@ export type DockerOSType = 'linux' | 'windows';
 
 export interface DockerInfo {
     readonly OSType: DockerOSType;
+    readonly OperatingSystem: string;
 }
 
 export interface PruneResult {


### PR DESCRIPTION
Fixes #3514. On Docker Desktop for Linux, they use the same VM setup as on Mac and Windows, so it is necessary to use `localhost` as the `debugAdapterHost`.