### PR TITLE
Use `-u` flag with `GetVsDbg.sh`

### DIFF
--- a/src/debugging/netcore/VsDbgHelper.ts
+++ b/src/debugging/netcore/VsDbgHelper.ts
@@ -34,7 +34,7 @@ const acquisition: { url: string, scriptPath: string, getShellCommand(runtime: V
             url: 'https://aka.ms/getvsdbgsh',
             scriptPath: path.join(vsDbgInstallBasePath, 'getvsdbg.sh'),
             getShellCommand: (runtime: VsDbgRuntime, version: VsDbgVersion) => {
-                return `chmod +x "${acquisition.scriptPath}" && "${acquisition.scriptPath}" -v ${version} -r ${runtime} -l "${getInstallDirectory(runtime, version)}"`;
+                return `chmod +x "${acquisition.scriptPath}" && "${acquisition.scriptPath}" -u -v ${version} -r ${runtime} -l "${getInstallDirectory(runtime, version)}"`;
             }
         };
 

--- a/src/tree/containers/ContainerTreeItem.ts
+++ b/src/tree/containers/ContainerTreeItem.ts
@@ -16,7 +16,16 @@ import { getContainerStateIcon } from "./ContainerProperties";
 import { DockerContainerInfo } from './ContainersTreeItem';
 import { FilesTreeItem } from "./files/FilesTreeItem";
 
-export class ContainerTreeItem extends ToolTipParentTreeItem implements MultiSelectNode {
+/**
+ * This interface defines properties used by the Remote Containers extension. These properties must not be removed from this class.
+ */
+interface ContainerTreeItemUsedByRemoteContainers {
+    readonly containerDesc: {
+        readonly Id: string;
+    };
+}
+
+export class ContainerTreeItem extends ToolTipParentTreeItem implements MultiSelectNode, ContainerTreeItemUsedByRemoteContainers {
     public static allContextRegExp: RegExp = /Container$/;
     public static runningContainerRegExp: RegExp = /^runningContainer$/i;
     private readonly _item: DockerContainerInfo;
@@ -76,8 +85,6 @@ export class ContainerTreeItem extends ToolTipParentTreeItem implements MultiSel
 
     /**
      * @deprecated This is only kept for backwards compatability with the "Remote Containers" extension
-     * They add a context menu item "Attach Visual Studio Code" to our container nodes that relies on containerDesc
-     * https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
      */
     public get containerDesc(): { Id: string } {
         return {

--- a/src/tree/volumes/VolumeTreeItem.ts
+++ b/src/tree/volumes/VolumeTreeItem.ts
@@ -11,7 +11,14 @@ import { getTreeId } from "../LocalRootTreeItemBase";
 import { resolveTooltipMarkdown } from "../resolveTooltipMarkdown";
 import { ToolTipTreeItem } from "../ToolTipTreeItem";
 
-export class VolumeTreeItem extends ToolTipTreeItem {
+/**
+ * This interface defines properties used by the Remote Containers extension. These properties must not be removed from this class.
+ */
+interface VolumeTreeItemUsedByRemoteContainers {
+    readonly volumeName: string;
+}
+
+export class VolumeTreeItem extends ToolTipTreeItem implements VolumeTreeItemUsedByRemoteContainers {
     public static contextValue: string = 'volume';
     public contextValue: string = VolumeTreeItem.contextValue;
     private readonly _item: DockerVolume;


### PR DESCRIPTION
Along with an upcoming new release of the VSDBG scripts, this will fix #3527.

Also includes unrelated addition of some interfaces to explicitly codify some things used by the Remote - Containers extension, so that if the property was accidentally removed, TypeScript would complain (because the class would no longer implement the interface).