### PR TITLE
Added option for running docker container in interactive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1128,6 +1128,11 @@
                                 "type": "string",
                                 "description": "%vscode-docker.tasks.docker-run.dockerRun.containerName%"
                             },
+                            "detached": {
+                                "type": "boolean",
+                                "description": "%vscode-docker.tasks.docker-run.dockerRun.detached%",
+                                "default": true
+                            },
                             "env": {
                                 "type": "object",
                                 "description": "%vscode-docker.tasks.docker-run.dockerRun.env%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -65,6 +65,7 @@
     "vscode-docker.tasks.docker-run.dockerRun.description": "Options for running the Docker container used for debugging. Learn more at https://aka.ms/vscode-docker-run-task",
     "vscode-docker.tasks.docker-run.dockerRun.command": "The command to run upon starting the container.",
     "vscode-docker.tasks.docker-run.dockerRun.containerName": "Name of the container used for debugging.",
+    "vscode-docker.tasks.docker-run.dockerRun.detached": "Whether or not to run detached.",
     "vscode-docker.tasks.docker-run.dockerRun.env": "Environment variables applied to the Docker container used for debugging.",
     "vscode-docker.tasks.docker-run.dockerRun.envFiles": "Files of environment variables read in and applied to the Docker container used for debugging.",
     "vscode-docker.tasks.docker-run.dockerRun.image": "The image to run.",

--- a/src/tasks/DockerRunTaskDefinitionBase.ts
+++ b/src/tasks/DockerRunTaskDefinitionBase.ts
@@ -27,6 +27,7 @@ export interface DockerContainerVolume {
 export interface DockerRunOptions {
     command?: string | ShellQuotedString[];
     containerName?: string;
+    detached?: boolean;
     entrypoint?: string;
     env?: { [key: string]: string };
     envFiles?: string[];

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -83,7 +83,8 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
 
     private async resolveCommandLine(runOptions: DockerRunOptions): Promise<CommandLineBuilder> {
         return CommandLineBuilder
-            .create(ext.dockerContextManager.getDockerCommand(), 'run', '-dt')
+            .create(ext.dockerContextManager.getDockerCommand(), 'run', '-t')
+            .withFlagArg('-d', runOptions.detached)
             .withFlagArg('-P', runOptions.portsPublishAll || (runOptions.portsPublishAll === undefined && (runOptions.ports === undefined || runOptions.ports.length < 1)))
             .withNamedArg('--name', runOptions.containerName)
             .withNamedArg('--network', runOptions.network)


### PR DESCRIPTION
I would like to propose this change to support interactive mode while running docker container from a task. Currently, there is no way to remove the `-d` flag as it is hard-coded. I tried to use the customRun option and passing in `-i` but it has no effect.