### PR TITLE
Update `@microsoft/vscode-azext-utils`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@microsoft/compose-language-service": "^0.1.1",
                 "@microsoft/vscode-azext-azureappservice": "^0.6.0",
                 "@microsoft/vscode-azext-azureutils": "^0.3.0",
-                "@microsoft/vscode-azext-utils": "^0.3.0",
+                "@microsoft/vscode-azext-utils": "^0.3.2",
                 "dayjs": "^1.10.4",
                 "dockerfile-language-server-nodejs": "^0.9.0",
                 "dockerode": "^3.2.1",
@@ -646,11 +646,11 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.0.tgz",
-            "integrity": "sha512-Pm/8OW68LgTcylmAuCIv8ZSKhzTf9jsFJrgrbkOz+QbbumqLs2hU2TekeiJdoo17p9gyES4xG6DiOQRakgSKag==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.2.tgz",
+            "integrity": "sha512-OJHU/svL5SU/ufi60s++nnHBgsXqmVXLeeS4qiRZhjPyBvuGOiRfN0Kz9R7K4YfUK+aJ8HOEdEm9U+NXz44QCw==",
             "dependencies": {
-                "@vscode/extension-telemetry": "^0.5.1",
+                "@vscode/extension-telemetry": "^0.5.2",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^5.1.1",
@@ -1131,9 +1131,9 @@
             "dev": true
         },
         "node_modules/@vscode/extension-telemetry": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.5.1.tgz",
-            "integrity": "sha512-cvFq8drxdLRF8KN72WcV4lTEa9GqDiRwy9EbnYuoSCD9Jdk8zHFF49MmACC1qs4R9Ko/C1uMOmeLJmVi8EA0rQ==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.5.2.tgz",
+            "integrity": "sha512-SiAv2PVXdNyHIx/CoOEKqzldy3Xh+3W2viy7bfSYs/SQZ4kZPAoi3JPVBg2SGpMZtQWcvyLFkLPsHYpSJYMq5Q==",
             "engines": {
                 "vscode": "^1.60.0"
             }
@@ -7743,11 +7743,11 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.0.tgz",
-            "integrity": "sha512-Pm/8OW68LgTcylmAuCIv8ZSKhzTf9jsFJrgrbkOz+QbbumqLs2hU2TekeiJdoo17p9gyES4xG6DiOQRakgSKag==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.2.tgz",
+            "integrity": "sha512-OJHU/svL5SU/ufi60s++nnHBgsXqmVXLeeS4qiRZhjPyBvuGOiRfN0Kz9R7K4YfUK+aJ8HOEdEm9U+NXz44QCw==",
             "requires": {
-                "@vscode/extension-telemetry": "^0.5.1",
+                "@vscode/extension-telemetry": "^0.5.2",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^5.1.1",
@@ -8123,9 +8123,9 @@
             "dev": true
         },
         "@vscode/extension-telemetry": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.5.1.tgz",
-            "integrity": "sha512-cvFq8drxdLRF8KN72WcV4lTEa9GqDiRwy9EbnYuoSCD9Jdk8zHFF49MmACC1qs4R9Ko/C1uMOmeLJmVi8EA0rQ=="
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.5.2.tgz",
+            "integrity": "sha512-SiAv2PVXdNyHIx/CoOEKqzldy3Xh+3W2viy7bfSYs/SQZ4kZPAoi3JPVBg2SGpMZtQWcvyLFkLPsHYpSJYMq5Q=="
         },
         "@vscode/test-electron": {
             "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -3142,7 +3142,7 @@
         "@microsoft/compose-language-service": "^0.1.1",
         "@microsoft/vscode-azext-azureappservice": "^0.6.0",
         "@microsoft/vscode-azext-azureutils": "^0.3.0",
-        "@microsoft/vscode-azext-utils": "^0.3.0",
+        "@microsoft/vscode-azext-utils": "^0.3.2",
         "dayjs": "^1.10.4",
         "dockerfile-language-server-nodejs": "^0.9.0",
         "dockerode": "^3.2.1",


### PR DESCRIPTION
Picks up a telemetry pipeline fix in upstream package: https://github.com/microsoft/vscode-extension-telemetry/issues/104