### PR TITLE
Update `protobufjs` to 6.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5314,9 +5314,9 @@
             "dev": true
         },
         "node_modules/protobufjs": {
-            "version": "6.11.2",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+            "version": "6.11.3",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+            "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
             "hasInstallScript": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
@@ -11250,9 +11250,9 @@
             "dev": true
         },
         "protobufjs": {
-            "version": "6.11.2",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+            "version": "6.11.3",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+            "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
             "requires": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",


### PR DESCRIPTION
Fixes CVE-2022-25878 and associated CG alert