### PR TITLE
Add another `Accept` header to image out-of-date check

### DIFF
--- a/src/tree/images/imageChecker/OutdatedImageChecker.ts
+++ b/src/tree/images/imageChecker/OutdatedImageChecker.ts
@@ -26,7 +26,7 @@ export class OutdatedImageChecker {
             headers: {
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 'X-Meta-Source-Client': ociClientId,
-                'Accept': 'application/vnd.docker.distribution.manifest.list.v2+json',
+                'Accept': 'application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json',
             },
         };
     }


### PR DESCRIPTION
Fixes #3696. I noticed that when using `Accept: application/vnd.docker.distribution.manifest.v2+json`, the expected result was returned for the MSSQL images, but not for the dotnet images. In contrast, when using `application/vnd.docker.distribution.manifest.list.v2+json` (which is what the current code does), it worked for dotnet but not MSSQL. When trying _both_, as suggested [here](https://docs.docker.com/registry/spec/manifest-v2-2/#backward-compatibility), everything worked for both types (and for Docker Hub too).