### PR TITLE
Fix Python paths in subfolders

### DIFF
--- a/src/scaffolding/wizard/python/PythonGatherInformationStep.ts
+++ b/src/scaffolding/wizard/python/PythonGatherInformationStep.ts
@@ -88,8 +88,8 @@ export class PythonGatherInformationStep extends GatherInformationStep<PythonSca
             asgiModule = wizardContext.pythonArtifact.file.replace(/\.[^/.]+$/, '');
         }
 
-        // Replace forward-slashes with dots.
-        asgiModule = asgiModule.replace(/\//g, '.');
+        // Replace slashes with dots.
+        asgiModule = asgiModule.replace(path.sep, '.');
 
         wizardContext.pythonCmdParts = [
             'gunicorn',
@@ -121,8 +121,8 @@ export class PythonGatherInformationStep extends GatherInformationStep<PythonSca
             wsgiModule = wizardContext.pythonArtifact.file.replace(/\.[^/.]+$/, '');
         }
 
-        // Replace forward-slashes with dots.
-        wsgiModule = wsgiModule.replace(/\//g, '.');
+        // Replace slashes with dots.
+        wsgiModule = wsgiModule.replace(path.sep, '.');
 
         wizardContext.pythonCmdParts = [
             'gunicorn',

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -69,7 +69,13 @@ export class PythonTaskHelper implements TaskHelper {
             runOptions.module = 'flask';
             runOptions.file = undefined;
         } else if (options.projectType === 'fastapi') {
-            runOptions.args.unshift(`${path.basename(runOptions.file, '.py')}:app`);
+            const basename = path.basename(runOptions.file, '.py');
+            const dirname = path.dirname(runOptions.file).replace(path.sep, '.');
+            if (dirname !== '.') {
+              runOptions.args.unshift(`${dirname}.${basename}:app`);
+            } else {
+              runOptions.args.unshift(`${basename}:app`);
+            }
             runOptions.module = 'uvicorn';
             runOptions.file = undefined;
         }


### PR DESCRIPTION
Related to #3533 I found this issue while testing. On Linux/Mac, the Python file path would have a forward slash, and this would work. On Windows however, it had a backslash, and the backslash was not replaced with a `.` as it should have been.