### PR TITLE
Changes to Scaffolding for .NET 8 Preview #3834

### DIFF
--- a/resources/templates/netCore/Dockerfile.template
+++ b/resources/templates/netCore/Dockerfile.template
@@ -12,11 +12,15 @@ ENV ASPNETCORE_URLS=http://+:{{ ports.[0] }}
 {{/if}}
 {{#unless (isRootPort ports)}}
 {{#if (eq netCorePlatformOS 'Linux')}}
+{{#if netCoreBaseImageDefaultUser }}
+USER {{ netCoreBaseImageDefaultUser }}
+{{else}}
 # Creates a non-root user with an explicit UID and adds permission to access the /app folder
 # For more info, please refer to https://aka.ms/vscode-docker-dotnet-configure-containers
 RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
+{{/if}}
 {{/if}}
 {{/unless}}
 FROM {{ netCoreSdkBaseImage }} AS build

--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -67,6 +67,7 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
                 wizardContext.netCoreSdkBaseImage = `${wizardContext.netCoreSdkBaseImage}-preview`;
             }
 
+            // change default user to adapt to Debian 12
             if (netCoreVersion.major >= 8) {
                 wizardContext.netCoreBaseImageDefaultUser = 'app';
             }

--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -60,6 +60,16 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             const netCoreVersion = semver.coerce(netCoreVersionString);
             wizardContext.netCoreRuntimeBaseImage = wizardContext.platform === '.NET: ASP.NET Core' ? `${aspNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}` : `${consoleNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}`;
             wizardContext.netCoreSdkBaseImage = `${netSdkImage}:${netCoreVersion.major}.${netCoreVersion.minor}`;
+
+            // append '-preview' at the end of version string to support new .NET 8 preview release naming
+            if (netCoreVersion.major === 8) {
+                wizardContext.netCoreRuntimeBaseImage = `${wizardContext.netCoreRuntimeBaseImage}-preview`;
+                wizardContext.netCoreSdkBaseImage = `${wizardContext.netCoreSdkBaseImage}-preview`;
+            }
+
+            if (netCoreVersion.major >= 8) {
+                wizardContext.netCoreBaseImageDefaultUser = 'app';
+            }
         }
 
         if (!wizardContext.serviceName) {

--- a/src/scaffolding/wizard/netCore/NetCoreScaffoldingWizardContext.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreScaffoldingWizardContext.ts
@@ -24,6 +24,7 @@ export interface NetCoreScaffoldingWizardContext extends ScaffoldingWizardContex
     netCoreRuntimeBaseImage?: string;
     netCoreSdkBaseImage?: string;
     netCorePlatformOS?: PlatformOS;
+    netCoreBaseImageDefaultUser?: string;
 }
 
 export function getNetCoreSubWizardOptions(wizardContext: ScaffoldingWizardContext): IWizardOptions<NetCoreScaffoldingWizardContext> {

--- a/src/tasks/netcore/NetCoreTaskHelper.ts
+++ b/src/tasks/netcore/NetCoreTaskHelper.ts
@@ -231,6 +231,12 @@ export class NetCoreTaskHelper implements TaskHelper {
                 permissions: 'ro'
             };
 
+            const nugetDefaultUserVolume: DockerContainerVolume = {
+                localPath: nugetRootVolume.localPath, // Same local path as the root one
+                containerPath: runOptions.os === 'Windows' ? 'C:\\Users\\ContainerUser\\.nuget\\packages' : '/home/app/.nuget/packages',
+                permissions: 'ro'
+            };
+
             addVolumeWithoutConflicts(volumes, appVolume);
             addVolumeWithoutConflicts(volumes, srcVolume);
             addVolumeWithoutConflicts(volumes, debuggerVolume);
@@ -239,6 +245,9 @@ export class NetCoreTaskHelper implements TaskHelper {
             }
             if (await fse.pathExists(nugetUserVolume.localPath)) {
                 addVolumeWithoutConflicts(volumes, nugetUserVolume);
+            }
+            if (await fse.pathExists(nugetDefaultUserVolume.localPath)) {
+                addVolumeWithoutConflicts(volumes, nugetDefaultUserVolume);
             }
         }
 


### PR DESCRIPTION
This PR addresses issue #3834 . 

This PR supports the change in naming convention for .NET 8 Docker tags & the change in `adduser` command for Debian 12.