### PR TITLE
Podman compatibility re: issues/#3241  

### DIFF
--- a/src/docker/ContextManager.ts
+++ b/src/docker/ContextManager.ts
@@ -35,7 +35,7 @@ const dockerContextsFolder = path.join(dockerConfigFolder, 'contexts', 'meta');
 /*
  TODO: podman 
  present version of podman is v4, beginning in v2 has equivalent of LocalPipe API 'libpod'
- WSL2 ubuntu 22.04 includes podman v3 (version i am using)
+ WSL2 ubuntu 22.04 includes podman v3 (version i am using w/ Win11 insiders)
 
  https://podman.io/blogs/2020/06/29/podman-v2-announce.html
  https://github.com/containers/podman
@@ -47,6 +47,13 @@ const dockerContextsFolder = path.join(dockerConfigFolder, 'contexts', 'meta');
  ^^^ to create the socket file 
  podman system service -t 5000 &
     (or switch -t 0 to run forever)
+
+In windows powershell I ran 
+    `podman system connection list`
+
+    ssh://user@localhost:59667/run/user/1000/podman/podman.sock
+    ssh://root@localhost:59667/run/podman/podman.sock
+
 */ 
 const WindowsLocalPipe = 'npipe:////./pipe/docker_engine';
 const UnixLocalPipe = 'unix:///var/run/docker.sock';


### PR DESCRIPTION
Dear @bwateratmsft, et al. 

I did some Principal Investigation re: issues/#3241 & Podman compat.  just for my own curio how furry this yak was.  Enjoyed your code! 🙊🙉🙈

Managed to get Podman "working", notes in the source comments (no actual code changes were required, but my approach with `sudo ln` on the socket is uber janky-ness).   I therefore explicitly say this pull request is NOT ready for merge, intended only for discussion, and includes my notes & research how to get podman working with vscode-docker extension for others also inclined in the community. 

I can/would/will keep going if you are open to accept a pull request,  still looking at issues/#3411 nerdctl support and but this is/was sufficient for my progress today. 😉👍

At a minimum the `const UnixLocalPipe` will need to become mutable, or another variable will need to get added. 

Imho after staring at this for ~2 hours (in my own efforts to learn podman & improve my typescript), my conclusion was that it probably makes sense to add a top level config 'use_podman_defaults' boolean
OR perhaps even better (given the cadence of podman ecosystem) "use_podman_version" with 0 being equivalent to "none", i.e. use the traditional 'docker' settings, within the workspace("docker") 

The benefit of a high level `use_podman_version` setting would be to future-proof a bit, first, very easy to detect & programmatically set/verify, and then new podman features & functionality could be coded as >= 2, 3, 4 ... as needed. 

Alternatively, the BIG elephant in the room - the entire project should probably be merged into the vscode-containers plugin .. and I can't imagine a future where a dev wants only one plugin and not the other ..  and the worst possible solution would be to do vscode-podman as a fork/3rd extension, imho it definitely doesn't make sense to fork/have two plugins 'docker v. podman'  + vscode-containers given the incredible amount of overlap all these have.  I dev in Rust, Python, Typescript, & Bash and suffer from plugin fatigue already.    

Even with podman support, the plugin should still be named 'vscode-docker', because: 
```
// These contexts are used by external consumers (e.g. the "Remote - Containers" extension), and should NOT be changed
type VSCodeContext = 'vscode-docker:aciContext' | 'vscode-docker:newSdkContext' | 'vscode-docker:newCliPresent' | 'vscode-docker:contextLocked';
```

So for now, discussion, plan small easy to chew bites -- my conclusion was hiding some podman compatibility internally to vscode-docker makes sense, adding a bit on podman in the docs, maybe even in the name so people can search for podman and this plugin comes up.   Should have zero impact to workflows & Remote - Containers ..  but an awareness that podman OCI usage is proliferating since Dockers new licensing model went into effect, this will likely continue.  

Keen to learn your & others thoughts/plans.  Hope this was helpful. 
Cheers!