### PR TITLE
Fix 'Add Docker Files to Workspace' command

### DIFF
--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -69,7 +69,13 @@ export class PythonTaskHelper implements TaskHelper {
             runOptions.module = 'flask';
             runOptions.file = undefined;
         } else if (options.projectType === 'fastapi') {
-            runOptions.args.unshift(`${path.basename(runOptions.file, '.py')}:app`);
+            const basename = path.basename(runOptions.file, '.py');
+            const dirname = path.dirname(runOptions.file).replace(path.sep, '.');
+            if (dirname !== '.') {
+              runOptions.args.unshift(`${dirname}.${basename}:app`);
+            } else {
+              runOptions.args.unshift(`${basename}:app`);
+            }
             runOptions.module = 'uvicorn';
             runOptions.file = undefined;
         }


### PR DESCRIPTION
When using the 'Add Docker Files to Workspace' command within a fastapi app where the main.py is in a subfolder the resulting 'tasks.json' will not include the subfolder which breaks the debug mode.

Example where main.py is in a directory called 'app':
Before:
```json
{
	"version": "2.0.0",
	"tasks": [
		{
			"type": "docker-build",
			"label": "docker-build",
			"platform": "python",
			"dockerBuild": {
				"tag": "guitartabsdocker:latest",
				"dockerfile": "${workspaceFolder}/Dockerfile",
				"context": "${workspaceFolder}",
				"pull": true
			}
		},
		{
			"type": "docker-run",
			"label": "docker-run: debug",
			"dependsOn": [
				"docker-build"
			],
			"python": {
				"args": [
					"main:app",
					"--host",
					"0.0.0.0",
					"--port",
					"8000"
				],
				"module": "uvicorn"
			}
		}
	]
}
```

After:

```json
{
	"version": "2.0.0",
	"tasks": [
		{
			"type": "docker-build",
			"label": "docker-build",
			"platform": "python",
			"dockerBuild": {
				"tag": "guitartabsdocker:latest",
				"dockerfile": "${workspaceFolder}/Dockerfile",
				"context": "${workspaceFolder}",
				"pull": true
			}
		},
		{
			"type": "docker-run",
			"label": "docker-run: debug",
			"dependsOn": [
				"docker-build"
			],
			"python": {
				"args": [
					"app.main:app",
					"--host",
					"0.0.0.0",
					"--port",
					"8000"
				],
				"module": "uvicorn"
			}
		}
	]
}
```
