### PR TITLE
Add return to Build ACR Command

### DIFF
--- a/src/commands/registries/azure/tasks/buildImageInAzure.ts
+++ b/src/commands/registries/azure/tasks/buildImageInAzure.ts
@@ -21,7 +21,11 @@ export async function buildImageInAzure(context: IActionContext, uri?: vscode.Ur
     
     let run = await getRun();
     const { KnownRunStatus } = await getArmContainerRegistry();
-    while (run.status === KnownRunStatus.Running) {
+    while (
+        run.status === KnownRunStatus.Started ||
+        run.status === KnownRunStatus.Queued ||
+        run.status === KnownRunStatus.Running
+    ) {
         await delay(WAIT_MS);
         run = await getRun();
     }

--- a/src/commands/registries/azure/tasks/buildImageInAzure.ts
+++ b/src/commands/registries/azure/tasks/buildImageInAzure.ts
@@ -5,24 +5,29 @@
 
 import * as vscode from 'vscode';
 import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { KnownRunStatus, Run } from '@azure/arm-containerregistry';
+import type { Run } from '@azure/arm-containerregistry';
 import { scheduleRunRequest } from './scheduleRunRequest';
-import { sleep } from '../../../../utils/sleep';
+import { delay } from '../../../../utils/promiseUtils';
+import { getArmContainerRegistry } from '../../../../utils/lazyPackages';
 
-const WAIT_MS = 500;
+const WAIT_MS = 5000;
 
-export async function buildImageInAzure(context: IActionContext, uri?: vscode.Uri | undefined): Promise<Run> {
+export async function buildImageInAzure(context: IActionContext, uri?: vscode.Uri | undefined): Promise<Run | undefined> {
     if (!vscode.workspace.isTrusted) {
         throw new UserCancelledError('enforceTrust');
     }
 
     const getRun = await scheduleRunRequest(context, "DockerBuildRequest", uri);
+    
     let run = await getRun();
+    const { KnownRunStatus }= await getArmContainerRegistry();
     while (run.status === KnownRunStatus.Running) {
-        await sleep(WAIT_MS);
+        await delay(WAIT_MS);
         run = await getRun();
     }
 
+    // we are returning the run so that other extensions can consume this with the vscode.commands.executeCommand
+    // currently it is used by the ms-kubernetes-tools.aks-devx-tools extension (https://github.com/Azure/aks-devx-tools)
     return run;
 }
 

--- a/src/commands/registries/azure/tasks/buildImageInAzure.ts
+++ b/src/commands/registries/azure/tasks/buildImageInAzure.ts
@@ -20,7 +20,7 @@ export async function buildImageInAzure(context: IActionContext, uri?: vscode.Ur
     const getRun = await scheduleRunRequest(context, "DockerBuildRequest", uri);
     
     let run = await getRun();
-    const { KnownRunStatus }= await getArmContainerRegistry();
+    const { KnownRunStatus } = await getArmContainerRegistry();
     while (run.status === KnownRunStatus.Running) {
         await delay(WAIT_MS);
         run = await getRun();

--- a/src/commands/registries/azure/tasks/buildImageInAzure.ts
+++ b/src/commands/registries/azure/tasks/buildImageInAzure.ts
@@ -5,12 +5,24 @@
 
 import * as vscode from 'vscode';
 import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
+import { KnownRunStatus, Run } from '@azure/arm-containerregistry';
 import { scheduleRunRequest } from './scheduleRunRequest';
+import { sleep } from '../../../../utils/sleep';
 
-export async function buildImageInAzure(context: IActionContext, uri?: vscode.Uri | undefined): Promise<void> {
+const WAIT_MS = 500;
+
+export async function buildImageInAzure(context: IActionContext, uri?: vscode.Uri | undefined): Promise<Run> {
     if (!vscode.workspace.isTrusted) {
         throw new UserCancelledError('enforceTrust');
     }
 
-    await scheduleRunRequest(context, "DockerBuildRequest", uri);
+    const getRun = await scheduleRunRequest(context, "DockerBuildRequest", uri);
+    let run = await getRun();
+    while (run.status === KnownRunStatus.Running) {
+        await sleep(WAIT_MS);
+        run = await getRun();
+    }
+
+    return run;
 }
+

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,6 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
-export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));


### PR DESCRIPTION
This PR adds a return to the `buildImageInAzure` command. We want to use this command in the [Azure/aks-devx-tools](https://github.com/Azure/aks-devx-tools) extension and need run information returned to do this. Anything returned by the `buildImageInAzure` command can be retrieved by a calling extension with the `vscode.commands.executeCommand` function. 

For more background on why we need run information returned, we specifically need whether or not the command succeeded and the full image path that was built. Our goal is to easily let users go from source code to an AKS deployment with `Generate Dockerfile` -> `Build Dockerfile` -> `Generate K8s Manifests` -> `Run on AKS`. Instead of rebuilding the `Build Dockerfile` step we thought it would make sense to consume this extension. We walk users through each step so we need to know if the `buildImageInAzure` command succeeded or failed so we can guide appropriately. The full image name returned is used to autofill defaults for the `Generate K8s Manifests` step.

This code addition will allow other extensions to consume this command as well (if they have similar needs). Additionally, it will assist with a few open issues like #3614. This code reworks the `buildImageInAzure` command to wait for the run to be finished. It would be trivial to create a progress notification like #3614 requests with these changes.

Thank you for your time looking at this PR. I'm happy to discuss more!