### PR TITLE
Change ACA contract to support `registryName` instead of `loginServer`

### DIFF
--- a/src/commands/registries/azure/deployImageToAca.ts
+++ b/src/commands/registries/azure/deployImageToAca.ts
@@ -57,7 +57,7 @@ export async function deployImageToAca(context: IActionContext, node?: RemoteTag
         }
 
         if (registry instanceof DockerHubNamespaceTreeItem || registry instanceof DockerV2RegistryTreeItemBase) {
-            // ACA preference for Docker Hub images to be prefixed with 'docker.io/...'
+            // Ensure Docker Hub images are prefixed with 'docker.io/...'
             if (!/^docker\.io\//i.test(commandOptions.image)) {
                 commandOptions.image = 'docker.io/' + commandOptions.image;
             }

--- a/src/tree/registries/dockerHub/DockerHubNamespaceTreeItem.ts
+++ b/src/tree/registries/dockerHub/DockerHubNamespaceTreeItem.ts
@@ -11,8 +11,6 @@ import { IDockerCliCredentials, RegistryTreeItemBase } from "../RegistryTreeItem
 import { DockerHubAccountTreeItem } from "./DockerHubAccountTreeItem";
 import { DockerHubRepositoryTreeItem } from "./DockerHubRepositoryTreeItem";
 
-const dockerHubRegistryUrl: string = 'https://index.docker.io/v1/';
-
 export class DockerHubNamespaceTreeItem extends RegistryTreeItemBase {
     public parent: DockerHubAccountTreeItem;
     public baseUrl: string = dockerHubUrl;
@@ -59,7 +57,7 @@ export class DockerHubNamespaceTreeItem extends RegistryTreeItemBase {
 
     public async getDockerCliCredentials(): Promise<IDockerCliCredentials> {
         return {
-            registryPath: dockerHubRegistryUrl,
+            registryPath: '',
             auth: {
                 username: this.parent.username,
                 password: await this.parent.getPassword()


### PR DESCRIPTION
See title.

Also reverted the Docker Hub registry path addition from my previous PR since we don't need it with this method