### PR TITLE
Bumps default python version to Python 3.10

### DIFF
--- a/resources/templates/python/Dockerfile.template
+++ b/resources/templates/python/Dockerfile.template
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 {{#if (isRootPort ports)}}
 # Warning: A port below 1024 has been exposed. This requires the image to run as a root user which is not a best practice.


### PR DESCRIPTION
resolves #3736 by changing the image from python 3.8-slim to 3.10-slim