### PR TITLE
Remove the extra diagnostic logging from execAsync

### DIFF
--- a/src/runtimes/clients/AutoConfigurableDockerClient.ts
+++ b/src/runtimes/clients/AutoConfigurableDockerClient.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { logCommandPath } from '../../utils/diagnostics';
 import { DockerClient } from '../docker';
 import { AutoConfigurableClient } from './AutoConfigurableClient';
 
@@ -21,7 +20,5 @@ export class AutoConfigurableDockerClient extends DockerClient implements AutoCo
         this.commandName = dockerCommand;
 
         ext.outputChannel.debug(`docker.dockerPath: ${this.commandName}`);
-
-        logCommandPath(ext.outputChannel, this.commandName);
     }
 }

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -3,12 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as stream from 'stream';
 import * as vscode from 'vscode';
-import { ext } from '../extensionVariables';
-import { CancellationError, CommandLineArgs, spawnStreamAsync, StreamSpawnOptions } from '../runtimes/docker';
-import { execAsync } from './execAsync';
-import { isLinux } from './osUtils';
 
 export function isLogLevelEnabled(outputChannel: vscode.LogOutputChannel, logLevel: vscode.LogLevel): boolean {
     return outputChannel && outputChannel.logLevel > 0 && outputChannel.logLevel <= logLevel;
@@ -61,104 +56,11 @@ export function logSystemInfo(outputChannel: vscode.LogOutputChannel): void {
         logProcessEnvironment(outputChannel);
 
         logDockerEnvironment(outputChannel);
-
-        // Linux specific system diagnostic logging
-        if (isLinux()) {
-            outputChannel.debug('--- System Info ---');
-            try {
-                execAsync('uname -a').catch(() => {/* Do not throw */ });
-            } catch {
-                // Do not throw for diagnostic logging
-            }
-
-            try {
-                execAsync('cat /etc/os-release').catch(() => {/* Do not throw */ });
-            } catch {
-                // Do not throw for diagnostic logging
-            }
-        }
     } else {
         systemInfoDisposable = outputChannel.onDidChangeLogLevel((logLevel) => {
             if (logLevel > vscode.LogLevel.Off && logLevel <= vscode.LogLevel.Debug) {
                 logSystemInfo(outputChannel);
             }
         });
-    }
-}
-
-export function logCommandPath(outputChannel: vscode.LogOutputChannel, command: string): void {
-    if (isLogLevelEnabled(outputChannel, vscode.LogLevel.Debug)) {
-        if (isLinux()) {
-            try {
-                execAsync(`which ${command}`).catch(() => {/* Do not throw errors */ });
-            } catch {
-                // Do not throw for diagnostic logging
-            }
-        }
-    }
-}
-
-export async function spawnStreamWithDiagnosticsAsync(
-    command: string,
-    args: CommandLineArgs,
-    options: StreamSpawnOptions,
-): Promise<void> {
-    let stdOutPipe: NodeJS.WritableStream | undefined = options.stdOutPipe;
-    if (ext.outputChannel.isDebugLoggingEnabled) {
-        const debugStdOutPipe = new stream.PassThrough();
-        debugStdOutPipe.on('data', (chunk: Buffer) => {
-            try {
-                ext.outputChannel.debug(chunk.toString());
-            } catch {
-                // Do not throw on diagnostic errors
-            }
-        });
-
-        if (stdOutPipe) {
-            debugStdOutPipe.pipe(stdOutPipe);
-        }
-        stdOutPipe = debugStdOutPipe;
-    }
-
-    const stdErrPipe = new stream.PassThrough();
-    stdErrPipe.on('data', (chunk: Buffer) => {
-        try {
-            ext.outputChannel.error(chunk.toString());
-        } catch {
-            // Do not throw on diagnostic errors
-        }
-    });
-
-    if (options.stdErrPipe) {
-        stdErrPipe.pipe(options.stdErrPipe);
-    }
-
-    const onCommand = (command) => {
-        ext.outputChannel.debug(command);
-        if (typeof options?.onCommand === 'function') {
-            options.onCommand(command);
-        }
-    };
-
-    options = {
-        ...options,
-        onCommand,
-        stdOutPipe,
-        stdErrPipe,
-    };
-
-    try {
-        return spawnStreamAsync(command, args, options);
-    } catch (err) {
-        if (err instanceof CancellationError || err instanceof vscode.CancellationError) {
-            ext.outputChannel.debug(err.message);
-        } else if (err instanceof Error) {
-            ext.outputChannel.error(err.message);
-        } else {
-            ext.outputChannel.error(`Unknown error: ${JSON.stringify(err)}`);
-        }
-
-        // Rethrow any errors
-        throw err;
     }
 }

--- a/src/utils/execAsync.ts
+++ b/src/utils/execAsync.ts
@@ -5,9 +5,8 @@
 
 import * as cp from 'child_process';
 import * as stream from 'stream';
-import { AccumulatorStream, Shell, StreamSpawnOptions } from '../runtimes/docker';
+import { AccumulatorStream, Shell, spawnStreamAsync, StreamSpawnOptions } from '../runtimes/docker';
 import { CancellationToken } from 'vscode';
-import { spawnStreamWithDiagnosticsAsync } from './diagnostics';
 
 type Progress = (content: string, err: boolean) => void;
 
@@ -58,7 +57,7 @@ export async function execAsync(command: string, options?: cp.ExecOptions & { st
         stdErrPipe: stderrIntermediate ?? stderrFinal,
     };
 
-    await spawnStreamWithDiagnosticsAsync(command, [], spawnOptions);
+    await spawnStreamAsync(command, [], spawnOptions);
 
     return {
         stdout: await stdoutFinal.getString(),


### PR DESCRIPTION
Ran into some issues testing the new execAsync diagnostic logging on Linux, so backing those specific changes out for now.