### PR TITLE
Refactored localize to use new l10n API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
                 "tar": "^6.1.11",
                 "tree-kill": "^1.2.2",
                 "vscode-languageclient": "^8.0.2",
-                "vscode-nls": "^5.0.0",
                 "vscode-tas-client": "^0.1.22",
                 "xml2js": "^0.4.23"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
                 "@types/node": "16.x",
                 "@types/node-fetch": "^2.5.12",
                 "@types/semver": "^7.3.9",
-                "@types/vscode": "1.74.0",
+                "@types/vscode": "1.75.0",
                 "@types/xml2js": "^0.4.8",
                 "@typescript-eslint/eslint-plugin": "^5.19.0",
                 "@typescript-eslint/parser": "^5.19.0",
@@ -57,7 +57,7 @@
                 "webpack-cli": "^4.6.0"
             },
             "engines": {
-                "vscode": "^1.74.0"
+                "vscode": "^1.75.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -916,9 +916,9 @@
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.74.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
+            "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
             "dev": true
         },
         "node_modules/@types/xml2js": {
@@ -7534,9 +7534,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.74.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
+            "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
             "dev": true
         },
         "@types/xml2js": {

--- a/package.json
+++ b/package.json
@@ -2891,7 +2891,6 @@
         "tar": "^6.1.11",
         "tree-kill": "^1.2.2",
         "vscode-languageclient": "^8.0.2",
-        "vscode-nls": "^5.0.0",
         "vscode-tas-client": "^0.1.22",
         "xml2js": "^0.4.23"
     }

--- a/package.json
+++ b/package.json
@@ -2809,7 +2809,7 @@
         ]
     },
     "engines": {
-        "vscode": "^1.74.0"
+        "vscode": "^1.75.0"
     },
     "capabilities": {
         "virtualWorkspaces": false,
@@ -2854,7 +2854,7 @@
         "@types/node": "16.x",
         "@types/node-fetch": "^2.5.12",
         "@types/semver": "^7.3.9",
-        "@types/vscode": "1.74.0",
+        "@types/vscode": "1.75.0",
         "@types/xml2js": "^0.4.8",
         "@typescript-eslint/eslint-plugin": "^5.19.0",
         "@typescript-eslint/parser": "^5.19.0",

--- a/src/commands/compose/compose.ts
+++ b/src/commands/compose/compose.ts
@@ -6,7 +6,6 @@
 import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { Item, createFileItem, quickPickDockerComposeFileItem } from '../../utils/quickPickFile';
 import { quickPickWorkspaceFolder } from '../../utils/quickPickWorkspaceFolder';
@@ -21,7 +20,7 @@ async function compose(context: IActionContext, commands: ('up' | 'down' | 'upSu
     // If a file is chosen, get its workspace folder, otherwise, require the user to choose
     // If a file is chosen that is not in a workspace, it will automatically fall back to quickPickWorkspaceFolder
     const folder: vscode.WorkspaceFolder = (dockerComposeFileUri ? vscode.workspace.getWorkspaceFolder(dockerComposeFileUri) : undefined) ||
-        await quickPickWorkspaceFolder(context, l10n.t('To run Docker compose you must first open a folder or workspace in VS Code.'));
+        await quickPickWorkspaceFolder(context, vscode.l10n.t('To run Docker compose you must first open a folder or workspace in VS Code.'));
 
     let commandParameterFileUris: vscode.Uri[];
     if (selectedComposeFileUris && selectedComposeFileUris.length) {
@@ -74,19 +73,19 @@ async function compose(context: IActionContext, commands: ('up' | 'down' | 'upSu
 }
 
 export async function composeUp(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
-    return await compose(context, ['up'], l10n.t('Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
+    return await compose(context, ['up'], vscode.l10n.t('Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
 export async function composeUpSubset(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
-    return await compose(context, ['upSubset'], l10n.t('Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
+    return await compose(context, ['upSubset'], vscode.l10n.t('Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
 export async function composeDown(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
-    return await compose(context, ['down'], l10n.t('Choose Docker Compose file to take down'), dockerComposeFileUri, selectedComposeFileUris);
+    return await compose(context, ['down'], vscode.l10n.t('Choose Docker Compose file to take down'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
 export async function composeRestart(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
-    return await compose(context, ['down', 'up'], l10n.t('Choose Docker Compose file to restart'), dockerComposeFileUri, selectedComposeFileUris);
+    return await compose(context, ['down', 'up'], vscode.l10n.t('Choose Docker Compose file to restart'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
 const serviceListPlaceholder = /\${serviceList}/i;

--- a/src/commands/compose/compose.ts
+++ b/src/commands/compose/compose.ts
@@ -6,7 +6,7 @@
 import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { Item, createFileItem, quickPickDockerComposeFileItem } from '../../utils/quickPickFile';
 import { quickPickWorkspaceFolder } from '../../utils/quickPickWorkspaceFolder';
@@ -21,7 +21,7 @@ async function compose(context: IActionContext, commands: ('up' | 'down' | 'upSu
     // If a file is chosen, get its workspace folder, otherwise, require the user to choose
     // If a file is chosen that is not in a workspace, it will automatically fall back to quickPickWorkspaceFolder
     const folder: vscode.WorkspaceFolder = (dockerComposeFileUri ? vscode.workspace.getWorkspaceFolder(dockerComposeFileUri) : undefined) ||
-        await quickPickWorkspaceFolder(context, localize('vscode-docker.commands.compose.workspaceFolder', 'To run Docker compose you must first open a folder or workspace in VS Code.'));
+        await quickPickWorkspaceFolder(context, l10n.t('To run Docker compose you must first open a folder or workspace in VS Code.'));
 
     let commandParameterFileUris: vscode.Uri[];
     if (selectedComposeFileUris && selectedComposeFileUris.length) {
@@ -74,19 +74,19 @@ async function compose(context: IActionContext, commands: ('up' | 'down' | 'upSu
 }
 
 export async function composeUp(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
-    return await compose(context, ['up'], localize('vscode-docker.commands.compose.chooseUp', 'Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
+    return await compose(context, ['up'], l10n.t('Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
 export async function composeUpSubset(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
-    return await compose(context, ['upSubset'], localize('vscode-docker.commands.compose.chooseUpSubset', 'Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
+    return await compose(context, ['upSubset'], l10n.t('Choose Docker Compose file to bring up'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
 export async function composeDown(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
-    return await compose(context, ['down'], localize('vscode-docker.commands.compose.chooseDown', 'Choose Docker Compose file to take down'), dockerComposeFileUri, selectedComposeFileUris);
+    return await compose(context, ['down'], l10n.t('Choose Docker Compose file to take down'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
 export async function composeRestart(context: IActionContext, dockerComposeFileUri?: vscode.Uri, selectedComposeFileUris?: vscode.Uri[]): Promise<void> {
-    return await compose(context, ['down', 'up'], localize('vscode-docker.commands.compose.chooseRestart', 'Choose Docker Compose file to restart'), dockerComposeFileUri, selectedComposeFileUris);
+    return await compose(context, ['down', 'up'], l10n.t('Choose Docker Compose file to restart'), dockerComposeFileUri, selectedComposeFileUris);
 }
 
 const serviceListPlaceholder = /\${serviceList}/i;

--- a/src/commands/compose/getComposeSubsetList.ts
+++ b/src/commands/compose/getComposeSubsetList.ts
@@ -6,7 +6,7 @@
 import { IActionContext, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { execAsync } from '../../utils/execAsync';
 
 // Matches an `up` or `down` and everything after it--so that it can be replaced with `config --services`, to get a service list using all of the files originally part of the compose command
@@ -23,16 +23,16 @@ export async function getComposeProfilesOrServices(context: IActionContext, work
     if (profiles?.length) {
         const profilesOrServices: IAzureQuickPickItem<SubsetType>[] = [
             {
-                label: localize('vscode-docker.getComposeSubsetList.services', 'Services'),
+                label: l10n.t('Services'),
                 data: 'services'
             },
             {
-                label: localize('vscode-docker.getComposeSubsetList.profiles', 'Profiles'),
+                label: l10n.t('Profiles'),
                 data: 'profiles'
             }
         ];
 
-        useProfiles = 'profiles' === (await context.ui.showQuickPick(profilesOrServices, { placeHolder: localize('vscode-docker.getComposeSubsetList.servicesOrProfiles', 'Do you want to start services or profiles?') })).data;
+        useProfiles = 'profiles' === (await context.ui.showQuickPick(profilesOrServices, { placeHolder: l10n.t('Do you want to start services or profiles?') })).data;
     }
 
     return {
@@ -65,7 +65,7 @@ export async function getComposeServiceList(context: IActionContext, workspaceFo
 
     if (!services?.length) {
         context.errorHandling.suppressReportIssue = true;
-        throw new Error(localize('vscode-docker.getComposeSubsetList.noServices', 'No services were found in the compose document(s). Did you mean to use profiles instead?'));
+        throw new Error(l10n.t('No services were found in the compose document(s). Did you mean to use profiles instead?'));
     }
 
     // Fetch the previously chosen services list. By default, all will be selected.
@@ -81,8 +81,8 @@ export async function getComposeServiceList(context: IActionContext, workspaceFo
 
 async function pickSubsets(context: IActionContext, type: SubsetType, allChoices: string[], previousChoices: string[]): Promise<string[]> {
     const label = type === 'profiles' ?
-        localize('vscode-docker.getComposeSubsetList.chooseProfiles', 'Choose profiles to start') :
-        localize('vscode-docker.getComposeSubsetList.choose', 'Choose services to start');
+        l10n.t('Choose profiles to start') :
+        l10n.t('Choose services to start');
 
     const pickChoices: IAzureQuickPickItem<string>[] = allChoices.map(s => ({
         label: s,

--- a/src/commands/compose/getComposeSubsetList.ts
+++ b/src/commands/compose/getComposeSubsetList.ts
@@ -6,7 +6,6 @@
 import { IActionContext, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { execAsync } from '../../utils/execAsync';
 
 // Matches an `up` or `down` and everything after it--so that it can be replaced with `config --services`, to get a service list using all of the files originally part of the compose command
@@ -23,16 +22,16 @@ export async function getComposeProfilesOrServices(context: IActionContext, work
     if (profiles?.length) {
         const profilesOrServices: IAzureQuickPickItem<SubsetType>[] = [
             {
-                label: l10n.t('Services'),
+                label: vscode.l10n.t('Services'),
                 data: 'services'
             },
             {
-                label: l10n.t('Profiles'),
+                label: vscode.l10n.t('Profiles'),
                 data: 'profiles'
             }
         ];
 
-        useProfiles = 'profiles' === (await context.ui.showQuickPick(profilesOrServices, { placeHolder: l10n.t('Do you want to start services or profiles?') })).data;
+        useProfiles = 'profiles' === (await context.ui.showQuickPick(profilesOrServices, { placeHolder: vscode.l10n.t('Do you want to start services or profiles?') })).data;
     }
 
     return {
@@ -65,7 +64,7 @@ export async function getComposeServiceList(context: IActionContext, workspaceFo
 
     if (!services?.length) {
         context.errorHandling.suppressReportIssue = true;
-        throw new Error(l10n.t('No services were found in the compose document(s). Did you mean to use profiles instead?'));
+        throw new Error(vscode.l10n.t('No services were found in the compose document(s). Did you mean to use profiles instead?'));
     }
 
     // Fetch the previously chosen services list. By default, all will be selected.
@@ -81,8 +80,8 @@ export async function getComposeServiceList(context: IActionContext, workspaceFo
 
 async function pickSubsets(context: IActionContext, type: SubsetType, allChoices: string[], previousChoices: string[]): Promise<string[]> {
     const label = type === 'profiles' ?
-        l10n.t('Choose profiles to start') :
-        l10n.t('Choose services to start');
+        vscode.l10n.t('Choose profiles to start') :
+        vscode.l10n.t('Choose services to start');
 
     const pickChoices: IAzureQuickPickItem<string>[] = allChoices.map(s => ({
         label: s,

--- a/src/commands/containers/attachShellContainer.ts
+++ b/src/commands/containers/attachShellContainer.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContainerOS, VoidCommandResponse } from '../../runtimes/docker';
 import { IActionContext } from '@microsoft/vscode-azext-utils';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
+import { ContainerOS, VoidCommandResponse } from '../../runtimes/docker';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { getDockerOSType } from '../../utils/osUtils';

--- a/src/commands/containers/attachShellContainer.ts
+++ b/src/commands/containers/attachShellContainer.ts
@@ -6,7 +6,7 @@
 import { ContainerOS, VoidCommandResponse } from '../../runtimes/docker';
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { getDockerOSType } from '../../utils/osUtils';
@@ -17,7 +17,7 @@ export async function attachShellContainer(context: IActionContext, node?: Conta
         await ext.containersTree.refresh(context);
         node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.runningContainerRegExp, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.containers.attachShellContainer.noContainers', 'No running containers are available to attach')
+            noItemFoundErrorMessage: l10n.t('No running containers are available to attach')
         });
     }
 
@@ -52,7 +52,7 @@ export async function attachShellContainer(context: IActionContext, node?: Conta
     );
 
     const taskCRF = new TaskCommandRunnerFactory({
-        taskName: localize('vscode-docker.commands.containers.attachShellContainer.terminalTitle', 'Shell: {0}', node.containerName),
+        taskName: l10n.t('Shell: {0}', node.containerName),
         alwaysRunNew: true,
         focus: true,
     });

--- a/src/commands/containers/browseContainer.ts
+++ b/src/commands/containers/browseContainer.ts
@@ -7,7 +7,7 @@ import { PortBinding } from '../../runtimes/docker';
 import { IActionContext, IAzureQuickPickItem, TelemetryProperties } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ContainerTreeItem } from "../../tree/containers/ContainerTreeItem";
 
 type BrowseTelemetryProperties = TelemetryProperties & { possiblePorts?: string, selectedPort?: string };
@@ -77,7 +77,7 @@ export async function browseContainer(context: IActionContext, node?: ContainerT
         await ext.containersTree.refresh(context);
         node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.runningContainerRegExp, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.containers.browseContainer.noContainers', 'No running containers are available to open in a browser')
+            noItemFoundErrorMessage: l10n.t('No running containers are available to open in a browser')
         });
     }
 
@@ -92,7 +92,7 @@ export async function browseContainer(context: IActionContext, node?: ContainerT
     telemetryProperties.possiblePorts = browsablePorts.map(port => port.containerPort).toString();
 
     if (browsablePorts.length === 0) {
-        void context.ui.showWarningMessage(localize('vscode-docker.commands.containers.browseContainer.noPorts', 'No valid ports are available.'));
+        void context.ui.showWarningMessage(l10n.t('No valid ports are available.'));
         return;
     }
 
@@ -120,7 +120,7 @@ export async function browseContainer(context: IActionContext, node?: ContainerT
         items.sort((a, b) => a.data.containerPort - b.data.containerPort);
 
         /* eslint-disable-next-line @typescript-eslint/promise-function-async */
-        const item = await context.ui.showQuickPick(items, { stepName: 'port', placeHolder: localize('vscode-docker.commands.containers.browseContainer.selectContainerPort', 'Select the container port to browse to.') });
+        const item = await context.ui.showQuickPick(items, { stepName: 'port', placeHolder: l10n.t('Select the container port to browse to.') });
 
         // NOTE: If the user cancels the prompt, then a UserCancelledError exception would be thrown.
 

--- a/src/commands/containers/browseContainer.ts
+++ b/src/commands/containers/browseContainer.ts
@@ -7,7 +7,6 @@ import { PortBinding } from '../../runtimes/docker';
 import { IActionContext, IAzureQuickPickItem, TelemetryProperties } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from "../../extensionVariables";
-import { l10n } from 'vscode';
 import { ContainerTreeItem } from "../../tree/containers/ContainerTreeItem";
 
 type BrowseTelemetryProperties = TelemetryProperties & { possiblePorts?: string, selectedPort?: string };
@@ -77,7 +76,7 @@ export async function browseContainer(context: IActionContext, node?: ContainerT
         await ext.containersTree.refresh(context);
         node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.runningContainerRegExp, {
             ...context,
-            noItemFoundErrorMessage: l10n.t('No running containers are available to open in a browser')
+            noItemFoundErrorMessage: vscode.l10n.t('No running containers are available to open in a browser')
         });
     }
 
@@ -92,7 +91,7 @@ export async function browseContainer(context: IActionContext, node?: ContainerT
     telemetryProperties.possiblePorts = browsablePorts.map(port => port.containerPort).toString();
 
     if (browsablePorts.length === 0) {
-        void context.ui.showWarningMessage(l10n.t('No valid ports are available.'));
+        void context.ui.showWarningMessage(vscode.l10n.t('No valid ports are available.'));
         return;
     }
 
@@ -120,7 +119,7 @@ export async function browseContainer(context: IActionContext, node?: ContainerT
         items.sort((a, b) => a.data.containerPort - b.data.containerPort);
 
         /* eslint-disable-next-line @typescript-eslint/promise-function-async */
-        const item = await context.ui.showQuickPick(items, { stepName: 'port', placeHolder: l10n.t('Select the container port to browse to.') });
+        const item = await context.ui.showQuickPick(items, { stepName: 'port', placeHolder: vscode.l10n.t('Select the container port to browse to.') });
 
         // NOTE: If the user cancels the prompt, then a UserCancelledError exception would be thrown.
 

--- a/src/commands/containers/composeGroup.ts
+++ b/src/commands/containers/composeGroup.ts
@@ -7,7 +7,7 @@ import { CommonOrchestratorCommandOptions, IContainerOrchestratorClient, LogsCom
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ContainerGroupTreeItem } from '../../tree/containers/ContainerGroupTreeItem';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
@@ -45,7 +45,7 @@ async function composeGroup<TOptions extends CommonOrchestratorCommandOptions>(
         await ext.containersTree.refresh(context);
         node = await ext.containersTree.showTreeItemPicker<ContainerGroupTreeItem>(/composeGroup$/i, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.containers.composeGroup.noComposeProjects', 'No Docker Compose projects are running.'),
+            noItemFoundErrorMessage: l10n.t('No Docker Compose projects are running.'),
         });
     }
 
@@ -56,7 +56,7 @@ async function composeGroup<TOptions extends CommonOrchestratorCommandOptions>(
 
     if (!workingDirectory || !orchestratorFiles || !projectName) {
         context.errorHandling.suppressReportIssue = true;
-        throw new Error(localize('vscode-docker.commands.containers.composeGroup.noCompose', 'Unable to determine compose project info for container group \'{0}\'.', node.label));
+        throw new Error(l10n.t('Unable to determine compose project info for container group \'{0}\'.', node.label));
     }
 
     const options: TOptions = {

--- a/src/commands/containers/composeGroup.ts
+++ b/src/commands/containers/composeGroup.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CommonOrchestratorCommandOptions, IContainerOrchestratorClient, LogsCommandOptions, VoidCommandResponse } from '../../runtimes/docker';
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
+import { CommonOrchestratorCommandOptions, IContainerOrchestratorClient, LogsCommandOptions, VoidCommandResponse } from '../../runtimes/docker';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ContainerGroupTreeItem } from '../../tree/containers/ContainerGroupTreeItem';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';

--- a/src/commands/containers/files/downloadContainerFile.ts
+++ b/src/commands/containers/files/downloadContainerFile.ts
@@ -7,7 +7,7 @@ import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-util
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ext } from '../../../extensionVariables';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { FileTreeItem } from '../../../tree/containers/files/FileTreeItem';
 import { multiSelectNodes } from '../../../utils/multiSelectNodes';
 
@@ -25,20 +25,20 @@ async function fileExists(file: vscode.Uri): Promise<boolean> {
 }
 
 const overwriteFile: vscode.MessageItem = {
-    title: localize('vscode-docker.commands.containers.files.downloadContainerFile.overwriteFile', 'Overwrite File')
+    title: l10n.t('Overwrite File')
 };
 
 const skipFile: vscode.MessageItem = {
-    title: localize('vscode-docker.commands.containers.files.downloadContainerFile.skipFile', 'Skip File')
+    title: l10n.t('Skip File')
 };
 
 const cancelDownload: vscode.MessageItem = {
-    title: localize('vscode-docker.commands.containers.files.downloadContainerFile.cancelDownload', 'Cancel')
+    title: l10n.t('Cancel')
 };
 
 export async function downloadContainerFile(context: IActionContext, node?: FileTreeItem, nodes?: FileTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: localize('vscode-docker.commands.containers.files.downloadContainerFile.noFiles', 'No files are available to download.') },
+        { ...context, noItemFoundErrorMessage: l10n.t('No files are available to download.') },
         ext.containersTree,
         'containerFile',
         node,
@@ -50,8 +50,8 @@ export async function downloadContainerFile(context: IActionContext, node?: File
             canSelectFiles: false,
             canSelectFolders: true,
             canSelectMany: false,
-            openLabel: localize('vscode-docker.commands.containers.files.downloadContainerFile.openLabel', 'Select'),
-            title: localize('vscode-docker.commands.containers.files.downloadContainerFile.openTitle', 'Select folder for download')
+            openLabel: l10n.t('Select'),
+            title: l10n.t('Select folder for download')
         });
 
     if (localFolderUris === undefined || localFolderUris.length === 0) {
@@ -74,7 +74,7 @@ export async function downloadContainerFile(context: IActionContext, node?: File
     await vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
-            title: localize('vscode-docker.commands.containers.files.downloadContainerFile.opening', 'Downloading File(s)...'),
+            title: l10n.t('Downloading File(s)...'),
             cancellable: true
         },
         async (task, token) => {
@@ -87,7 +87,7 @@ export async function downloadContainerFile(context: IActionContext, node?: File
 
                 if (localFileExists) {
                     const result = await vscode.window.showWarningMessage(
-                        localize('vscode-docker.commands.containers.files.downloadContainerFile.existingFileWarning', 'The file \'{0}\' already exists in folder \'{1}\'.', file.fileName, localFolderUri.fsPath),
+                        l10n.t('The file \'{0}\' already exists in folder \'{1}\'.', file.fileName, localFolderUri.fsPath),
                         overwriteFile,
                         skipFile,
                         cancelDownload);

--- a/src/commands/containers/files/downloadContainerFile.ts
+++ b/src/commands/containers/files/downloadContainerFile.ts
@@ -7,7 +7,6 @@ import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-util
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ext } from '../../../extensionVariables';
-import { l10n } from 'vscode';
 import { FileTreeItem } from '../../../tree/containers/files/FileTreeItem';
 import { multiSelectNodes } from '../../../utils/multiSelectNodes';
 
@@ -25,20 +24,20 @@ async function fileExists(file: vscode.Uri): Promise<boolean> {
 }
 
 const overwriteFile: vscode.MessageItem = {
-    title: l10n.t('Overwrite File')
+    title: vscode.l10n.t('Overwrite File')
 };
 
 const skipFile: vscode.MessageItem = {
-    title: l10n.t('Skip File')
+    title: vscode.l10n.t('Skip File')
 };
 
 const cancelDownload: vscode.MessageItem = {
-    title: l10n.t('Cancel')
+    title: vscode.l10n.t('Cancel')
 };
 
 export async function downloadContainerFile(context: IActionContext, node?: FileTreeItem, nodes?: FileTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: l10n.t('No files are available to download.') },
+        { ...context, noItemFoundErrorMessage: vscode.l10n.t('No files are available to download.') },
         ext.containersTree,
         'containerFile',
         node,
@@ -50,8 +49,8 @@ export async function downloadContainerFile(context: IActionContext, node?: File
             canSelectFiles: false,
             canSelectFolders: true,
             canSelectMany: false,
-            openLabel: l10n.t('Select'),
-            title: l10n.t('Select folder for download')
+            openLabel: vscode.l10n.t('Select'),
+            title: vscode.l10n.t('Select folder for download')
         });
 
     if (localFolderUris === undefined || localFolderUris.length === 0) {
@@ -74,7 +73,7 @@ export async function downloadContainerFile(context: IActionContext, node?: File
     await vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
-            title: l10n.t('Downloading File(s)...'),
+            title: vscode.l10n.t('Downloading File(s)...'),
             cancellable: true
         },
         async (task, token) => {
@@ -87,7 +86,7 @@ export async function downloadContainerFile(context: IActionContext, node?: File
 
                 if (localFileExists) {
                     const result = await vscode.window.showWarningMessage(
-                        l10n.t('The file \'{0}\' already exists in folder \'{1}\'.', file.fileName, localFolderUri.fsPath),
+                        vscode.l10n.t('The file \'{0}\' already exists in folder \'{1}\'.', file.fileName, localFolderUri.fsPath),
                         overwriteFile,
                         skipFile,
                         cancelDownload);

--- a/src/commands/containers/files/openContainerFile.ts
+++ b/src/commands/containers/files/openContainerFile.ts
@@ -6,14 +6,13 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../../extensionVariables';
-import { l10n } from 'vscode';
 import { FileTreeItem } from '../../../tree/containers/files/FileTreeItem';
 import { multiSelectNodes } from '../../../utils/multiSelectNodes';
 import { getCancelPromise } from '../../../utils/promiseUtils';
 
 export async function openContainerFile(context: IActionContext, node?: FileTreeItem, nodes?: FileTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: l10n.t('No files are available to open.') },
+        { ...context, noItemFoundErrorMessage: vscode.l10n.t('No files are available to open.') },
         ext.containersTree,
         'containerFile',
         node,
@@ -23,7 +22,7 @@ export async function openContainerFile(context: IActionContext, node?: FileTree
     await vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
-            title: l10n.t('Opening File(s)...'),
+            title: vscode.l10n.t('Opening File(s)...'),
             cancellable: true
         },
         async (task, token) => {

--- a/src/commands/containers/files/openContainerFile.ts
+++ b/src/commands/containers/files/openContainerFile.ts
@@ -6,14 +6,14 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../../extensionVariables';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { FileTreeItem } from '../../../tree/containers/files/FileTreeItem';
 import { multiSelectNodes } from '../../../utils/multiSelectNodes';
 import { getCancelPromise } from '../../../utils/promiseUtils';
 
 export async function openContainerFile(context: IActionContext, node?: FileTreeItem, nodes?: FileTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: localize('vscode-docker.commands.containers.files.openContainerFile.noFiles', 'No files are available to open.') },
+        { ...context, noItemFoundErrorMessage: l10n.t('No files are available to open.') },
         ext.containersTree,
         'containerFile',
         node,
@@ -23,7 +23,7 @@ export async function openContainerFile(context: IActionContext, node?: FileTree
     await vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
-            title: localize('vscode-docker.commands.containers.files.openContainerFile.opening', 'Opening File(s)...'),
+            title: l10n.t('Opening File(s)...'),
             cancellable: true
         },
         async (task, token) => {

--- a/src/commands/containers/inspectContainer.ts
+++ b/src/commands/containers/inspectContainer.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext, openReadOnlyJson } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ContainerTreeItem } from "../../tree/containers/ContainerTreeItem";
 
 export async function inspectContainer(context: IActionContext, node?: ContainerTreeItem): Promise<void> {
@@ -13,7 +13,7 @@ export async function inspectContainer(context: IActionContext, node?: Container
         await ext.containersTree.refresh(context);
         node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.allContextRegExp, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.containers.inspect.noContainers', 'No containers are available to inspect')
+            noItemFoundErrorMessage: l10n.t('No containers are available to inspect')
         });
     }
 

--- a/src/commands/containers/inspectContainer.ts
+++ b/src/commands/containers/inspectContainer.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, openReadOnlyJson } from "@microsoft/vscode-azext-utils";
-import { ext } from "../../extensionVariables";
 import { l10n } from 'vscode';
+import { ext } from "../../extensionVariables";
 import { ContainerTreeItem } from "../../tree/containers/ContainerTreeItem";
 
 export async function inspectContainer(context: IActionContext, node?: ContainerTreeItem): Promise<void> {

--- a/src/commands/containers/pruneContainers.ts
+++ b/src/commands/containers/pruneContainers.ts
@@ -6,16 +6,15 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { convertToMB } from '../../utils/convertToMB';
 
 export async function pruneContainers(context: IActionContext): Promise<void> {
-    const confirmPrune: string = l10n.t('Are you sure you want to remove all stopped containers?');
+    const confirmPrune: string = vscode.l10n.t('Are you sure you want to remove all stopped containers?');
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: l10n.t('Remove') });
+    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: vscode.l10n.t('Remove') });
 
     await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: l10n.t('Pruning containers...') },
+        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Pruning containers...') },
         async () => {
             const result = await ext.runWithDefaults(client =>
                 client.pruneContainers({})
@@ -23,9 +22,9 @@ export async function pruneContainers(context: IActionContext): Promise<void> {
 
             let message: string;
             if (result?.containersDeleted?.length && Number.isInteger(result?.spaceReclaimed)) {
-                message = l10n.t('Removed {0} stopped container(s) and reclaimed {1} MB of space.', result.containersDeleted.length, convertToMB(result.spaceReclaimed));
+                message = vscode.l10n.t('Removed {0} stopped container(s) and reclaimed {1} MB of space.', result.containersDeleted.length, convertToMB(result.spaceReclaimed));
             } else {
-                message = l10n.t('Removed stopped containers.');
+                message = vscode.l10n.t('Removed stopped containers.');
             }
 
             // Don't wait

--- a/src/commands/containers/pruneContainers.ts
+++ b/src/commands/containers/pruneContainers.ts
@@ -6,16 +6,16 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { convertToMB } from '../../utils/convertToMB';
 
 export async function pruneContainers(context: IActionContext): Promise<void> {
-    const confirmPrune: string = localize('vscode-docker.commands.containers.prune.confirm', 'Are you sure you want to remove all stopped containers?');
+    const confirmPrune: string = l10n.t('Are you sure you want to remove all stopped containers?');
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: localize('vscode-docker.commands.containers.prune.remove', 'Remove') });
+    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: l10n.t('Remove') });
 
     await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: localize('vscode-docker.commands.containers.pruning', 'Pruning containers...') },
+        { location: vscode.ProgressLocation.Notification, title: l10n.t('Pruning containers...') },
         async () => {
             const result = await ext.runWithDefaults(client =>
                 client.pruneContainers({})
@@ -23,9 +23,9 @@ export async function pruneContainers(context: IActionContext): Promise<void> {
 
             let message: string;
             if (result?.containersDeleted?.length && Number.isInteger(result?.spaceReclaimed)) {
-                message = localize('vscode-docker.commands.containers.prune.removed', 'Removed {0} stopped container(s) and reclaimed {1} MB of space.', result.containersDeleted.length, convertToMB(result.spaceReclaimed));
+                message = l10n.t('Removed {0} stopped container(s) and reclaimed {1} MB of space.', result.containersDeleted.length, convertToMB(result.spaceReclaimed));
             } else {
-                message = localize('vscode-docker.commands.containers.prune.removed2', 'Removed stopped containers.');
+                message = l10n.t('Removed stopped containers.');
             }
 
             // Don't wait

--- a/src/commands/containers/removeContainer.ts
+++ b/src/commands/containers/removeContainer.ts
@@ -6,13 +6,13 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function removeContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: localize('vscode-docker.commands.containers.remove.noContainers', 'No containers are available to remove') },
+        { ...context, noItemFoundErrorMessage: l10n.t('No containers are available to remove') },
         ext.containersTree,
         ContainerTreeItem.allContextRegExp,
         node,
@@ -21,15 +21,15 @@ export async function removeContainer(context: IActionContext, node?: ContainerT
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = localize('vscode-docker.commands.containers.remove.confirmSingle', 'Are you sure you want to remove container "{0}"?', nodes[0].label);
+        confirmRemove = l10n.t('Are you sure you want to remove container "{0}"?', nodes[0].label);
     } else {
-        confirmRemove = localize('vscode-docker.commands.containers.remove.confirmMulti', 'Are you sure you want to remove selected containers?');
+        confirmRemove = l10n.t('Are you sure you want to remove selected containers?');
     }
 
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: localize('vscode-docker.commands.containers.remove.remove', 'Remove') });
+    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: l10n.t('Remove') });
 
-    const removing: string = localize('vscode-docker.commands.containers.remove.removing', 'Removing container(s)...');
+    const removing: string = l10n.t('Removing container(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removing }, async () => {
         await Promise.all(nodes.map(async n => await n.deleteTreeItem(context)));
     });

--- a/src/commands/containers/removeContainer.ts
+++ b/src/commands/containers/removeContainer.ts
@@ -6,13 +6,12 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function removeContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: l10n.t('No containers are available to remove') },
+        { ...context, noItemFoundErrorMessage: vscode.l10n.t('No containers are available to remove') },
         ext.containersTree,
         ContainerTreeItem.allContextRegExp,
         node,
@@ -21,15 +20,15 @@ export async function removeContainer(context: IActionContext, node?: ContainerT
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = l10n.t('Are you sure you want to remove container "{0}"?', nodes[0].label);
+        confirmRemove = vscode.l10n.t('Are you sure you want to remove container "{0}"?', nodes[0].label);
     } else {
-        confirmRemove = l10n.t('Are you sure you want to remove selected containers?');
+        confirmRemove = vscode.l10n.t('Are you sure you want to remove selected containers?');
     }
 
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: l10n.t('Remove') });
+    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: vscode.l10n.t('Remove') });
 
-    const removing: string = l10n.t('Removing container(s)...');
+    const removing: string = vscode.l10n.t('Removing container(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removing }, async () => {
         await Promise.all(nodes.map(async n => await n.deleteTreeItem(context)));
     });

--- a/src/commands/containers/restartContainer.ts
+++ b/src/commands/containers/restartContainer.ts
@@ -6,20 +6,20 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function restartContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: localize('vscode-docker.commands.containers.restart.noContainers', 'No containers are available to restart') },
+        { ...context, noItemFoundErrorMessage: l10n.t('No containers are available to restart') },
         ext.containersTree,
         /^(created|dead|exited|paused|running|terminated)Container$/i,
         node,
         nodes
     );
 
-    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('vscode-docker.commands.containers.restart.restarting', 'Restarting Container(s)...') }, async () => {
+    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: l10n.t('Restarting Container(s)...') }, async () => {
         await ext.runWithDefaults(client =>
             client.restartContainers({ container: nodes.map(n => n.containerId) })
         );

--- a/src/commands/containers/restartContainer.ts
+++ b/src/commands/containers/restartContainer.ts
@@ -6,20 +6,19 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function restartContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: l10n.t('No containers are available to restart') },
+        { ...context, noItemFoundErrorMessage: vscode.l10n.t('No containers are available to restart') },
         ext.containersTree,
         /^(created|dead|exited|paused|running|terminated)Container$/i,
         node,
         nodes
     );
 
-    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: l10n.t('Restarting Container(s)...') }, async () => {
+    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Restarting Container(s)...') }, async () => {
         await ext.runWithDefaults(client =>
             client.restartContainers({ container: nodes.map(n => n.containerId) })
         );

--- a/src/commands/containers/selectContainer.ts
+++ b/src/commands/containers/selectContainer.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 
 export async function selectContainer(context: IActionContext): Promise<string> {
@@ -14,7 +14,7 @@ export async function selectContainer(context: IActionContext): Promise<string> 
 
     const node: ContainerTreeItem = await ext.containersTree.showTreeItemPicker(ContainerTreeItem.runningContainerRegExp, {
         ...context,
-        noItemFoundErrorMessage: localize('vscode-docker.commands.containers.select.noContainers', 'No running containers are available')
+        noItemFoundErrorMessage: l10n.t('No running containers are available')
     });
 
     return node.containerId;

--- a/src/commands/containers/selectContainer.ts
+++ b/src/commands/containers/selectContainer.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 
 export async function selectContainer(context: IActionContext): Promise<string> {

--- a/src/commands/containers/startContainer.ts
+++ b/src/commands/containers/startContainer.ts
@@ -6,20 +6,19 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function startContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: l10n.t('No containers are available to start') },
+        { ...context, noItemFoundErrorMessage: vscode.l10n.t('No containers are available to start') },
         ext.containersTree,
         /^(created|dead|exited|paused|terminated)Container$/i,
         node,
         nodes
     );
 
-    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: l10n.t('Starting Container(s)...') }, async () => {
+    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Starting Container(s)...') }, async () => {
         await ext.runWithDefaults(client =>
             client.startContainers({ container: nodes.map(n => n.containerId) })
         );

--- a/src/commands/containers/startContainer.ts
+++ b/src/commands/containers/startContainer.ts
@@ -6,20 +6,20 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function startContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: localize('vscode-docker.commands.containers.start.noContainers', 'No containers are available to start') },
+        { ...context, noItemFoundErrorMessage: l10n.t('No containers are available to start') },
         ext.containersTree,
         /^(created|dead|exited|paused|terminated)Container$/i,
         node,
         nodes
     );
 
-    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('vscode-docker.commands.containers.start.starting', 'Starting Container(s)...') }, async () => {
+    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: l10n.t('Starting Container(s)...') }, async () => {
         await ext.runWithDefaults(client =>
             client.startContainers({ container: nodes.map(n => n.containerId) })
         );

--- a/src/commands/containers/stopContainer.ts
+++ b/src/commands/containers/stopContainer.ts
@@ -6,20 +6,19 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function stopContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: l10n.t('No containers are available to stop') },
+        { ...context, noItemFoundErrorMessage: vscode.l10n.t('No containers are available to stop') },
         ext.containersTree,
         /^(paused|restarting|running)Container$/i,
         node,
         nodes
     );
 
-    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: l10n.t('Stopping Container(s)...') }, async () => {
+    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Stopping Container(s)...') }, async () => {
         await ext.runWithDefaults(client =>
             client.stopContainers({ container: nodes.map(n => n.containerId) })
         );

--- a/src/commands/containers/stopContainer.ts
+++ b/src/commands/containers/stopContainer.ts
@@ -6,20 +6,20 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function stopContainer(context: IActionContext, node?: ContainerTreeItem, nodes?: ContainerTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, noItemFoundErrorMessage: localize('vscode-docker.commands.containers.stop.noContainers', 'No containers are available to stop') },
+        { ...context, noItemFoundErrorMessage: l10n.t('No containers are available to stop') },
         ext.containersTree,
         /^(paused|restarting|running)Container$/i,
         node,
         nodes
     );
 
-    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('vscode-docker.commands.containers.stop.stopping', 'Stopping Container(s)...') }, async () => {
+    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: l10n.t('Stopping Container(s)...') }, async () => {
         await ext.runWithDefaults(client =>
             client.stopContainers({ container: nodes.map(n => n.containerId) })
         );

--- a/src/commands/containers/viewContainerLogs.ts
+++ b/src/commands/containers/viewContainerLogs.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { selectLogsCommand } from '../selectCommandTemplate';
@@ -15,7 +15,7 @@ export async function viewContainerLogs(context: IActionContext, node?: Containe
         await ext.containersTree.refresh(context);
         node = await ext.containersTree.showTreeItemPicker<ContainerTreeItem>(ContainerTreeItem.allContextRegExp, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.containers.viewLogs.noContainers', 'No containers are available to view logs')
+            noItemFoundErrorMessage: l10n.t('No containers are available to view logs')
         });
     }
 
@@ -27,7 +27,7 @@ export async function viewContainerLogs(context: IActionContext, node?: Containe
     );
 
     const taskCRF = new TaskCommandRunnerFactory({
-        taskName: localize('vscode-docker.commands.containers.viewLogs.terminalTitle', 'Logs: {0}', node.containerName),
+        taskName: l10n.t('Logs: {0}', node.containerName),
         alwaysRunNew: true,
         focus: true,
     });

--- a/src/commands/containers/viewContainerLogs.ts
+++ b/src/commands/containers/viewContainerLogs.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { selectLogsCommand } from '../selectCommandTemplate';

--- a/src/commands/context/inspectDockerContext.ts
+++ b/src/commands/context/inspectDockerContext.ts
@@ -5,14 +5,14 @@
 
 import { IActionContext, openReadOnlyJson } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ContextTreeItem } from '../../tree/contexts/ContextTreeItem';
 
 export async function inspectDockerContext(actionContext: IActionContext, node?: ContextTreeItem): Promise<void> {
     if (!node) {
         node = await ext.contextsTree.showTreeItemPicker<ContextTreeItem>(ContextTreeItem.allContextRegExp, {
             ...actionContext,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.contexts.inspect.noContexts', 'No Docker contexts are available to inspect'),
+            noItemFoundErrorMessage: l10n.t('No Docker contexts are available to inspect'),
             suppressCreatePick: true,
         });
     }

--- a/src/commands/context/inspectDockerContext.ts
+++ b/src/commands/context/inspectDockerContext.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, openReadOnlyJson } from '@microsoft/vscode-azext-utils';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
 import { ContextTreeItem } from '../../tree/contexts/ContextTreeItem';
 
 export async function inspectDockerContext(actionContext: IActionContext, node?: ContextTreeItem): Promise<void> {

--- a/src/commands/context/removeDockerContext.ts
+++ b/src/commands/context/removeDockerContext.ts
@@ -6,24 +6,23 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { ContextTreeItem } from '../../tree/contexts/ContextTreeItem';
 
 export async function removeDockerContext(actionContext: IActionContext, node?: ContextTreeItem): Promise<void> {
     if (!node) {
         node = await ext.contextsTree.showTreeItemPicker<ContextTreeItem>(ContextTreeItem.removableContextRegExp, {
             ...actionContext,
-            noItemFoundErrorMessage: l10n.t('No Docker contexts are available to remove'),
+            noItemFoundErrorMessage: vscode.l10n.t('No Docker contexts are available to remove'),
             suppressCreatePick: true,
         });
     }
 
-    const removeConfirmationMessage = l10n.t('Are you sure you want to remove Docker context \'{0}\'?', node.name);
+    const removeConfirmationMessage = vscode.l10n.t('Are you sure you want to remove Docker context \'{0}\'?', node.name);
 
     // no need to check result - cancel will throw a UserCancelledError
-    await actionContext.ui.showWarningMessage(removeConfirmationMessage, { modal: true }, { title: l10n.t('Remove') });
+    await actionContext.ui.showWarningMessage(removeConfirmationMessage, { modal: true }, { title: vscode.l10n.t('Remove') });
 
-    const removingMessage: string = l10n.t('Removing Docker context(s)...');
+    const removingMessage: string = vscode.l10n.t('Removing Docker context(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removingMessage }, async () => {
         await node.deleteTreeItem(actionContext);
     });

--- a/src/commands/context/removeDockerContext.ts
+++ b/src/commands/context/removeDockerContext.ts
@@ -6,24 +6,24 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ContextTreeItem } from '../../tree/contexts/ContextTreeItem';
 
 export async function removeDockerContext(actionContext: IActionContext, node?: ContextTreeItem): Promise<void> {
     if (!node) {
         node = await ext.contextsTree.showTreeItemPicker<ContextTreeItem>(ContextTreeItem.removableContextRegExp, {
             ...actionContext,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.contexts.remove.noContexts', 'No Docker contexts are available to remove'),
+            noItemFoundErrorMessage: l10n.t('No Docker contexts are available to remove'),
             suppressCreatePick: true,
         });
     }
 
-    const removeConfirmationMessage = localize('vscode-docker.commands.context.remove.confirmSingle', 'Are you sure you want to remove Docker context \'{0}\'?', node.name);
+    const removeConfirmationMessage = l10n.t('Are you sure you want to remove Docker context \'{0}\'?', node.name);
 
     // no need to check result - cancel will throw a UserCancelledError
-    await actionContext.ui.showWarningMessage(removeConfirmationMessage, { modal: true }, { title: localize('vscode-docker.commands.context.remove', 'Remove') });
+    await actionContext.ui.showWarningMessage(removeConfirmationMessage, { modal: true }, { title: l10n.t('Remove') });
 
-    const removingMessage: string = localize('vscode-docker.commands.context.remove.removing', 'Removing Docker context(s)...');
+    const removingMessage: string = l10n.t('Removing Docker context(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removingMessage }, async () => {
         await node.deleteTreeItem(actionContext);
     });

--- a/src/commands/context/useDockerContext.ts
+++ b/src/commands/context/useDockerContext.ts
@@ -6,7 +6,7 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ContextTreeItem } from '../../tree/contexts/ContextTreeItem';
 
 export async function useDockerContext(actionContext: IActionContext, node?: ContextTreeItem): Promise<void> {
@@ -14,7 +14,7 @@ export async function useDockerContext(actionContext: IActionContext, node?: Con
     if (!node) {
         node = await ext.contextsTree.showTreeItemPicker<ContextTreeItem>(ContextTreeItem.allContextRegExp, {
             ...actionContext,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.contexts.use.noContexts', 'No Docker contexts are available to use'),
+            noItemFoundErrorMessage: l10n.t('No Docker contexts are available to use'),
         });
         invokedFromCommandPalette = true;
     }
@@ -23,6 +23,6 @@ export async function useDockerContext(actionContext: IActionContext, node?: Con
     await node.use();
 
     if (invokedFromCommandPalette) {
-        void vscode.window.showInformationMessage(localize('vscode-docker.commands.context.contextInUse', 'Using Docker context \'{0}\'', node.name));
+        void vscode.window.showInformationMessage(l10n.t('Using Docker context \'{0}\'', node.name));
     }
 }

--- a/src/commands/context/useDockerContext.ts
+++ b/src/commands/context/useDockerContext.ts
@@ -6,7 +6,6 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { ContextTreeItem } from '../../tree/contexts/ContextTreeItem';
 
 export async function useDockerContext(actionContext: IActionContext, node?: ContextTreeItem): Promise<void> {
@@ -14,7 +13,7 @@ export async function useDockerContext(actionContext: IActionContext, node?: Con
     if (!node) {
         node = await ext.contextsTree.showTreeItemPicker<ContextTreeItem>(ContextTreeItem.allContextRegExp, {
             ...actionContext,
-            noItemFoundErrorMessage: l10n.t('No Docker contexts are available to use'),
+            noItemFoundErrorMessage: vscode.l10n.t('No Docker contexts are available to use'),
         });
         invokedFromCommandPalette = true;
     }
@@ -23,6 +22,6 @@ export async function useDockerContext(actionContext: IActionContext, node?: Con
     await node.use();
 
     if (invokedFromCommandPalette) {
-        void vscode.window.showInformationMessage(l10n.t('Using Docker context \'{0}\'', node.name));
+        void vscode.window.showInformationMessage(vscode.l10n.t('Using Docker context \'{0}\'', node.name));
     }
 }

--- a/src/commands/dockerInstaller.ts
+++ b/src/commands/dockerInstaller.ts
@@ -5,7 +5,6 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
-import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../runtimes/runners/TaskCommandRunnerFactory';
 import { runtimeInstallStatusProvider } from '../utils/RuntimeInstallStatusProvider';
 import { streamToFile } from '../utils/httpRequest';
@@ -19,8 +18,8 @@ export abstract class DockerInstallerBase {
     public async downloadAndInstallDocker(context: IActionContext): Promise<void> {
         const shouldInstall: boolean = await this.preInstallCheck();
         if (shouldInstall) {
-            const downloadingMessage: string = l10n.t('Downloading Docker installer...');
-            const installationMessage: string = l10n.t('The Docker Desktop installation is started. Complete the installation and then start Docker Desktop.');
+            const downloadingMessage: string = vscode.l10n.t('Downloading Docker installer...');
+            const installationMessage: string = vscode.l10n.t('The Docker Desktop installation is started. Complete the installation and then start Docker Desktop.');
             let downloadedFileName: string;
 
             context.telemetry.properties.stage = 'download';
@@ -29,8 +28,8 @@ export abstract class DockerInstallerBase {
                     { location: vscode.ProgressLocation.Notification, title: downloadingMessage },
                     async () => this.downloadInstaller());
             } catch (error) {
-                const message = l10n.t('Downloading the Docker Desktop installer failed. Do you want to manually download and install?');
-                const title = l10n.t('Download');
+                const message = vscode.l10n.t('Downloading the Docker Desktop installer failed. Do you want to manually download and install?');
+                const title = vscode.l10n.t('Download');
                 this.handleError(context, message, title, this.downloadUrl);
                 throw error;
             }
@@ -42,8 +41,8 @@ export abstract class DockerInstallerBase {
             try {
                 await this.install(context, downloadedFileName, command);
             } catch (error) {
-                const message = `${l10n.t('Docker Desktop installation failed')}. ${error}`;
-                const title = l10n.t('Install Instruction');
+                const message = `${vscode.l10n.t('Docker Desktop installation failed')}. ${error}`;
+                const title = vscode.l10n.t('Install Instruction');
                 this.handleError(context, message, title, 'https://aka.ms/AA37qtj');
                 throw error;
             }
@@ -53,8 +52,8 @@ export abstract class DockerInstallerBase {
     private async preInstallCheck(): Promise<boolean> {
         let proceedInstall = true;
         if (await runtimeInstallStatusProvider.isRuntimeInstalledRealTimeCheck()) {
-            const reinstallMessage = l10n.t('Docker Desktop is already installed. Would you like to reinstall?');
-            const install = l10n.t('Reinstall');
+            const reinstallMessage = vscode.l10n.t('Docker Desktop is already installed. Would you like to reinstall?');
+            const install = vscode.l10n.t('Reinstall');
             const response = await vscode.window.showInformationMessage(reinstallMessage, ...[install]);
             proceedInstall = response !== undefined;
         }
@@ -87,7 +86,7 @@ export class WindowsDockerInstaller extends DockerInstallerBase {
     }
 
     protected async install(context: IActionContext, fileName: string): Promise<void> {
-        const title = l10n.t('Docker Install');
+        const title = vscode.l10n.t('Docker Install');
         const command = this.getInstallCommand(fileName);
 
         const taskCRF = new TaskCommandRunnerFactory({
@@ -109,7 +108,7 @@ export class MacDockerInstaller extends DockerInstallerBase {
     }
 
     protected async install(context: IActionContext, fileName: string): Promise<void> {
-        const title = l10n.t('Docker Install');
+        const title = vscode.l10n.t('Docker Install');
         const command = this.getInstallCommand(fileName);
 
         const taskCRF = new TaskCommandRunnerFactory({
@@ -125,11 +124,11 @@ export class MacDockerInstaller extends DockerInstallerBase {
 
 export async function showDockerInstallNotification(): Promise<void> {
     const installMessage = isLinux() ?
-        l10n.t('Docker is not installed. Would you like to learn more about installing Docker?') :
-        l10n.t('Docker Desktop is not installed. Would you like to install it?');
+        vscode.l10n.t('Docker is not installed. Would you like to learn more about installing Docker?') :
+        vscode.l10n.t('Docker Desktop is not installed. Would you like to install it?');
 
-    const learnMore = l10n.t('Learn more');
-    const install = l10n.t('Install');
+    const learnMore = vscode.l10n.t('Learn more');
+    const install = vscode.l10n.t('Install');
 
     const confirmationPrompt: vscode.MessageItem = isLinux() ? { title: learnMore } : { title: install };
     const response = await vscode.window.showInformationMessage(installMessage, ...[confirmationPrompt]);

--- a/src/commands/dockerInstaller.ts
+++ b/src/commands/dockerInstaller.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../runtimes/runners/TaskCommandRunnerFactory';
 import { runtimeInstallStatusProvider } from '../utils/RuntimeInstallStatusProvider';
 import { streamToFile } from '../utils/httpRequest';
@@ -19,8 +19,8 @@ export abstract class DockerInstallerBase {
     public async downloadAndInstallDocker(context: IActionContext): Promise<void> {
         const shouldInstall: boolean = await this.preInstallCheck();
         if (shouldInstall) {
-            const downloadingMessage: string = localize('vscode-docker.commands.DockerInstallerBase.downloading', 'Downloading Docker installer...');
-            const installationMessage: string = localize('vscode-docker.commands.DockerInstallerBase.installationMessage', 'The Docker Desktop installation is started. Complete the installation and then start Docker Desktop.');
+            const downloadingMessage: string = l10n.t('Downloading Docker installer...');
+            const installationMessage: string = l10n.t('The Docker Desktop installation is started. Complete the installation and then start Docker Desktop.');
             let downloadedFileName: string;
 
             context.telemetry.properties.stage = 'download';
@@ -29,8 +29,8 @@ export abstract class DockerInstallerBase {
                     { location: vscode.ProgressLocation.Notification, title: downloadingMessage },
                     async () => this.downloadInstaller());
             } catch (error) {
-                const message = localize('vscode-docker.commands.DockerInstallerBase.downloadFailed', 'Downloading the Docker Desktop installer failed. Do you want to manually download and install?');
-                const title = localize('vscode-docker.commands.DockerInstallerBase.download', 'Download');
+                const message = l10n.t('Downloading the Docker Desktop installer failed. Do you want to manually download and install?');
+                const title = l10n.t('Download');
                 this.handleError(context, message, title, this.downloadUrl);
                 throw error;
             }
@@ -42,8 +42,8 @@ export abstract class DockerInstallerBase {
             try {
                 await this.install(context, downloadedFileName, command);
             } catch (error) {
-                const message = `${localize('vscode-docker.commands.DockerInstallerBase.installFailed', 'Docker Desktop installation failed')}. ${error}`;
-                const title = localize('vscode-docker.commands.DockerInstallerBase.openInstallLink', 'Install Instruction');
+                const message = `${l10n.t('Docker Desktop installation failed')}. ${error}`;
+                const title = l10n.t('Install Instruction');
                 this.handleError(context, message, title, 'https://aka.ms/AA37qtj');
                 throw error;
             }
@@ -53,8 +53,8 @@ export abstract class DockerInstallerBase {
     private async preInstallCheck(): Promise<boolean> {
         let proceedInstall = true;
         if (await runtimeInstallStatusProvider.isRuntimeInstalledRealTimeCheck()) {
-            const reinstallMessage = localize('vscode-docker.commands.DockerInstallerBase.reInstall', 'Docker Desktop is already installed. Would you like to reinstall?');
-            const install = localize('vscode-docker.commands.DockerInstallerBase.reinstall', 'Reinstall');
+            const reinstallMessage = l10n.t('Docker Desktop is already installed. Would you like to reinstall?');
+            const install = l10n.t('Reinstall');
             const response = await vscode.window.showInformationMessage(reinstallMessage, ...[install]);
             proceedInstall = response !== undefined;
         }
@@ -87,7 +87,7 @@ export class WindowsDockerInstaller extends DockerInstallerBase {
     }
 
     protected async install(context: IActionContext, fileName: string): Promise<void> {
-        const title = localize('vscode-docker.commands.WindowsDockerInstaller.terminalTitle', 'Docker Install');
+        const title = l10n.t('Docker Install');
         const command = this.getInstallCommand(fileName);
 
         const taskCRF = new TaskCommandRunnerFactory({
@@ -109,7 +109,7 @@ export class MacDockerInstaller extends DockerInstallerBase {
     }
 
     protected async install(context: IActionContext, fileName: string): Promise<void> {
-        const title = localize('vscode-docker.commands.MacDockerInstaller.terminalTitle', 'Docker Install');
+        const title = l10n.t('Docker Install');
         const command = this.getInstallCommand(fileName);
 
         const taskCRF = new TaskCommandRunnerFactory({
@@ -125,11 +125,11 @@ export class MacDockerInstaller extends DockerInstallerBase {
 
 export async function showDockerInstallNotification(): Promise<void> {
     const installMessage = isLinux() ?
-        localize('vscode-docker.commands.dockerInstaller.installDockerInfo', 'Docker is not installed. Would you like to learn more about installing Docker?') :
-        localize('vscode-docker.commands.dockerInstaller.installDocker', 'Docker Desktop is not installed. Would you like to install it?');
+        l10n.t('Docker is not installed. Would you like to learn more about installing Docker?') :
+        l10n.t('Docker Desktop is not installed. Would you like to install it?');
 
-    const learnMore = localize('vscode-docker.commands.dockerInstaller.learnMore', 'Learn more');
-    const install = localize('vscode-docker.commands.dockerInstaller.install', 'Install');
+    const learnMore = l10n.t('Learn more');
+    const install = l10n.t('Install');
 
     const confirmationPrompt: vscode.MessageItem = isLinux() ? { title: learnMore } : { title: install };
     const response = await vscode.window.showInformationMessage(installMessage, ...[confirmationPrompt]);

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -6,7 +6,6 @@
 import { IActionContext, IAzureQuickPickOptions } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { extensionId } from '../constants';
-import { l10n } from 'vscode';
 
 interface HelpMenuItem extends vscode.QuickPickItem {
     handler(): Promise<void>,
@@ -15,10 +14,10 @@ interface HelpMenuItem extends vscode.QuickPickItem {
 
 export async function help(context: IActionContext): Promise<void> {
     const items: HelpMenuItem[] = [
-        { label: l10n.t('Get started with Docker...'), handler: getStarted, telemetryID: 'getStarted' },
-        { label: l10n.t('Review Docker extension issues...'), handler: reviewIssues, telemetryID: 'reviewIssues' },
-        { label: l10n.t('Report Docker extension issue...'), handler: reportIssue, telemetryID: 'reportIssue' },
-        { label: l10n.t('Edit settings...'), handler: editSettings, telemetryID: 'editSettings' }
+        { label: vscode.l10n.t('Get started with Docker...'), handler: getStarted, telemetryID: 'getStarted' },
+        { label: vscode.l10n.t('Review Docker extension issues...'), handler: reviewIssues, telemetryID: 'reviewIssues' },
+        { label: vscode.l10n.t('Report Docker extension issue...'), handler: reportIssue, telemetryID: 'reportIssue' },
+        { label: vscode.l10n.t('Edit settings...'), handler: editSettings, telemetryID: 'editSettings' }
     ];
 
     const options: IAzureQuickPickOptions = { canPickMany: false, suppressPersistence: true };

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -6,7 +6,7 @@
 import { IActionContext, IAzureQuickPickOptions } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { extensionId } from '../constants';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 
 interface HelpMenuItem extends vscode.QuickPickItem {
     handler(): Promise<void>,
@@ -15,10 +15,10 @@ interface HelpMenuItem extends vscode.QuickPickItem {
 
 export async function help(context: IActionContext): Promise<void> {
     const items: HelpMenuItem[] = [
-        { label: localize('vscode-docker.commands.help.getStarted', 'Get started with Docker...'), handler: getStarted, telemetryID: 'getStarted' },
-        { label: localize('vscode-docker.commands.help.review', 'Review Docker extension issues...'), handler: reviewIssues, telemetryID: 'reviewIssues' },
-        { label: localize('vscode-docker.commands.help.report', 'Report Docker extension issue...'), handler: reportIssue, telemetryID: 'reportIssue' },
-        { label: localize('vscode-docker.commands.help.editSettings', 'Edit settings...'), handler: editSettings, telemetryID: 'editSettings' }
+        { label: l10n.t('Get started with Docker...'), handler: getStarted, telemetryID: 'getStarted' },
+        { label: l10n.t('Review Docker extension issues...'), handler: reviewIssues, telemetryID: 'reviewIssues' },
+        { label: l10n.t('Report Docker extension issue...'), handler: reportIssue, telemetryID: 'reportIssue' },
+        { label: l10n.t('Edit settings...'), handler: editSettings, telemetryID: 'editSettings' }
     ];
 
     const options: IAzureQuickPickOptions = { canPickMany: false, suppressPersistence: true };

--- a/src/commands/images/buildImage.ts
+++ b/src/commands/images/buildImage.ts
@@ -7,7 +7,7 @@ import { IActionContext, UserCancelledError } from "@microsoft/vscode-azext-util
 import * as path from "path";
 import * as vscode from "vscode";
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from "../../runtimes/runners/TaskCommandRunnerFactory";
 import { getOfficialBuildTaskForDockerfile } from "../../tasks/TaskHelper";
 import { getValidImageNameFromPath } from "../../utils/getValidImageName";
@@ -32,7 +32,7 @@ export async function buildImage(context: IActionContext, dockerFileUri: vscode.
         rootFolder = vscode.workspace.getWorkspaceFolder(dockerFileUri);
     }
 
-    rootFolder = rootFolder || await quickPickWorkspaceFolder(context, localize('vscode-docker.commands.images.build.workspaceFolder', 'To build Docker files you must first open a folder or workspace in VS Code.'));
+    rootFolder = rootFolder || await quickPickWorkspaceFolder(context, l10n.t('To build Docker files you must first open a folder or workspace in VS Code.'));
 
     const dockerFileItem = await quickPickDockerFileItem(context, dockerFileUri, rootFolder);
     const task = await getOfficialBuildTaskForDockerfile(context, dockerFileItem.absoluteFilePath, rootFolder);

--- a/src/commands/images/buildImage.ts
+++ b/src/commands/images/buildImage.ts
@@ -7,7 +7,6 @@ import { IActionContext, UserCancelledError } from "@microsoft/vscode-azext-util
 import * as path from "path";
 import * as vscode from "vscode";
 import { ext } from "../../extensionVariables";
-import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from "../../runtimes/runners/TaskCommandRunnerFactory";
 import { getOfficialBuildTaskForDockerfile } from "../../tasks/TaskHelper";
 import { getValidImageNameFromPath } from "../../utils/getValidImageName";
@@ -32,7 +31,7 @@ export async function buildImage(context: IActionContext, dockerFileUri: vscode.
         rootFolder = vscode.workspace.getWorkspaceFolder(dockerFileUri);
     }
 
-    rootFolder = rootFolder || await quickPickWorkspaceFolder(context, l10n.t('To build Docker files you must first open a folder or workspace in VS Code.'));
+    rootFolder = rootFolder || await quickPickWorkspaceFolder(context, vscode.l10n.t('To build Docker files you must first open a folder or workspace in VS Code.'));
 
     const dockerFileItem = await quickPickDockerFileItem(context, dockerFileUri, rootFolder);
     const task = await getOfficialBuildTaskForDockerfile(context, dockerFileItem.absoluteFilePath, rootFolder);

--- a/src/commands/images/copyFullTag.ts
+++ b/src/commands/images/copyFullTag.ts
@@ -6,7 +6,7 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 
 export async function copyFullTag(context: IActionContext, node: ImageTreeItem | undefined): Promise<string> {
@@ -14,7 +14,7 @@ export async function copyFullTag(context: IActionContext, node: ImageTreeItem |
         await ext.imagesTree.refresh(context);
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.images.copyFullTag.noImages', 'No images are available to copy tag')
+            noItemFoundErrorMessage: l10n.t('No images are available to copy tag')
         });
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/src/commands/images/copyFullTag.ts
+++ b/src/commands/images/copyFullTag.ts
@@ -6,7 +6,6 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 
 export async function copyFullTag(context: IActionContext, node: ImageTreeItem | undefined): Promise<string> {
@@ -14,7 +13,7 @@ export async function copyFullTag(context: IActionContext, node: ImageTreeItem |
         await ext.imagesTree.refresh(context);
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
-            noItemFoundErrorMessage: l10n.t('No images are available to copy tag')
+            noItemFoundErrorMessage: vscode.l10n.t('No images are available to copy tag')
         });
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/src/commands/images/inspectImage.ts
+++ b/src/commands/images/inspectImage.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext, openReadOnlyJson } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ImageTreeItem } from "../../tree/images/ImageTreeItem";
 
 export async function inspectImage(context: IActionContext, node?: ImageTreeItem): Promise<void> {
@@ -13,7 +13,7 @@ export async function inspectImage(context: IActionContext, node?: ImageTreeItem
         await ext.imagesTree.refresh(context);
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.images.inspect.noImages', 'No images are available to inspect')
+            noItemFoundErrorMessage: l10n.t('No images are available to inspect')
         });
     }
 

--- a/src/commands/images/inspectImage.ts
+++ b/src/commands/images/inspectImage.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, openReadOnlyJson } from "@microsoft/vscode-azext-utils";
-import { ext } from "../../extensionVariables";
 import { l10n } from 'vscode';
+import { ext } from "../../extensionVariables";
 import { ImageTreeItem } from "../../tree/images/ImageTreeItem";
 
 export async function inspectImage(context: IActionContext, node?: ImageTreeItem): Promise<void> {

--- a/src/commands/images/pruneImages.ts
+++ b/src/commands/images/pruneImages.ts
@@ -6,16 +6,16 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { convertToMB } from '../../utils/convertToMB';
 
 export async function pruneImages(context: IActionContext): Promise<void> {
-    const confirmPrune: string = localize('vscode-docker.commands.images.prune.confirm', 'Are you sure you want to remove all dangling images?');
+    const confirmPrune: string = l10n.t('Are you sure you want to remove all dangling images?');
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: localize('vscode-docker.commands.images.prune.remove', 'Remove') });
+    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: l10n.t('Remove') });
 
     await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: localize('vscode-docker.commands.images.pruning', 'Pruning images...') },
+        { location: vscode.ProgressLocation.Notification, title: l10n.t('Pruning images...') },
         async () => {
             const result = await ext.runWithDefaults(client =>
                 client.pruneImages({})
@@ -23,9 +23,9 @@ export async function pruneImages(context: IActionContext): Promise<void> {
 
             let message: string;
             if (result?.imageRefsDeleted?.length && Number.isInteger(result?.spaceReclaimed)) {
-                message = localize('vscode-docker.commands.images.prune.removed', 'Removed {0} dangling image(s) and reclaimed {1} MB of space.', result.imageRefsDeleted.length, convertToMB(result.spaceReclaimed));
+                message = l10n.t('Removed {0} dangling image(s) and reclaimed {1} MB of space.', result.imageRefsDeleted.length, convertToMB(result.spaceReclaimed));
             } else {
-                message = localize('vscode-docker.commands.images.prune.removed2', 'Removed dangling images.');
+                message = l10n.t('Removed dangling images.');
             }
 
             // Don't wait

--- a/src/commands/images/pruneImages.ts
+++ b/src/commands/images/pruneImages.ts
@@ -6,16 +6,15 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { convertToMB } from '../../utils/convertToMB';
 
 export async function pruneImages(context: IActionContext): Promise<void> {
-    const confirmPrune: string = l10n.t('Are you sure you want to remove all dangling images?');
+    const confirmPrune: string = vscode.l10n.t('Are you sure you want to remove all dangling images?');
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: l10n.t('Remove') });
+    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: vscode.l10n.t('Remove') });
 
     await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: l10n.t('Pruning images...') },
+        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Pruning images...') },
         async () => {
             const result = await ext.runWithDefaults(client =>
                 client.pruneImages({})
@@ -23,9 +22,9 @@ export async function pruneImages(context: IActionContext): Promise<void> {
 
             let message: string;
             if (result?.imageRefsDeleted?.length && Number.isInteger(result?.spaceReclaimed)) {
-                message = l10n.t('Removed {0} dangling image(s) and reclaimed {1} MB of space.', result.imageRefsDeleted.length, convertToMB(result.spaceReclaimed));
+                message = vscode.l10n.t('Removed {0} dangling image(s) and reclaimed {1} MB of space.', result.imageRefsDeleted.length, convertToMB(result.spaceReclaimed));
             } else {
-                message = l10n.t('Removed dangling images.');
+                message = vscode.l10n.t('Removed dangling images.');
             }
 
             // Don't wait

--- a/src/commands/images/pullImage.ts
+++ b/src/commands/images/pullImage.ts
@@ -5,14 +5,14 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function pullImage(context: IActionContext, node?: ImageTreeItem, nodes?: ImageTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: localize('vscode-docker.commands.images.pull.noImages', 'No images are available to pull') },
+        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: l10n.t('No images are available to pull') },
         ext.imagesTree,
         ImageTreeItem.contextValue,
         node,
@@ -24,7 +24,7 @@ export async function pullImage(context: IActionContext, node?: ImageTreeItem, n
     const client = await ext.runtimeManager.getClient();
     const taskCRF = new TaskCommandRunnerFactory(
         {
-            taskName: localize('vscode-docker.commands.images.pull.terminalTitle', 'Pull images')
+            taskName: l10n.t('Pull images')
         }
     );
 
@@ -33,7 +33,7 @@ export async function pullImage(context: IActionContext, node?: ImageTreeItem, n
         if (/:<none>/i.test(n.fullTag)) {
             // Warn only once
             if (!noneTagWarningShown) {
-                void context.ui.showWarningMessage(localize('vscode-docker.commands.images.pull.noneTag', 'Images without tags will be skipped.'));
+                void context.ui.showWarningMessage(l10n.t('Images without tags will be skipped.'));
                 noneTagWarningShown = true;
             }
 

--- a/src/commands/images/pullImage.ts
+++ b/src/commands/images/pullImage.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';

--- a/src/commands/images/pushImage.ts
+++ b/src/commands/images/pushImage.ts
@@ -6,7 +6,7 @@
 import { IActionContext, NoResourceFoundError } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { registryExpectedContextValues } from '../../tree/registries/registryContextValues';
@@ -18,7 +18,7 @@ export async function pushImage(context: IActionContext, node: ImageTreeItem | u
         await ext.imagesTree.refresh(context);
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.images.push.noImages', 'No images are available to push'),
+            noItemFoundErrorMessage: l10n.t('No images are available to push'),
         });
     }
 
@@ -51,7 +51,7 @@ export async function pushImage(context: IActionContext, node: ImageTreeItem | u
 
         const progressOptions: vscode.ProgressOptions = {
             location: vscode.ProgressLocation.Notification,
-            title: localize('vscode-docker.commands.images.push.fetchingCreds', 'Fetching login credentials...'),
+            title: l10n.t('Fetching login credentials...'),
         };
 
         connectedRegistry = await vscode.window.withProgress(progressOptions, async () => await tryGetConnectedRegistryForPath(context, baseImagePath));

--- a/src/commands/images/pushImage.ts
+++ b/src/commands/images/pushImage.ts
@@ -6,7 +6,6 @@
 import { IActionContext, NoResourceFoundError } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { registryExpectedContextValues } from '../../tree/registries/registryContextValues';
@@ -18,7 +17,7 @@ export async function pushImage(context: IActionContext, node: ImageTreeItem | u
         await ext.imagesTree.refresh(context);
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
-            noItemFoundErrorMessage: l10n.t('No images are available to push'),
+            noItemFoundErrorMessage: vscode.l10n.t('No images are available to push'),
         });
     }
 
@@ -51,7 +50,7 @@ export async function pushImage(context: IActionContext, node: ImageTreeItem | u
 
         const progressOptions: vscode.ProgressOptions = {
             location: vscode.ProgressLocation.Notification,
-            title: l10n.t('Fetching login credentials...'),
+            title: vscode.l10n.t('Fetching login credentials...'),
         };
 
         connectedRegistry = await vscode.window.withProgress(progressOptions, async () => await tryGetConnectedRegistryForPath(context, baseImagePath));

--- a/src/commands/images/removeImage.ts
+++ b/src/commands/images/removeImage.ts
@@ -6,13 +6,13 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function removeImage(context: IActionContext, node?: ImageTreeItem, nodes?: ImageTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: localize('vscode-docker.commands.images.remove.noImages', 'No images are available to remove') },
+        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: l10n.t('No images are available to remove') },
         ext.imagesTree,
         ImageTreeItem.contextValue,
         node,
@@ -21,15 +21,15 @@ export async function removeImage(context: IActionContext, node?: ImageTreeItem,
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = localize('vscode-docker.commands.images.remove.confirmSingle', 'Are you sure you want to remove image "{0}"? If there are other tags or child images for this image, only the tag will be removed.', nodes[0].fullTag);
+        confirmRemove = l10n.t('Are you sure you want to remove image "{0}"? If there are other tags or child images for this image, only the tag will be removed.', nodes[0].fullTag);
     } else {
-        confirmRemove = localize('vscode-docker.commands.images.remove.confirmMulti', 'Are you sure you want to remove the selected images? If there are other tags or child images for these images, only the tag will be removed.');
+        confirmRemove = l10n.t('Are you sure you want to remove the selected images? If there are other tags or child images for these images, only the tag will be removed.');
     }
 
     // no need to check result - cancel will throw a UserCancelledError
     await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: 'Remove' });
 
-    const removing: string = localize('vscode-docker.commands.images.remove.removing', 'Removing image(s)...');
+    const removing: string = l10n.t('Removing image(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removing }, async () => {
         await Promise.all(nodes.map(async n => await n.deleteTreeItem(context)));
     });

--- a/src/commands/images/removeImage.ts
+++ b/src/commands/images/removeImage.ts
@@ -6,13 +6,12 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function removeImage(context: IActionContext, node?: ImageTreeItem, nodes?: ImageTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: l10n.t('No images are available to remove') },
+        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: vscode.l10n.t('No images are available to remove') },
         ext.imagesTree,
         ImageTreeItem.contextValue,
         node,
@@ -21,15 +20,15 @@ export async function removeImage(context: IActionContext, node?: ImageTreeItem,
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = l10n.t('Are you sure you want to remove image "{0}"? If there are other tags or child images for this image, only the tag will be removed.', nodes[0].fullTag);
+        confirmRemove = vscode.l10n.t('Are you sure you want to remove image "{0}"? If there are other tags or child images for this image, only the tag will be removed.', nodes[0].fullTag);
     } else {
-        confirmRemove = l10n.t('Are you sure you want to remove the selected images? If there are other tags or child images for these images, only the tag will be removed.');
+        confirmRemove = vscode.l10n.t('Are you sure you want to remove the selected images? If there are other tags or child images for these images, only the tag will be removed.');
     }
 
     // no need to check result - cancel will throw a UserCancelledError
     await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: 'Remove' });
 
-    const removing: string = l10n.t('Removing image(s)...');
+    const removing: string = vscode.l10n.t('Removing image(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removing }, async () => {
         await Promise.all(nodes.map(async n => await n.deleteTreeItem(context)));
     });

--- a/src/commands/images/runAzureCliImage.ts
+++ b/src/commands/images/runAzureCliImage.ts
@@ -10,7 +10,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { getDockerOSType } from '../../utils/osUtils';
 
@@ -19,7 +19,7 @@ export async function runAzureCliImage(context: IActionContext): Promise<void> {
     context.telemetry.properties.dockerOSType = osType;
 
     if (osType === "windows") {
-        const message = localize('vscode-docker.commands.images.runAzureCli.linuxOnly', 'Currently, you can only run the Azure CLI when running Linux based containers.');
+        const message = l10n.t('Currently, you can only run the Azure CLI when running Linux based containers.');
         if (await vscode.window.showErrorMessage(message, DialogResponses.learnMore) === DialogResponses.learnMore) {
             await vscode.env.openExternal(vscode.Uri.parse('https://docs.docker.com/docker-for-windows/#/switch-between-windows-and-linux-containers'));
         }

--- a/src/commands/images/runAzureCliImage.ts
+++ b/src/commands/images/runAzureCliImage.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RunContainerBindMount } from '../../runtimes/docker';
 import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
+import { RunContainerBindMount } from '../../runtimes/docker';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { getDockerOSType } from '../../utils/osUtils';
 

--- a/src/commands/images/runImage.ts
+++ b/src/commands/images/runImage.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { selectRunCommand } from '../selectCommandTemplate';

--- a/src/commands/images/runImage.ts
+++ b/src/commands/images/runImage.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { selectRunCommand } from '../selectCommandTemplate';
@@ -23,7 +23,7 @@ async function runImageCore(context: IActionContext, node: ImageTreeItem | undef
         await ext.imagesTree.refresh(context);
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.images.run.noImages', 'No images are available to run')
+            noItemFoundErrorMessage: l10n.t('No images are available to run')
         });
     }
 

--- a/src/commands/images/tagImage.ts
+++ b/src/commands/images/tagImage.ts
@@ -6,7 +6,7 @@
 import { IActionContext, TelemetryProperties } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { RegistryTreeItemBase } from '../../tree/registries/RegistryTreeItemBase';
 
@@ -15,7 +15,7 @@ export async function tagImage(context: IActionContext, node?: ImageTreeItem, re
         await ext.imagesTree.refresh(context);
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.images.tag.noImages', 'No images are available to tag')
+            noItemFoundErrorMessage: l10n.t('No images are available to tag')
         });
     }
 
@@ -33,7 +33,7 @@ export async function tagImage(context: IActionContext, node?: ImageTreeItem, re
 export async function getTagFromUserInput(context: IActionContext, fullTag: string, baseImagePath?: string): Promise<string> {
     const opt: vscode.InputBoxOptions = {
         ignoreFocusOut: true,
-        prompt: localize('vscode-docker.commands.images.tag.tagAs', 'Tag image as...'),
+        prompt: l10n.t('Tag image as...'),
     };
 
     if (fullTag.includes('/')) {

--- a/src/commands/images/tagImage.ts
+++ b/src/commands/images/tagImage.ts
@@ -6,7 +6,6 @@
 import { IActionContext, TelemetryProperties } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { RegistryTreeItemBase } from '../../tree/registries/RegistryTreeItemBase';
 
@@ -15,7 +14,7 @@ export async function tagImage(context: IActionContext, node?: ImageTreeItem, re
         await ext.imagesTree.refresh(context);
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
             ...context,
-            noItemFoundErrorMessage: l10n.t('No images are available to tag')
+            noItemFoundErrorMessage: vscode.l10n.t('No images are available to tag')
         });
     }
 
@@ -33,7 +32,7 @@ export async function tagImage(context: IActionContext, node?: ImageTreeItem, re
 export async function getTagFromUserInput(context: IActionContext, fullTag: string, baseImagePath?: string): Promise<string> {
     const opt: vscode.InputBoxOptions = {
         ignoreFocusOut: true,
-        prompt: l10n.t('Tag image as...'),
+        prompt: vscode.l10n.t('Tag image as...'),
     };
 
     if (fullTag.includes('/')) {

--- a/src/commands/networks/createNetwork.ts
+++ b/src/commands/networks/createNetwork.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
 import { getDockerOSType } from '../../utils/osUtils';
 
 export async function createNetwork(context: IActionContext): Promise<void> {

--- a/src/commands/networks/createNetwork.ts
+++ b/src/commands/networks/createNetwork.ts
@@ -5,14 +5,14 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { getDockerOSType } from '../../utils/osUtils';
 
 export async function createNetwork(context: IActionContext): Promise<void> {
 
     const name = await context.ui.showInputBox({
         value: '',
-        prompt: localize('vscode-docker.commands.networks.create.promptName', 'Name of the network')
+        prompt: l10n.t('Name of the network')
     });
 
     const osType = await getDockerOSType();
@@ -32,7 +32,7 @@ export async function createNetwork(context: IActionContext): Promise<void> {
         drivers,
         {
             canPickMany: false,
-            placeHolder: localize('vscode-docker.commands.networks.create.promptDriver', 'Select the network driver to use (default is "bridge").')
+            placeHolder: l10n.t('Select the network driver to use (default is "bridge").')
         }
     );
 

--- a/src/commands/networks/inspectNetwork.ts
+++ b/src/commands/networks/inspectNetwork.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, openReadOnlyJson } from "@microsoft/vscode-azext-utils";
-import { ext } from "../../extensionVariables";
 import { l10n } from 'vscode';
+import { ext } from "../../extensionVariables";
 import { NetworkTreeItem } from "../../tree/networks/NetworkTreeItem";
 
 export async function inspectNetwork(context: IActionContext, node?: NetworkTreeItem): Promise<void> {

--- a/src/commands/networks/inspectNetwork.ts
+++ b/src/commands/networks/inspectNetwork.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext, openReadOnlyJson } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { NetworkTreeItem } from "../../tree/networks/NetworkTreeItem";
 
 export async function inspectNetwork(context: IActionContext, node?: NetworkTreeItem): Promise<void> {
@@ -13,7 +13,7 @@ export async function inspectNetwork(context: IActionContext, node?: NetworkTree
         await ext.networksTree.refresh(context);
         node = await ext.networksTree.showTreeItemPicker<NetworkTreeItem>(NetworkTreeItem.allContextRegExp, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.networks.inspect.noNetworks', 'No networks are available to inspect')
+            noItemFoundErrorMessage: l10n.t('No networks are available to inspect')
         });
     }
 

--- a/src/commands/networks/pruneNetworks.ts
+++ b/src/commands/networks/pruneNetworks.ts
@@ -6,15 +6,14 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 
 export async function pruneNetworks(context: IActionContext): Promise<void> {
-    const confirmPrune: string = l10n.t('Are you sure you want to remove all unused networks?');
+    const confirmPrune: string = vscode.l10n.t('Are you sure you want to remove all unused networks?');
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: l10n.t('Remove') });
+    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: vscode.l10n.t('Remove') });
 
     await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: l10n.t('Pruning networks...') },
+        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Pruning networks...') },
         async () => {
             const result = await ext.runWithDefaults(client =>
                 client.pruneNetworks({})
@@ -22,9 +21,9 @@ export async function pruneNetworks(context: IActionContext): Promise<void> {
 
             let message: string;
             if (result?.networksDeleted?.length) {
-                message = l10n.t('Removed {0} unused networks(s).', result.networksDeleted.length);
+                message = vscode.l10n.t('Removed {0} unused networks(s).', result.networksDeleted.length);
             } else {
-                message = l10n.t('Removed unused networks.');
+                message = vscode.l10n.t('Removed unused networks.');
             }
 
             // Don't wait

--- a/src/commands/networks/pruneNetworks.ts
+++ b/src/commands/networks/pruneNetworks.ts
@@ -6,15 +6,15 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 
 export async function pruneNetworks(context: IActionContext): Promise<void> {
-    const confirmPrune: string = localize('vscode-docker.commands.networks.prune.confirm', 'Are you sure you want to remove all unused networks?');
+    const confirmPrune: string = l10n.t('Are you sure you want to remove all unused networks?');
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: localize('vscode-docker.commands.networks.prune.remove', 'Remove') });
+    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: l10n.t('Remove') });
 
     await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: localize('vscode-docker.commands.networks.pruning', 'Pruning networks...') },
+        { location: vscode.ProgressLocation.Notification, title: l10n.t('Pruning networks...') },
         async () => {
             const result = await ext.runWithDefaults(client =>
                 client.pruneNetworks({})
@@ -22,9 +22,9 @@ export async function pruneNetworks(context: IActionContext): Promise<void> {
 
             let message: string;
             if (result?.networksDeleted?.length) {
-                message = localize('vscode-docker.commands.networks.prune.removed', 'Removed {0} unused networks(s).', result.networksDeleted.length);
+                message = l10n.t('Removed {0} unused networks(s).', result.networksDeleted.length);
             } else {
-                message = localize('vscode-docker.commands.networks.prune.removed2', 'Removed unused networks.');
+                message = l10n.t('Removed unused networks.');
             }
 
             // Don't wait

--- a/src/commands/networks/removeNetwork.ts
+++ b/src/commands/networks/removeNetwork.ts
@@ -6,13 +6,13 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { NetworkTreeItem } from '../../tree/networks/NetworkTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function removeNetwork(context: IActionContext, node?: NetworkTreeItem, nodes?: NetworkTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: localize('vscode-docker.commands.networks.remove.noNetworks', 'No networks are available to remove') },
+        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: l10n.t('No networks are available to remove') },
         ext.networksTree,
         NetworkTreeItem.customNetworkRegExp,
         node,
@@ -21,15 +21,15 @@ export async function removeNetwork(context: IActionContext, node?: NetworkTreeI
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = localize('vscode-docker.commands.networks.remove.confirmSingle', 'Are you sure you want to remove network "{0}"?', nodes[0].label);
+        confirmRemove = l10n.t('Are you sure you want to remove network "{0}"?', nodes[0].label);
     } else {
-        confirmRemove = localize('vscode-docker.commands.networks.remove.confirmMulti', 'Are you sure you want to remove selected networks?');
+        confirmRemove = l10n.t('Are you sure you want to remove selected networks?');
     }
 
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: localize('vscode-docker.commands.networks.remove.remove', 'Remove') });
+    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: l10n.t('Remove') });
 
-    const removing: string = localize('vscode-docker.commands.networks.remove.removing', 'Removing network(s)...');
+    const removing: string = l10n.t('Removing network(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removing }, async () => {
         await Promise.all(nodes.map(async n => await n.deleteTreeItem(context)));
     });

--- a/src/commands/networks/removeNetwork.ts
+++ b/src/commands/networks/removeNetwork.ts
@@ -6,13 +6,12 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { NetworkTreeItem } from '../../tree/networks/NetworkTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function removeNetwork(context: IActionContext, node?: NetworkTreeItem, nodes?: NetworkTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: l10n.t('No networks are available to remove') },
+        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: vscode.l10n.t('No networks are available to remove') },
         ext.networksTree,
         NetworkTreeItem.customNetworkRegExp,
         node,
@@ -21,15 +20,15 @@ export async function removeNetwork(context: IActionContext, node?: NetworkTreeI
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = l10n.t('Are you sure you want to remove network "{0}"?', nodes[0].label);
+        confirmRemove = vscode.l10n.t('Are you sure you want to remove network "{0}"?', nodes[0].label);
     } else {
-        confirmRemove = l10n.t('Are you sure you want to remove selected networks?');
+        confirmRemove = vscode.l10n.t('Are you sure you want to remove selected networks?');
     }
 
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: l10n.t('Remove') });
+    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: vscode.l10n.t('Remove') });
 
-    const removing: string = l10n.t('Removing network(s)...');
+    const removing: string = vscode.l10n.t('Removing network(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removing }, async () => {
         await Promise.all(nodes.map(async n => await n.deleteTreeItem(context)));
     });

--- a/src/commands/pruneSystem.ts
+++ b/src/commands/pruneSystem.ts
@@ -6,16 +6,15 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
-import { l10n } from 'vscode';
 import { convertToMB } from '../utils/convertToMB';
 
 export async function pruneSystem(context: IActionContext): Promise<void> {
-    const confirmPrune: string = l10n.t('Are you sure you want to remove all stopped containers, dangling images, unused networks, and unused volumes? Removing volumes may result in data loss!');
+    const confirmPrune: string = vscode.l10n.t('Are you sure you want to remove all stopped containers, dangling images, unused networks, and unused volumes? Removing volumes may result in data loss!');
     // no need to check result - cancel will throw a UserCancelledError
     await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: 'Remove' });
 
     await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: l10n.t('Pruning system...') },
+        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Pruning system...') },
         async () => {
             const containersResult = await ext.runWithDefaults(client =>
                 client.pruneContainers({})
@@ -35,7 +34,7 @@ export async function pruneSystem(context: IActionContext): Promise<void> {
                 imagesResult?.imageRefsDeleted?.length && Number.isInteger(imagesResult?.spaceReclaimed) &&
                 networksResult?.networksDeleted?.length &&
                 volumesResult?.volumesDeleted?.length && Number.isInteger(volumesResult?.spaceReclaimed)) {
-                message = l10n.t(
+                message = vscode.l10n.t(
                     'Removed {0} container(s), {1} image(s), {2} network(s), {3} volume(s) and reclaimed {4} MB of space.',
                     containersResult.containersDeleted.length,
                     imagesResult.imageRefsDeleted.length,
@@ -44,7 +43,7 @@ export async function pruneSystem(context: IActionContext): Promise<void> {
                     convertToMB(containersResult.spaceReclaimed + imagesResult.spaceReclaimed + volumesResult.spaceReclaimed)
                 );
             } else {
-                message = l10n.t('Removed stopped containers, dangling images, unused networks, and unused volumes.');
+                message = vscode.l10n.t('Removed stopped containers, dangling images, unused networks, and unused volumes.');
             }
 
             // Don't wait

--- a/src/commands/pruneSystem.ts
+++ b/src/commands/pruneSystem.ts
@@ -6,16 +6,16 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { convertToMB } from '../utils/convertToMB';
 
 export async function pruneSystem(context: IActionContext): Promise<void> {
-    const confirmPrune: string = localize('vscode-docker.commands.pruneSystem.confirm', 'Are you sure you want to remove all stopped containers, dangling images, unused networks, and unused volumes? Removing volumes may result in data loss!');
+    const confirmPrune: string = l10n.t('Are you sure you want to remove all stopped containers, dangling images, unused networks, and unused volumes? Removing volumes may result in data loss!');
     // no need to check result - cancel will throw a UserCancelledError
     await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: 'Remove' });
 
     await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: localize('vscode-docker.commands.pruneSystem.pruning', 'Pruning system...') },
+        { location: vscode.ProgressLocation.Notification, title: l10n.t('Pruning system...') },
         async () => {
             const containersResult = await ext.runWithDefaults(client =>
                 client.pruneContainers({})
@@ -35,8 +35,7 @@ export async function pruneSystem(context: IActionContext): Promise<void> {
                 imagesResult?.imageRefsDeleted?.length && Number.isInteger(imagesResult?.spaceReclaimed) &&
                 networksResult?.networksDeleted?.length &&
                 volumesResult?.volumesDeleted?.length && Number.isInteger(volumesResult?.spaceReclaimed)) {
-                message = localize(
-                    'vscode-docker.commands.pruneSystem.removed',
+                message = l10n.t(
                     'Removed {0} container(s), {1} image(s), {2} network(s), {3} volume(s) and reclaimed {4} MB of space.',
                     containersResult.containersDeleted.length,
                     imagesResult.imageRefsDeleted.length,
@@ -45,7 +44,7 @@ export async function pruneSystem(context: IActionContext): Promise<void> {
                     convertToMB(containersResult.spaceReclaimed + imagesResult.spaceReclaimed + volumesResult.spaceReclaimed)
                 );
             } else {
-                message = localize('vscode-docker.commands.pruneSystem.removed2', 'Removed stopped containers, dangling images, unused networks, and unused volumes.');
+                message = l10n.t('Removed stopped containers, dangling images, unused networks, and unused volumes.');
             }
 
             // Don't wait

--- a/src/commands/registerLocalCommand.ts
+++ b/src/commands/registerLocalCommand.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { DockerExtensionKind, getVSCodeRemoteInfo } from '../utils/getVSCodeRemoteInfo';
 import { registerCommand } from './registerCommands';
 
@@ -26,6 +26,6 @@ async function verifyIsRunningLocally(context: IActionContext): Promise<void> {
 
     if (remoteInfo.extensionKind !== DockerExtensionKind.local) {
         context.errorHandling.suppressReportIssue = true;
-        throw new Error(localize('vscode-docker.commands.installDocker.noRemote', 'This command cannot be used in a remote session.'));
+        throw new Error(l10n.t('This command cannot be used in a remote session.'));
     }
 }

--- a/src/commands/registerWorkspaceCommand.ts
+++ b/src/commands/registerWorkspaceCommand.ts
@@ -6,7 +6,7 @@
 import { IActionContext, UserCancelledError, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
 import { ConfigurationTarget, MessageItem, WorkspaceConfiguration, commands, workspace } from 'vscode';
 import { extensionId } from '../constants';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { DockerExtensionKind, IVSCodeRemoteInfo, RemoteKind, getVSCodeRemoteInfo } from '../utils/getVSCodeRemoteInfo';
 import { registerCommand } from './registerCommands';
 
@@ -37,18 +37,18 @@ async function verifyIsRunningInWorkspace(context: IActionContext): Promise<void
             let learnMoreLink: string;
             switch (remoteInfo.remoteKind) {
                 case RemoteKind.ssh:
-                    message = localize('vscode-docker.commands.registerWorkspaceCommands.local', 'This operation is not supported because the Docker extension is currently running on your local machine.');
-                    switchTitle = localize('vscode-docker.commands.registerWorkspaceCommands.switchSsh', 'Switch to Remote SSH');
+                    message = l10n.t('This operation is not supported because the Docker extension is currently running on your local machine.');
+                    switchTitle = l10n.t('Switch to Remote SSH');
                     learnMoreLink = 'https://aka.ms/AA5y2rd';
                     break;
                 case RemoteKind.wsl:
-                    message = localize('vscode-docker.commands.registerWorkspaceCommands.outsideWsl', 'This operation is not supported because the Docker extension is currently running outside of WSL.');
-                    switchTitle = localize('vscode-docker.commands.registerWorkspaceCommands.switchWsl', 'Switch to WSL');
+                    message = l10n.t('This operation is not supported because the Docker extension is currently running outside of WSL.');
+                    switchTitle = l10n.t('Switch to WSL');
                     learnMoreLink = 'https://aka.ms/AA5xvjn';
                     break;
                 case RemoteKind.devContainer:
-                    message = localize('vscode-docker.commands.registerWorkspaceCommands.outsideContainer', 'This operation is not supported because the Docker extension is currently running outside of your container.');
-                    switchTitle = localize('vscode-docker.commands.registerWorkspaceCommands.switchContainer', 'Switch to Container');
+                    message = l10n.t('This operation is not supported because the Docker extension is currently running outside of your container.');
+                    switchTitle = l10n.t('Switch to Container');
                     learnMoreLink = 'https://aka.ms/AA5xva6';
                     break;
                 default:
@@ -60,8 +60,8 @@ async function verifyIsRunningInWorkspace(context: IActionContext): Promise<void
             await context.ui.showWarningMessage(message, { learnMoreLink, stepName: 'switchExtensionKind' }, switchBtn);
             updateExtensionKind('workspace');
 
-            const reloadMessage: string = localize('vscode-docker.commands.registerWorkspaceCommands.reloadRequired', 'This change to the Docker extension requires reloading VS Code to take effect.');
-            const reload: MessageItem = { title: localize('vscode-docker.commands.registerWorkspaceCommands.reload', 'Reload Now') };
+            const reloadMessage: string = l10n.t('This change to the Docker extension requires reloading VS Code to take effect.');
+            const reload: MessageItem = { title: l10n.t('Reload Now') };
             await context.ui.showWarningMessage(reloadMessage, { stepName: 'requiresReload' }, reload);
 
             // Add a one-off event here before reloading the window otherwise we'll lose telemetry for this code path

--- a/src/commands/registerWorkspaceCommand.ts
+++ b/src/commands/registerWorkspaceCommand.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, UserCancelledError, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
-import { ConfigurationTarget, MessageItem, WorkspaceConfiguration, commands, workspace } from 'vscode';
+import { ConfigurationTarget, MessageItem, WorkspaceConfiguration, commands, workspace, l10n } from 'vscode';
 import { extensionId } from '../constants';
-import { l10n } from 'vscode';
 import { DockerExtensionKind, IVSCodeRemoteInfo, RemoteKind, getVSCodeRemoteInfo } from '../utils/getVSCodeRemoteInfo';
 import { registerCommand } from './registerCommands';
 

--- a/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
+++ b/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
@@ -8,7 +8,7 @@ import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
 import type { IAppServiceWizardContext } from "@microsoft/vscode-azext-azureappservice"; // These are only dev-time imports so don't need to be lazy
 import { Progress } from "vscode";
 import { ext } from "../../../extensionVariables";
-import { localize } from "../../../localize";
+import { l10n } from 'vscode';
 import { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
 import { RemoteTagTreeItem } from '../../../tree/registries/RemoteTagTreeItem';
 import { getArmAuth, getArmContainerRegistry, getAzExtAppService, getAzExtAzureUtils } from "../../../utils/lazyPackages";
@@ -21,7 +21,7 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
     }
 
     public async execute(context: IAppServiceWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
-        const message: string = localize('vscode-docker.commands.registries.azure.deployImage.assigningPullRole', 'Granting permission for App Service to pull image from ACR...');
+        const message: string = l10n.t('Granting permission for App Service to pull image from ACR...');
         ext.outputChannel.info(message);
         progress.report({ message: message });
 
@@ -41,7 +41,7 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
 
         if (!(registry?.id)) {
             throw new Error(
-                localize('vscode-docker.commands.registries.deployImage.noRegistryId', 'Unable to get details from Container Registry {0}', registryTreeItem.baseUrl)
+                l10n.t('Unable to get details from Container Registry {0}', registryTreeItem.baseUrl)
             );
         }
 
@@ -50,7 +50,7 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
 
         if (!(acrPullRoleDefinition?.id)) {
             throw new Error(
-                localize('vscode-docker.commands.registries.deployImage.noRoleDefinition', 'Unable to get AcrPull role definition on subscription {0}', context.subscriptionId)
+                l10n.t('Unable to get AcrPull role definition on subscription {0}', context.subscriptionId)
             );
         }
 
@@ -59,7 +59,7 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
 
         if (!(siteInfo?.identity?.principalId)) {
             throw new Error(
-                localize('vscode-docker.commands.registries.deployImage.noPrincipalid', 'Unable to get identity principal ID for web site {0}', context.site.name)
+                l10n.t('Unable to get identity principal ID for web site {0}', context.site.name)
             );
         }
 
@@ -75,7 +75,7 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
 
         if (!config) {
             throw new Error(
-                localize('vscode-docker.commands.registries.deployImage.updateConfig', 'Unable to get configuration for web site {0}', context.site.name)
+                l10n.t('Unable to get configuration for web site {0}', context.site.name)
             );
         }
 

--- a/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
+++ b/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
@@ -3,12 +3,11 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { randomUUID } from "crypto";
-import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
 import type { IAppServiceWizardContext } from "@microsoft/vscode-azext-azureappservice"; // These are only dev-time imports so don't need to be lazy
-import { Progress } from "vscode";
+import { AzureWizardExecuteStep } from "@microsoft/vscode-azext-utils";
+import { randomUUID } from "crypto";
+import { l10n, Progress } from "vscode";
 import { ext } from "../../../extensionVariables";
-import { l10n } from 'vscode';
 import { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
 import { RemoteTagTreeItem } from '../../../tree/registries/RemoteTagTreeItem';
 import { getArmAuth, getArmContainerRegistry, getAzExtAppService, getAzExtAzureUtils } from "../../../utils/lazyPackages";

--- a/src/commands/registries/azure/DockerSiteCreateStep.ts
+++ b/src/commands/registries/azure/DockerSiteCreateStep.ts
@@ -9,7 +9,7 @@ import type { AzExtLocation } from '@microsoft/vscode-azext-azureutils'; // Thes
 import { AzureWizardExecuteStep, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { Progress } from "vscode";
 import { ext } from "../../../extensionVariables";
-import { localize } from "../../../localize";
+import { l10n } from 'vscode';
 import { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
 import { DockerHubNamespaceTreeItem } from '../../../tree/registries/dockerHub/DockerHubNamespaceTreeItem';
 import { DockerV2RegistryTreeItemBase } from '../../../tree/registries/dockerV2/DockerV2RegistryTreeItemBase';
@@ -28,7 +28,7 @@ export class DockerSiteCreateStep extends AzureWizardExecuteStep<IAppServiceCont
     }
 
     public async execute(context: IAppServiceContainerWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
-        const creatingNewApp: string = localize('vscode-docker.commands.registries.azure.deployImage.creatingWebApp', 'Creating web app "{0}"...', context.newSiteName);
+        const creatingNewApp: string = l10n.t('Creating web app "{0}"...', context.newSiteName);
         ext.outputChannel.info(creatingNewApp);
         progress.report({ message: creatingNewApp });
         const siteConfig = await this.getNewSiteConfig(context);
@@ -84,7 +84,7 @@ export class DockerSiteCreateStep extends AzureWizardExecuteStep<IAppServiceCont
         else if (registryTI instanceof AzureRegistryTreeItem && context.customLocation) {
             const cred = await registryTI.tryGetAdminCredentials(context);
             if (!cred?.username || !cred?.passwords?.[0]?.value) {
-                throw new Error(localize('vscode-docker.commands.registries.azure.dockersitecreatestep.notAdminEnabled', 'Azure App service deployment on Azure Arc only supports running images from Azure Container Registries with admin enabled'));
+                throw new Error(l10n.t('Azure App service deployment on Azure Arc only supports running images from Azure Container Registries with admin enabled'));
             }
 
             username = cred.username;
@@ -103,12 +103,12 @@ export class DockerSiteCreateStep extends AzureWizardExecuteStep<IAppServiceCont
                 username = registryTI.cachedProvider.username;
                 password = await getRegistryPassword(registryTI.cachedProvider);
             } else {
-                throw new RangeError(localize('vscode-docker.commands.registries.azure.deployImage.unrecognizedNodeTypeA', 'Unrecognized node type "{0}"', registryTI.constructor.name));
+                throw new RangeError(l10n.t('Unrecognized node type "{0}"', registryTI.constructor.name));
             }
 
             registryUrl = registryTI.baseUrl;
         } else {
-            throw new RangeError(localize('vscode-docker.commands.registries.azure.deployImage.unrecognizedNodeTypeB', 'Unrecognized node type "{0}"', registryTI.constructor.name));
+            throw new RangeError(l10n.t('Unrecognized node type "{0}"', registryTI.constructor.name));
         }
 
         if (username && password) {

--- a/src/commands/registries/azure/DockerSiteCreateStep.ts
+++ b/src/commands/registries/azure/DockerSiteCreateStep.ts
@@ -3,13 +3,12 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { WebSiteManagementClient, Site, SiteConfig, NameValuePair } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
+import type { NameValuePair, Site, SiteConfig, WebSiteManagementClient } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
 import type { CustomLocation } from "@microsoft/vscode-azext-azureappservice"; // These are only dev-time imports so don't need to be lazy
 import type { AzExtLocation } from '@microsoft/vscode-azext-azureutils'; // These are only dev-time imports so don't need to be lazy
 import { AzureWizardExecuteStep, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
-import { Progress } from "vscode";
+import { l10n, Progress } from "vscode";
 import { ext } from "../../../extensionVariables";
-import { l10n } from 'vscode';
 import { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
 import { DockerHubNamespaceTreeItem } from '../../../tree/registries/dockerHub/DockerHubNamespaceTreeItem';
 import { DockerV2RegistryTreeItemBase } from '../../../tree/registries/dockerV2/DockerV2RegistryTreeItemBase';

--- a/src/commands/registries/azure/DockerWebhookCreateStep.ts
+++ b/src/commands/registries/azure/DockerWebhookCreateStep.ts
@@ -3,13 +3,12 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from "vscode";
 import type { Site } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
 import type { Webhook, WebhookCreateParameters } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
 import type { IAppServiceWizardContext } from "@microsoft/vscode-azext-azureappservice"; // These are only dev-time imports so don't need to be lazy
 import { AzureWizardExecuteStep, nonNullProp } from "@microsoft/vscode-azext-utils";
+import * as vscode from "vscode";
 import { ext } from "../../../extensionVariables";
-import { l10n } from 'vscode';
 import { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
 import { AzureRepositoryTreeItem } from '../../../tree/registries/azure/AzureRepositoryTreeItem';
 import { DockerHubRepositoryTreeItem } from '../../../tree/registries/dockerHub/DockerHubRepositoryTreeItem';
@@ -36,15 +35,15 @@ export class DockerWebhookCreateStep extends AzureWizardExecuteStep<IAppServiceW
         const siteClient = await parsedSite.createClient(context);
         const appUri: string = (await siteClient.getWebAppPublishCredential()).scmUri;
         if (this._treeItem.parent instanceof AzureRepositoryTreeItem) {
-            const creatingNewWebhook: string = l10n.t('Creating webhook for web app "{0}"...', context.newSiteName);
+            const creatingNewWebhook: string = vscode.l10n.t('Creating webhook for web app "{0}"...', context.newSiteName);
             ext.outputChannel.info(creatingNewWebhook);
             progress.report({ message: creatingNewWebhook });
             const webhook = await this.createWebhookForApp(context, this._treeItem, context.site, appUri);
-            ext.outputChannel.info(l10n.t('Created webhook "{0}" with scope "{1}", id: "{2}" and location: "{3}"', webhook.name, webhook.scope, webhook.id, webhook.location));
+            ext.outputChannel.info(vscode.l10n.t('Created webhook "{0}" with scope "{1}", id: "{2}" and location: "{3}"', webhook.name, webhook.scope, webhook.id, webhook.location));
         } else if (this._treeItem.parent instanceof DockerHubRepositoryTreeItem) {
             // point to dockerhub to create a webhook
             // http://cloud.docker.com/repository/docker/<registryName>/<repoName>/webHooks
-            const dockerhubPrompt: string = l10n.t('Copy & Open');
+            const dockerhubPrompt: string = vscode.l10n.t('Copy & Open');
             const dockerhubUri: string = `https://cloud.docker.com/repository/docker/${this._treeItem.parent.parent.namespace}/${this._treeItem.parent.repoName}/webHooks`;
 
             // NOTE: The response to the information message is not awaited but handled independently of the wizard steps.
@@ -54,7 +53,7 @@ export class DockerWebhookCreateStep extends AzureWizardExecuteStep<IAppServiceW
 
             /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
             vscode.window
-                .showInformationMessage(l10n.t('To set up a CI/CD webhook, open the page "{0}" and enter the URI to the created web app in your dockerhub account', dockerhubUri), dockerhubPrompt)
+                .showInformationMessage(vscode.l10n.t('To set up a CI/CD webhook, open the page "{0}" and enter the URI to the created web app in your dockerhub account', dockerhubUri), dockerhubPrompt)
                 .then(response => {
                     if (response) {
                         void vscode.env.clipboard.writeText(appUri);

--- a/src/commands/registries/azure/DockerWebhookCreateStep.ts
+++ b/src/commands/registries/azure/DockerWebhookCreateStep.ts
@@ -9,7 +9,7 @@ import type { Webhook, WebhookCreateParameters } from '@azure/arm-containerregis
 import type { IAppServiceWizardContext } from "@microsoft/vscode-azext-azureappservice"; // These are only dev-time imports so don't need to be lazy
 import { AzureWizardExecuteStep, nonNullProp } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../../extensionVariables";
-import { localize } from "../../../localize";
+import { l10n } from 'vscode';
 import { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
 import { AzureRepositoryTreeItem } from '../../../tree/registries/azure/AzureRepositoryTreeItem';
 import { DockerHubRepositoryTreeItem } from '../../../tree/registries/dockerHub/DockerHubRepositoryTreeItem';
@@ -36,15 +36,15 @@ export class DockerWebhookCreateStep extends AzureWizardExecuteStep<IAppServiceW
         const siteClient = await parsedSite.createClient(context);
         const appUri: string = (await siteClient.getWebAppPublishCredential()).scmUri;
         if (this._treeItem.parent instanceof AzureRepositoryTreeItem) {
-            const creatingNewWebhook: string = localize('vscode-docker.commands.registries.azure.dockerWebhook.creatingWebhook', 'Creating webhook for web app "{0}"...', context.newSiteName);
+            const creatingNewWebhook: string = l10n.t('Creating webhook for web app "{0}"...', context.newSiteName);
             ext.outputChannel.info(creatingNewWebhook);
             progress.report({ message: creatingNewWebhook });
             const webhook = await this.createWebhookForApp(context, this._treeItem, context.site, appUri);
-            ext.outputChannel.info(localize('vscode-docker.commands.registries.azure.dockerWebhook.createdWebhook', 'Created webhook "{0}" with scope "{1}", id: "{2}" and location: "{3}"', webhook.name, webhook.scope, webhook.id, webhook.location));
+            ext.outputChannel.info(l10n.t('Created webhook "{0}" with scope "{1}", id: "{2}" and location: "{3}"', webhook.name, webhook.scope, webhook.id, webhook.location));
         } else if (this._treeItem.parent instanceof DockerHubRepositoryTreeItem) {
             // point to dockerhub to create a webhook
             // http://cloud.docker.com/repository/docker/<registryName>/<repoName>/webHooks
-            const dockerhubPrompt: string = localize('vscode-docker.commands.registries.azure.dockerWebhook.copyAndOpen', 'Copy & Open');
+            const dockerhubPrompt: string = l10n.t('Copy & Open');
             const dockerhubUri: string = `https://cloud.docker.com/repository/docker/${this._treeItem.parent.parent.namespace}/${this._treeItem.parent.repoName}/webHooks`;
 
             // NOTE: The response to the information message is not awaited but handled independently of the wizard steps.
@@ -54,7 +54,7 @@ export class DockerWebhookCreateStep extends AzureWizardExecuteStep<IAppServiceW
 
             /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
             vscode.window
-                .showInformationMessage(localize('vscode-docker.commands.registries.azure.dockerWebhook.cicd', 'To set up a CI/CD webhook, open the page "{0}" and enter the URI to the created web app in your dockerhub account', dockerhubUri), dockerhubPrompt)
+                .showInformationMessage(l10n.t('To set up a CI/CD webhook, open the page "{0}" and enter the URI to the created web app in your dockerhub account', dockerhubUri), dockerhubPrompt)
                 .then(response => {
                     if (response) {
                         void vscode.env.clipboard.writeText(appUri);

--- a/src/commands/registries/azure/WebSitesPortPromptStep.ts
+++ b/src/commands/registries/azure/WebSitesPortPromptStep.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep } from "@microsoft/vscode-azext-utils";
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { IAppServiceContainerWizardContext } from './deployImageToAzure';
 
 export class WebSitesPortPromptStep extends AzureWizardPromptStep<IAppServiceContainerWizardContext> {
 
     public async prompt(context: IAppServiceContainerWizardContext): Promise<void> {
-        const prompt: string = localize('vscode-docker.deployAppService.WebSitesPortPromptStep.whatPort', 'What port does your app listen on?');
+        const prompt: string = l10n.t('What port does your app listen on?');
         const placeHolder: string = '80';
         const value: string = '80';
         const portString: string = await context.ui.showInputBox({ prompt, placeHolder, value, validateInput });
@@ -30,6 +30,6 @@ function validateInput(value: string | undefined): string | undefined {
         }
     }
 
-    return localize('vscode-docker.deployAppService.WebSitesPortPromptStep.InvalidPort', 'Port must be a positive integer (1 to 65535).');
+    return l10n.t('Port must be a positive integer (1 to 65535).');
 }
 

--- a/src/commands/registries/azure/deleteAzureRegistry.ts
+++ b/src/commands/registries/azure/deleteAzureRegistry.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
-import { ProgressLocation, window } from 'vscode';
+import { l10n, ProgressLocation, window } from 'vscode';
 import { ext } from '../../../extensionVariables';
-import { l10n } from 'vscode';
 import type { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
 import { registryExpectedContextValues } from '../../../tree/registries/registryContextValues';
 

--- a/src/commands/registries/azure/deleteAzureRegistry.ts
+++ b/src/commands/registries/azure/deleteAzureRegistry.ts
@@ -6,7 +6,7 @@
 import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
 import { ProgressLocation, window } from 'vscode';
 import { ext } from '../../../extensionVariables';
-import { localize } from "../../../localize";
+import { l10n } from 'vscode';
 import type { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
 import { registryExpectedContextValues } from '../../../tree/registries/registryContextValues';
 
@@ -15,16 +15,16 @@ export async function deleteAzureRegistry(context: IActionContext, node?: AzureR
         node = await ext.registriesTree.showTreeItemPicker<AzureRegistryTreeItem>(registryExpectedContextValues.azure.registry, { ...context, suppressCreatePick: true });
     }
 
-    const confirmDelete: string = localize('vscode-docker.commands.registries.azure.deleteRegistry.confirm', 'Are you sure you want to delete registry "{0}" and its associated images?', node.registryName);
+    const confirmDelete: string = l10n.t('Are you sure you want to delete registry "{0}" and its associated images?', node.registryName);
     // no need to check result - cancel will throw a UserCancelledError
     await context.ui.showWarningMessage(confirmDelete, { modal: true }, DialogResponses.deleteResponse);
 
-    const deleting = localize('vscode-docker.commands.registries.azure.deleteRegistry.deleting', 'Deleting registry "{0}"...', node.registryName);
+    const deleting = l10n.t('Deleting registry "{0}"...', node.registryName);
     await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async () => {
         await node.deleteTreeItem(context);
     });
 
-    const message = localize('vscode-docker.commands.registries.azure.deleteRegistry.deleted', 'Successfully deleted registry "{0}".', node.registryName);
+    const message = l10n.t('Successfully deleted registry "{0}".', node.registryName);
     // don't wait
     /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
     window.showInformationMessage(message);

--- a/src/commands/registries/azure/deleteAzureRepository.ts
+++ b/src/commands/registries/azure/deleteAzureRepository.ts
@@ -6,7 +6,7 @@
 import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
 import { ProgressLocation, window } from 'vscode';
 import { ext } from '../../../extensionVariables';
-import { localize } from "../../../localize";
+import { l10n } from 'vscode';
 import type { AzureRepositoryTreeItem } from '../../../tree/registries/azure/AzureRepositoryTreeItem';
 import { registryExpectedContextValues } from '../../../tree/registries/registryContextValues';
 
@@ -15,16 +15,16 @@ export async function deleteAzureRepository(context: IActionContext, node?: Azur
         node = await ext.registriesTree.showTreeItemPicker<AzureRepositoryTreeItem>(registryExpectedContextValues.azure.repository, { ...context, suppressCreatePick: true });
     }
 
-    const confirmDelete = localize('vscode-docker.commands.registries.azure.deleteRepository.confirm', 'Are you sure you want to delete repository "{0}" and its associated images?', node.repoName);
+    const confirmDelete = l10n.t('Are you sure you want to delete repository "{0}" and its associated images?', node.repoName);
     // no need to check result - cancel will throw a UserCancelledError
     await context.ui.showWarningMessage(confirmDelete, { modal: true }, DialogResponses.deleteResponse);
 
-    const deleting = localize('vscode-docker.commands.registries.azure.deleteRepository.deleting', 'Deleting repository "{0}"...', node.repoName);
+    const deleting = l10n.t('Deleting repository "{0}"...', node.repoName);
     await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async () => {
         await node.deleteTreeItem(context);
     });
 
-    const deleteSucceeded = localize('vscode-docker.commands.registries.azure.deleteRepository.deleted', 'Successfully deleted repository "{0}".', node.repoName);
+    const deleteSucceeded = l10n.t('Successfully deleted repository "{0}".', node.repoName);
     // don't wait
     /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
     window.showInformationMessage(deleteSucceeded);

--- a/src/commands/registries/azure/deleteAzureRepository.ts
+++ b/src/commands/registries/azure/deleteAzureRepository.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
-import { ProgressLocation, window } from 'vscode';
+import { l10n, ProgressLocation, window } from 'vscode';
 import { ext } from '../../../extensionVariables';
-import { l10n } from 'vscode';
 import type { AzureRepositoryTreeItem } from '../../../tree/registries/azure/AzureRepositoryTreeItem';
 import { registryExpectedContextValues } from '../../../tree/registries/registryContextValues';
 

--- a/src/commands/registries/azure/deployImageToAca.ts
+++ b/src/commands/registries/azure/deployImageToAca.ts
@@ -7,7 +7,7 @@ import * as semver from 'semver';
 import * as vscode from 'vscode';
 import { DialogResponses, IActionContext, nonNullProp, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { RemoteTagTreeItem } from '../../../tree/registries/RemoteTagTreeItem';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { ext } from '../../../extensionVariables';
 import { registryExpectedContextValues } from '../../../tree/registries/registryContextValues';
 import { RegistryTreeItemBase } from '../../../tree/registries/RegistryTreeItemBase';
@@ -52,7 +52,7 @@ export async function deployImageToAca(context: IActionContext, node?: RemoteTag
         const { auth } = await registry.getDockerCliCredentials() as { auth?: { username?: string, password?: string } };
 
         if (!auth?.username || !auth?.password) {
-            throw new Error(localize('vscode-docker.commands.registries.azure.deployImageToAca.noCredentials', 'No credentials found for registry "{0}".', registry.label));
+            throw new Error(l10n.t('No credentials found for registry "{0}".', registry.label));
         }
 
         if (registry instanceof DockerHubNamespaceTreeItem) {
@@ -87,14 +87,13 @@ function isAcaExtensionInstalled(): boolean {
 }
 
 async function openAcaInstallPage(context: IActionContext): Promise<void> {
-    const message = localize(
-        'vscode-docker.commands.registries.azure.deployImageToAca.installAcaExtension',
+    const message = l10n.t(
         'Version {0} or higher of the Azure Container Apps extension is required to deploy to Azure Container Apps. Would you like to install it now?',
         minimumAcaExtensionVersion
     );
 
     const installButton: vscode.MessageItem = {
-        title: localize('vscode-docker.commands.registries.azure.deployImageToAca.install', 'Install'),
+        title: l10n.t('Install'),
     };
 
     const response = await context.ui.showWarningMessage(message, { modal: true }, installButton, DialogResponses.cancel);

--- a/src/commands/registries/azure/deployImageToAca.ts
+++ b/src/commands/registries/azure/deployImageToAca.ts
@@ -3,18 +3,17 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { DialogResponses, IActionContext, nonNullProp, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as semver from 'semver';
 import * as vscode from 'vscode';
-import { DialogResponses, IActionContext, nonNullProp, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { RemoteTagTreeItem } from '../../../tree/registries/RemoteTagTreeItem';
-import { l10n } from 'vscode';
 import { ext } from '../../../extensionVariables';
-import { registryExpectedContextValues } from '../../../tree/registries/registryContextValues';
-import { RegistryTreeItemBase } from '../../../tree/registries/RegistryTreeItemBase';
+import { parseDockerLikeImageName } from '../../../runtimes/docker/clients/DockerClientBase/parseDockerLikeImageName';
 import { AzureRegistryTreeItem } from '../../../tree/registries/azure/AzureRegistryTreeItem';
 import { DockerHubNamespaceTreeItem } from '../../../tree/registries/dockerHub/DockerHubNamespaceTreeItem';
+import { registryExpectedContextValues } from '../../../tree/registries/registryContextValues';
+import { RegistryTreeItemBase } from '../../../tree/registries/RegistryTreeItemBase';
+import { RemoteTagTreeItem } from '../../../tree/registries/RemoteTagTreeItem';
 import { addImageTaggingTelemetry } from '../../images/tagImage';
-import { parseDockerLikeImageName } from '../../../runtimes/docker/clients/DockerClientBase/parseDockerLikeImageName';
 
 const acaExtensionId = 'ms-azuretools.vscode-azurecontainerapps';
 const minimumAcaExtensionVersion = '0.4.0';
@@ -52,7 +51,7 @@ export async function deployImageToAca(context: IActionContext, node?: RemoteTag
         const { auth } = await registry.getDockerCliCredentials() as { auth?: { username?: string, password?: string } };
 
         if (!auth?.username || !auth?.password) {
-            throw new Error(l10n.t('No credentials found for registry "{0}".', registry.label));
+            throw new Error(vscode.l10n.t('No credentials found for registry "{0}".', registry.label));
         }
 
         if (registry instanceof DockerHubNamespaceTreeItem) {
@@ -87,13 +86,13 @@ function isAcaExtensionInstalled(): boolean {
 }
 
 async function openAcaInstallPage(context: IActionContext): Promise<void> {
-    const message = l10n.t(
+    const message = vscode.l10n.t(
         'Version {0} or higher of the Azure Container Apps extension is required to deploy to Azure Container Apps. Would you like to install it now?',
         minimumAcaExtensionVersion
     );
 
     const installButton: vscode.MessageItem = {
-        title: l10n.t('Install'),
+        title: vscode.l10n.t('Install'),
     };
 
     const response = await context.ui.showWarningMessage(message, { modal: true }, installButton, DialogResponses.cancel);

--- a/src/commands/registries/azure/deployImageToAzure.ts
+++ b/src/commands/registries/azure/deployImageToAzure.ts
@@ -6,9 +6,8 @@
 import type { Site } from '@azure/arm-appservice'; // These are only dev-time imports so don't need to be lazy
 import type { IAppServiceWizardContext } from "@microsoft/vscode-azext-azureappservice"; // These are only dev-time imports so don't need to be lazy
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, nonNullProp } from "@microsoft/vscode-azext-utils";
-import { Uri, env, window } from "vscode";
+import { env, l10n, Uri, window } from "vscode";
 import { ext } from "../../../extensionVariables";
-import { l10n } from 'vscode';
 import { RegistryApi } from '../../../tree/registries/all/RegistryApi';
 import { azureRegistryProviderId } from '../../../tree/registries/azure/azureRegistryProvider';
 import { registryExpectedContextValues } from '../../../tree/registries/registryContextValues';

--- a/src/commands/registries/azure/deployImageToAzure.ts
+++ b/src/commands/registries/azure/deployImageToAzure.ts
@@ -8,7 +8,7 @@ import type { IAppServiceWizardContext } from "@microsoft/vscode-azext-azureapps
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, nonNullProp } from "@microsoft/vscode-azext-utils";
 import { Uri, env, window } from "vscode";
 import { ext } from "../../../extensionVariables";
-import { localize } from "../../../localize";
+import { l10n } from 'vscode';
 import { RegistryApi } from '../../../tree/registries/all/RegistryApi';
 import { azureRegistryProviderId } from '../../../tree/registries/azure/azureRegistryProvider';
 import { registryExpectedContextValues } from '../../../tree/registries/registryContextValues';
@@ -59,17 +59,17 @@ export async function deployImageToAzure(context: IActionContext, node?: RemoteT
         new DockerWebhookCreateStep(node),
     ];
 
-    const title = localize('vscode-docker.commands.registries.azure.deployImage.title', 'Create new web app');
+    const title = l10n.t('Create new web app');
     const wizard = new AzureWizard(wizardContext, { title, promptSteps, executeSteps });
     await wizard.prompt();
     await wizard.execute();
 
     const site: Site = nonNullProp(wizardContext, 'site');
     const siteUri: string = `https://${site.defaultHostName}`;
-    const createdNewWebApp: string = localize('vscode-docker.commands.registries.azure.deployImage.created', 'Successfully created web app "{0}": {1}', site.name, siteUri);
+    const createdNewWebApp: string = l10n.t('Successfully created web app "{0}": {1}', site.name, siteUri);
     ext.outputChannel.info(createdNewWebApp);
 
-    const openSite: string = localize('vscode-docker.commands.registries.azure.deployImage.openSite', 'Open Site');
+    const openSite: string = l10n.t('Open Site');
     // don't wait
     /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
     window.showInformationMessage(createdNewWebApp, ...[openSite]).then((selection) => {

--- a/src/commands/registries/azure/tasks/runAzureTask.ts
+++ b/src/commands/registries/azure/tasks/runAzureTask.ts
@@ -5,9 +5,8 @@
 
 import type { TaskRunRequest } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { window } from "vscode";
+import { l10n, window } from "vscode";
 import { ext } from "../../../../extensionVariables";
-import { l10n } from 'vscode';
 import { AzureTaskTreeItem } from "../../../../tree/registries/azure/AzureTaskTreeItem";
 
 export async function runAzureTask(context: IActionContext, node?: AzureTaskTreeItem): Promise<void> {

--- a/src/commands/registries/azure/tasks/runAzureTask.ts
+++ b/src/commands/registries/azure/tasks/runAzureTask.ts
@@ -7,7 +7,7 @@ import type { TaskRunRequest } from "@azure/arm-containerregistry"; // These are
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { window } from "vscode";
 import { ext } from "../../../../extensionVariables";
-import { localize } from "../../../../localize";
+import { l10n } from 'vscode';
 import { AzureTaskTreeItem } from "../../../../tree/registries/azure/AzureTaskTreeItem";
 
 export async function runAzureTask(context: IActionContext, node?: AzureTaskTreeItem): Promise<void> {
@@ -21,5 +21,5 @@ export async function runAzureTask(context: IActionContext, node?: AzureTaskTree
     await node.parent.refresh(context);
     // don't wait
     /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
-    window.showInformationMessage(localize('vscode-docker.commands.registries.azure.tasks.runTaskScheduled', 'Successfully scheduled run "{0}" for task "{1}".', run.runId, node.taskName));
+    window.showInformationMessage(l10n.t('Successfully scheduled run "{0}" for task "{1}".', run.runId, node.taskName));
 }

--- a/src/commands/registries/azure/tasks/scheduleRunRequest.ts
+++ b/src/commands/registries/azure/tasks/scheduleRunRequest.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode';
 import type { DockerBuildRequest as AcrDockerBuildRequest, FileTaskRunRequest as AcrFileTaskRunRequest, OS as AcrOS, Run as AcrRun, ContainerRegistryManagementClient } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import { IActionContext, IAzureQuickPickItem, nonNullProp } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../../../extensionVariables';
-import { localize } from "../../../../localize";
+import { l10n } from 'vscode';
 import { AzureRegistryTreeItem } from '../../../../tree/registries/azure/AzureRegistryTreeItem';
 import { registryExpectedContextValues } from "../../../../tree/registries/registryContextValues";
 import { delay } from '../../../../utils/promiseUtils';
@@ -36,20 +36,20 @@ export async function scheduleRunRequest(context: IActionContext, requestType: '
     let fileItem: Item;
     let imageName: string;
     if (requestType === 'DockerBuildRequest') {
-        rootFolder = await quickPickWorkspaceFolder(context, localize('vscode-docker.commands.registries.azure.tasks.buildFolder', 'To quick build Docker files you must first open a folder or workspace in VS Code.'));
+        rootFolder = await quickPickWorkspaceFolder(context, l10n.t('To quick build Docker files you must first open a folder or workspace in VS Code.'));
         fileItem = await quickPickDockerFileItem(context, uri, rootFolder);
         imageName = await quickPickImageName(context, rootFolder, fileItem);
     } else if (requestType === 'FileTaskRunRequest') {
-        rootFolder = await quickPickWorkspaceFolder(context, localize('vscode-docker.commands.registries.azure.tasks.yamlFolder', 'To run a task from a .yaml file you must first open a folder or workspace in VS Code.'));
-        fileItem = await quickPickYamlFileItem(context, uri, rootFolder, localize('vscode-docker.commands.registries.azure.tasks.yamlYaml', 'To run a task from a .yaml file you must have yaml file in your VS Code workspace.'));
+        rootFolder = await quickPickWorkspaceFolder(context, l10n.t('To run a task from a .yaml file you must first open a folder or workspace in VS Code.'));
+        fileItem = await quickPickYamlFileItem(context, uri, rootFolder, l10n.t('To run a task from a .yaml file you must have yaml file in your VS Code workspace.'));
     } else {
-        throw new Error(localize('vscode-docker.commands.registries.azure.tasks.runTypeUnsupported', 'Run Request Type Currently not supported.'));
+        throw new Error(l10n.t('Run Request Type Currently not supported.'));
     }
 
     const node = await ext.registriesTree.showTreeItemPicker<AzureRegistryTreeItem>(registryExpectedContextValues.azure.registry, context);
 
     const osPick = ['Linux', 'Windows'].map(item => <IAzureQuickPickItem<AcrOS>>{ label: item, data: item });
-    const osType: AcrOS = (await context.ui.showQuickPick(osPick, { placeHolder: localize('vscode-docker.commands.registries.azure.tasks.selectOs', 'Select image base OS') })).data;
+    const osType: AcrOS = (await context.ui.showQuickPick(osPick, { placeHolder: l10n.t('Select image base OS') })).data;
 
     const tarFilePath: string = getTempSourceArchivePath();
 
@@ -65,7 +65,7 @@ export async function scheduleRunRequest(context: IActionContext, requestType: '
         }
 
         const uploadedSourceLocation: string = await uploadSourceCode(await node.getClient(context), node.registryName, node.resourceGroup, rootUri, tarFilePath);
-        ext.outputChannel.info(localize('vscode-docker.commands.registries.azure.tasks.uploaded', 'Uploaded source code from {0}', tarFilePath));
+        ext.outputChannel.info(l10n.t('Uploaded source code from {0}', tarFilePath));
 
         let runRequest: AcrDockerBuildRequest | AcrFileTaskRunRequest;
         if (requestType === 'DockerBuildRequest') {
@@ -87,11 +87,11 @@ export async function scheduleRunRequest(context: IActionContext, requestType: '
         }
 
         // Schedule the run and Clean up.
-        ext.outputChannel.info(localize('vscode-docker.commands.registries.azure.tasks.setUp', 'Set up run request'));
+        ext.outputChannel.info(l10n.t('Set up run request'));
 
         const client = await node.getClient(context);
         const run = await client.registries.beginScheduleRunAndWait(node.resourceGroup, node.registryName, runRequest);
-        ext.outputChannel.info(localize('vscode-docker.commands.registries.azure.tasks.scheduledRun', 'Scheduled run {0}', run.runId));
+        ext.outputChannel.info(l10n.t('Scheduled run {0}', run.runId));
 
         void streamLogs(context, node, run);
 
@@ -134,21 +134,21 @@ async function quickPickImageName(context: IActionContext, rootFolder: vscode.Wo
 }
 
 async function uploadSourceCode(client: ContainerRegistryManagementClient, registryName: string, resourceGroupName: string, rootFolder: vscode.Uri, tarFilePath: string): Promise<string> {
-    ext.outputChannel.info(localize('vscode-docker.commands.registries.azure.tasks.sendingSource', '   Sending source code to temp file'));
+    ext.outputChannel.info(l10n.t('   Sending source code to temp file'));
     const source: string = rootFolder.fsPath;
     let items = await fse.readdir(source);
     items = items.filter(i => !(i in vcsIgnoreList));
     // tslint:disable-next-line:no-unsafe-any
     tar.c({ cwd: source }, items).pipe(fse.createWriteStream(tarFilePath));
 
-    ext.outputChannel.info(localize('vscode-docker.commands.registries.azure.tasks.gettingBuildSourceUploadUrl', '   Getting build source upload URL'));
+    ext.outputChannel.info(l10n.t('   Getting build source upload URL'));
     const sourceUploadLocation = await client.registries.getBuildSourceUploadUrl(resourceGroupName, registryName);
     const uploadUrl: string = sourceUploadLocation.uploadUrl;
     const relativePath: string = sourceUploadLocation.relativePath;
 
     const storageBlob = await getStorageBlob();
     const blobClient = new storageBlob.BlockBlobClient(uploadUrl);
-    ext.outputChannel.info(localize('vscode-docker.commands.registries.azure.tasks.creatingBlockBlob', '   Creating block blob'));
+    ext.outputChannel.info(l10n.t('   Creating block blob'));
     await blobClient.uploadFile(tarFilePath);
 
     return relativePath;
@@ -202,7 +202,7 @@ function getTempSourceArchivePath(): string {
     /* tslint:disable-next-line:insecure-random */
     const id: number = Math.floor(Math.random() * Math.pow(10, idPrecision));
     const archive = `sourceArchive${id}.tar.gz`;
-    ext.outputChannel.info(localize('vscode-docker.commands.registries.azure.tasks.settingUpTempFile', 'Setting up temp file with \'{0}\'', archive));
+    ext.outputChannel.info(l10n.t('Setting up temp file with \'{0}\'', archive));
     const tarFilePath: string = path.join(os.tmpdir(), archive);
     return tarFilePath;
 }

--- a/src/commands/registries/azure/tasks/scheduleRunRequest.ts
+++ b/src/commands/registries/azure/tasks/scheduleRunRequest.ts
@@ -3,23 +3,22 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { ContainerRegistryManagementClient, DockerBuildRequest as AcrDockerBuildRequest, FileTaskRunRequest as AcrFileTaskRunRequest, OS as AcrOS, Run as AcrRun } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
+import { IActionContext, IAzureQuickPickItem, nonNullProp } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as tar from 'tar';
 import * as vscode from 'vscode';
-import type { DockerBuildRequest as AcrDockerBuildRequest, FileTaskRunRequest as AcrFileTaskRunRequest, OS as AcrOS, Run as AcrRun, ContainerRegistryManagementClient } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
-import { IActionContext, IAzureQuickPickItem, nonNullProp } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../../../extensionVariables';
-import { l10n } from 'vscode';
 import { AzureRegistryTreeItem } from '../../../../tree/registries/azure/AzureRegistryTreeItem';
 import { registryExpectedContextValues } from "../../../../tree/registries/registryContextValues";
+import { bufferToString } from "../../../../utils/execAsync";
+import { getStorageBlob } from '../../../../utils/lazyPackages';
 import { delay } from '../../../../utils/promiseUtils';
 import { Item, quickPickDockerFileItem, quickPickYamlFileItem } from '../../../../utils/quickPickFile';
 import { quickPickWorkspaceFolder } from '../../../../utils/quickPickWorkspaceFolder';
-import { bufferToString } from "../../../../utils/execAsync";
 import { addImageTaggingTelemetry, getTagFromUserInput } from '../../../images/tagImage';
-import { getStorageBlob } from '../../../../utils/lazyPackages';
 
 const idPrecision = 6;
 const vcsIgnoreList = ['.git', '.gitignore', '.bzr', 'bzrignore', '.hg', '.hgignore', '.svn'];
@@ -36,20 +35,20 @@ export async function scheduleRunRequest(context: IActionContext, requestType: '
     let fileItem: Item;
     let imageName: string;
     if (requestType === 'DockerBuildRequest') {
-        rootFolder = await quickPickWorkspaceFolder(context, l10n.t('To quick build Docker files you must first open a folder or workspace in VS Code.'));
+        rootFolder = await quickPickWorkspaceFolder(context, vscode.l10n.t('To quick build Docker files you must first open a folder or workspace in VS Code.'));
         fileItem = await quickPickDockerFileItem(context, uri, rootFolder);
         imageName = await quickPickImageName(context, rootFolder, fileItem);
     } else if (requestType === 'FileTaskRunRequest') {
-        rootFolder = await quickPickWorkspaceFolder(context, l10n.t('To run a task from a .yaml file you must first open a folder or workspace in VS Code.'));
-        fileItem = await quickPickYamlFileItem(context, uri, rootFolder, l10n.t('To run a task from a .yaml file you must have yaml file in your VS Code workspace.'));
+        rootFolder = await quickPickWorkspaceFolder(context, vscode.l10n.t('To run a task from a .yaml file you must first open a folder or workspace in VS Code.'));
+        fileItem = await quickPickYamlFileItem(context, uri, rootFolder, vscode.l10n.t('To run a task from a .yaml file you must have yaml file in your VS Code workspace.'));
     } else {
-        throw new Error(l10n.t('Run Request Type Currently not supported.'));
+        throw new Error(vscode.l10n.t('Run Request Type Currently not supported.'));
     }
 
     const node = await ext.registriesTree.showTreeItemPicker<AzureRegistryTreeItem>(registryExpectedContextValues.azure.registry, context);
 
     const osPick = ['Linux', 'Windows'].map(item => <IAzureQuickPickItem<AcrOS>>{ label: item, data: item });
-    const osType: AcrOS = (await context.ui.showQuickPick(osPick, { placeHolder: l10n.t('Select image base OS') })).data;
+    const osType: AcrOS = (await context.ui.showQuickPick(osPick, { placeHolder: vscode.l10n.t('Select image base OS') })).data;
 
     const tarFilePath: string = getTempSourceArchivePath();
 
@@ -65,7 +64,7 @@ export async function scheduleRunRequest(context: IActionContext, requestType: '
         }
 
         const uploadedSourceLocation: string = await uploadSourceCode(await node.getClient(context), node.registryName, node.resourceGroup, rootUri, tarFilePath);
-        ext.outputChannel.info(l10n.t('Uploaded source code from {0}', tarFilePath));
+        ext.outputChannel.info(vscode.l10n.t('Uploaded source code from {0}', tarFilePath));
 
         let runRequest: AcrDockerBuildRequest | AcrFileTaskRunRequest;
         if (requestType === 'DockerBuildRequest') {
@@ -87,11 +86,11 @@ export async function scheduleRunRequest(context: IActionContext, requestType: '
         }
 
         // Schedule the run and Clean up.
-        ext.outputChannel.info(l10n.t('Set up run request'));
+        ext.outputChannel.info(vscode.l10n.t('Set up run request'));
 
         const client = await node.getClient(context);
         const run = await client.registries.beginScheduleRunAndWait(node.resourceGroup, node.registryName, runRequest);
-        ext.outputChannel.info(l10n.t('Scheduled run {0}', run.runId));
+        ext.outputChannel.info(vscode.l10n.t('Scheduled run {0}', run.runId));
 
         void streamLogs(context, node, run);
 
@@ -134,21 +133,21 @@ async function quickPickImageName(context: IActionContext, rootFolder: vscode.Wo
 }
 
 async function uploadSourceCode(client: ContainerRegistryManagementClient, registryName: string, resourceGroupName: string, rootFolder: vscode.Uri, tarFilePath: string): Promise<string> {
-    ext.outputChannel.info(l10n.t('   Sending source code to temp file'));
+    ext.outputChannel.info(vscode.l10n.t('   Sending source code to temp file'));
     const source: string = rootFolder.fsPath;
     let items = await fse.readdir(source);
     items = items.filter(i => !(i in vcsIgnoreList));
     // tslint:disable-next-line:no-unsafe-any
     tar.c({ cwd: source }, items).pipe(fse.createWriteStream(tarFilePath));
 
-    ext.outputChannel.info(l10n.t('   Getting build source upload URL'));
+    ext.outputChannel.info(vscode.l10n.t('   Getting build source upload URL'));
     const sourceUploadLocation = await client.registries.getBuildSourceUploadUrl(resourceGroupName, registryName);
     const uploadUrl: string = sourceUploadLocation.uploadUrl;
     const relativePath: string = sourceUploadLocation.relativePath;
 
     const storageBlob = await getStorageBlob();
     const blobClient = new storageBlob.BlockBlobClient(uploadUrl);
-    ext.outputChannel.info(l10n.t('   Creating block blob'));
+    ext.outputChannel.info(vscode.l10n.t('   Creating block blob'));
     await blobClient.uploadFile(tarFilePath);
 
     return relativePath;
@@ -202,7 +201,7 @@ function getTempSourceArchivePath(): string {
     /* tslint:disable-next-line:insecure-random */
     const id: number = Math.floor(Math.random() * Math.pow(10, idPrecision));
     const archive = `sourceArchive${id}.tar.gz`;
-    ext.outputChannel.info(l10n.t('Setting up temp file with \'{0}\'', archive));
+    ext.outputChannel.info(vscode.l10n.t('Setting up temp file with \'{0}\'', archive));
     const tarFilePath: string = path.join(os.tmpdir(), archive);
     return tarFilePath;
 }

--- a/src/commands/registries/azure/tasks/viewAzureTaskLogs.ts
+++ b/src/commands/registries/azure/tasks/viewAzureTaskLogs.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, nonNullProp, openReadOnlyContent } from "@microsoft/vscode-azext-utils";
-import { ext } from "../../../../extensionVariables";
 import { l10n } from 'vscode';
+import { ext } from "../../../../extensionVariables";
 import { AzureTaskRunTreeItem } from "../../../../tree/registries/azure/AzureTaskRunTreeItem";
-import { getStorageBlob } from "../../../../utils/lazyPackages";
 import { bufferToString } from "../../../../utils/execAsync";
+import { getStorageBlob } from "../../../../utils/lazyPackages";
 
 export async function viewAzureTaskLogs(context: IActionContext, node?: AzureTaskRunTreeItem): Promise<void> {
     if (!node) {

--- a/src/commands/registries/azure/tasks/viewAzureTaskLogs.ts
+++ b/src/commands/registries/azure/tasks/viewAzureTaskLogs.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext, nonNullProp, openReadOnlyContent } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../../../extensionVariables";
-import { localize } from "../../../../localize";
+import { l10n } from 'vscode';
 import { AzureTaskRunTreeItem } from "../../../../tree/registries/azure/AzureTaskRunTreeItem";
 import { getStorageBlob } from "../../../../utils/lazyPackages";
 import { bufferToString } from "../../../../utils/execAsync";
@@ -16,7 +16,7 @@ export async function viewAzureTaskLogs(context: IActionContext, node?: AzureTas
     }
 
     const registryTI = node.parent.parent.parent;
-    await node.runWithTemporaryDescription(context, localize('vscode-docker.commands.registries.azure.tasks.retrievingLogs', 'Retrieving logs...'), async () => {
+    await node.runWithTemporaryDescription(context, l10n.t('Retrieving logs...'), async () => {
         const result = await (await registryTI.getClient(context)).runs.getLogSasUrl(registryTI.resourceGroup, registryTI.registryName, node.runId);
 
         const storageBlob = await getStorageBlob();

--- a/src/commands/registries/azure/untagAzureImage.ts
+++ b/src/commands/registries/azure/untagAzureImage.ts
@@ -6,7 +6,7 @@
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { ProgressLocation, window } from "vscode";
 import { ext } from "../../../extensionVariables";
-import { localize } from "../../../localize";
+import { l10n } from 'vscode';
 import { registryExpectedContextValues } from "../../../tree/registries/registryContextValues";
 import { RemoteTagTreeItem } from "../../../tree/registries/RemoteTagTreeItem";
 import { registryRequest } from "../../../utils/registryRequestUtils";
@@ -16,15 +16,15 @@ export async function untagAzureImage(context: IActionContext, node?: RemoteTagT
         node = await ext.registriesTree.showTreeItemPicker<RemoteTagTreeItem>(registryExpectedContextValues.azure.tag, {
             ...context,
             suppressCreatePick: true,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.registries.azure.untag.noImages', 'No images are available to untag')
+            noItemFoundErrorMessage: l10n.t('No images are available to untag')
         });
     }
 
-    const confirmUntag: string = localize('vscode-docker.commands.registries.azure.untag.confirm', 'Are you sure you want to untag image "{0}"? This does not delete the manifest referenced by the tag.', node.repoNameAndTag);
+    const confirmUntag: string = l10n.t('Are you sure you want to untag image "{0}"? This does not delete the manifest referenced by the tag.', node.repoNameAndTag);
     // no need to check result - cancel will throw a UserCancelledError
     await context.ui.showWarningMessage(confirmUntag, { modal: true }, { title: "Untag" });
 
-    const untagging = localize('vscode-docker.commands.registries.azure.untag.untagging', 'Untagging image "{0}"...', node.repoNameAndTag);
+    const untagging = l10n.t('Untagging image "{0}"...', node.repoNameAndTag);
     const repoTI = node.parent;
     await window.withProgress({ location: ProgressLocation.Notification, title: untagging }, async () => {
         await registryRequest(repoTI, 'DELETE', `v2/_acr/${repoTI.repoName}/tags/${node.tag}`);
@@ -33,5 +33,5 @@ export async function untagAzureImage(context: IActionContext, node?: RemoteTagT
 
     // don't wait
     /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
-    window.showInformationMessage(localize('vscode-docker.commands.registries.azure.untag.untagged', 'Successfully untagged image "{0}".', node.repoNameAndTag));
+    window.showInformationMessage(l10n.t('Successfully untagged image "{0}".', node.repoNameAndTag));
 }

--- a/src/commands/registries/azure/untagAzureImage.ts
+++ b/src/commands/registries/azure/untagAzureImage.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { ProgressLocation, window } from "vscode";
+import { l10n, ProgressLocation, window } from "vscode";
 import { ext } from "../../../extensionVariables";
-import { l10n } from 'vscode';
 import { registryExpectedContextValues } from "../../../tree/registries/registryContextValues";
 import { RemoteTagTreeItem } from "../../../tree/registries/RemoteTagTreeItem";
 import { registryRequest } from "../../../utils/registryRequestUtils";

--- a/src/commands/registries/copyRemoteFullTag.ts
+++ b/src/commands/registries/copyRemoteFullTag.ts
@@ -6,7 +6,7 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { registryExpectedContextValues } from '../../tree/registries/registryContextValues';
 import { RemoteTagTreeItem } from '../../tree/registries/RemoteTagTreeItem';
 
@@ -14,7 +14,7 @@ export async function copyRemoteFullTag(context: IActionContext, node?: RemoteTa
     if (!node) {
         node = await ext.registriesTree.showTreeItemPicker<RemoteTagTreeItem>([registryExpectedContextValues.dockerV2.tag, registryExpectedContextValues.dockerHub.tag], {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.registries.copyRemoteFullTag.noImages', 'No remote images are available to copy the full tag')
+            noItemFoundErrorMessage: l10n.t('No remote images are available to copy the full tag')
         });
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/src/commands/registries/copyRemoteFullTag.ts
+++ b/src/commands/registries/copyRemoteFullTag.ts
@@ -6,7 +6,6 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { registryExpectedContextValues } from '../../tree/registries/registryContextValues';
 import { RemoteTagTreeItem } from '../../tree/registries/RemoteTagTreeItem';
 
@@ -14,7 +13,7 @@ export async function copyRemoteFullTag(context: IActionContext, node?: RemoteTa
     if (!node) {
         node = await ext.registriesTree.showTreeItemPicker<RemoteTagTreeItem>([registryExpectedContextValues.dockerV2.tag, registryExpectedContextValues.dockerHub.tag], {
             ...context,
-            noItemFoundErrorMessage: l10n.t('No remote images are available to copy the full tag')
+            noItemFoundErrorMessage: vscode.l10n.t('No remote images are available to copy the full tag')
         });
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/src/commands/registries/copyRemoteImageDigest.ts
+++ b/src/commands/registries/copyRemoteImageDigest.ts
@@ -6,7 +6,7 @@
 import { IActionContext, nonNullProp } from "@microsoft/vscode-azext-utils";
 import * as vscode from "vscode";
 import { ext } from "../../extensionVariables";
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { AzureTaskRunTreeItem } from "../../tree/registries/azure/AzureTaskRunTreeItem";
 import { DockerV2TagTreeItem } from "../../tree/registries/dockerV2/DockerV2TagTreeItem";
 import { registryExpectedContextValues } from "../../tree/registries/registryContextValues";
@@ -15,7 +15,7 @@ export async function copyRemoteImageDigest(context: IActionContext, node?: Dock
     if (!node) {
         node = await ext.registriesTree.showTreeItemPicker<DockerV2TagTreeItem>(registryExpectedContextValues.dockerV2.tag, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.registries.copyRemote.noImages', 'No remote images are available to copy the digest')
+            noItemFoundErrorMessage: l10n.t('No remote images are available to copy the digest')
         });
     }
 
@@ -24,10 +24,10 @@ export async function copyRemoteImageDigest(context: IActionContext, node?: Dock
         if (node.outputImage) {
             digest = nonNullProp(node.outputImage, 'digest');
         } else {
-            throw new Error(localize('vscode-docker.commands.registries.copyRemote.noOutputImage', 'Failed to find output image for this task run.'));
+            throw new Error(l10n.t('Failed to find output image for this task run.'));
         }
     } else {
-        await node.runWithTemporaryDescription(context, localize('vscode-docker.commands.registries.copyRemote.gettingDigest', 'Getting digest...'), async () => {
+        await node.runWithTemporaryDescription(context, l10n.t('Getting digest...'), async () => {
             digest = await (<DockerV2TagTreeItem>node).getDigest();
         });
     }

--- a/src/commands/registries/copyRemoteImageDigest.ts
+++ b/src/commands/registries/copyRemoteImageDigest.ts
@@ -6,7 +6,6 @@
 import { IActionContext, nonNullProp } from "@microsoft/vscode-azext-utils";
 import * as vscode from "vscode";
 import { ext } from "../../extensionVariables";
-import { l10n } from 'vscode';
 import { AzureTaskRunTreeItem } from "../../tree/registries/azure/AzureTaskRunTreeItem";
 import { DockerV2TagTreeItem } from "../../tree/registries/dockerV2/DockerV2TagTreeItem";
 import { registryExpectedContextValues } from "../../tree/registries/registryContextValues";
@@ -15,7 +14,7 @@ export async function copyRemoteImageDigest(context: IActionContext, node?: Dock
     if (!node) {
         node = await ext.registriesTree.showTreeItemPicker<DockerV2TagTreeItem>(registryExpectedContextValues.dockerV2.tag, {
             ...context,
-            noItemFoundErrorMessage: l10n.t('No remote images are available to copy the digest')
+            noItemFoundErrorMessage: vscode.l10n.t('No remote images are available to copy the digest')
         });
     }
 
@@ -24,10 +23,10 @@ export async function copyRemoteImageDigest(context: IActionContext, node?: Dock
         if (node.outputImage) {
             digest = nonNullProp(node.outputImage, 'digest');
         } else {
-            throw new Error(l10n.t('Failed to find output image for this task run.'));
+            throw new Error(vscode.l10n.t('Failed to find output image for this task run.'));
         }
     } else {
-        await node.runWithTemporaryDescription(context, l10n.t('Getting digest...'), async () => {
+        await node.runWithTemporaryDescription(context, vscode.l10n.t('Getting digest...'), async () => {
             digest = await (<DockerV2TagTreeItem>node).getDigest();
         });
     }

--- a/src/commands/registries/deleteRemoteImage.ts
+++ b/src/commands/registries/deleteRemoteImage.ts
@@ -6,7 +6,7 @@
 import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
 import { ProgressLocation, window } from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { DockerV2TagTreeItem } from '../../tree/registries/dockerV2/DockerV2TagTreeItem';
 import { registryExpectedContextValues } from '../../tree/registries/registryContextValues';
 
@@ -15,23 +15,23 @@ export async function deleteRemoteImage(context: IActionContext, node?: DockerV2
         node = await ext.registriesTree.showTreeItemPicker<DockerV2TagTreeItem>(registryExpectedContextValues.dockerV2.tag, {
             ...context,
             suppressCreatePick: true,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.registries.deleteRemote.noImages', 'No remote images are available to delete')
+            noItemFoundErrorMessage: l10n.t('No remote images are available to delete')
         });
     }
 
-    const confirmDelete = localize('vscode-docker.commands.registries.deleteRemote.confirm', 'Are you sure you want to delete image "{0}"? This will delete all images that have the same digest.', node.repoNameAndTag);
+    const confirmDelete = l10n.t('Are you sure you want to delete image "{0}"? This will delete all images that have the same digest.', node.repoNameAndTag);
     // no need to check result - cancel will throw a UserCancelledError
     await context.ui.showWarningMessage(confirmDelete, { modal: true }, DialogResponses.deleteResponse);
 
     const repoTI = node.parent;
-    const deleting = localize('vscode-docker.commands.registries.deleteRemote.deleting', 'Deleting image "{0}"...', node.repoNameAndTag);
+    const deleting = l10n.t('Deleting image "{0}"...', node.repoNameAndTag);
     await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async () => {
         await node.deleteTreeItem(context);
     });
 
     // Other tags that also matched the image may have been deleted, so refresh the whole repository
     await repoTI.refresh(context);
-    const message = localize('vscode-docker.commands.registries.deleteRemote.deleted', 'Successfully deleted image "{0}".', node.repoNameAndTag);
+    const message = l10n.t('Successfully deleted image "{0}".', node.repoNameAndTag);
     // don't wait
     /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
     window.showInformationMessage(message);

--- a/src/commands/registries/deleteRemoteImage.ts
+++ b/src/commands/registries/deleteRemoteImage.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
-import { ProgressLocation, window } from 'vscode';
+import { l10n, ProgressLocation, window } from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { DockerV2TagTreeItem } from '../../tree/registries/dockerV2/DockerV2TagTreeItem';
 import { registryExpectedContextValues } from '../../tree/registries/registryContextValues';
 

--- a/src/commands/registries/dockerHub/openDockerHubInBrowser.ts
+++ b/src/commands/registries/dockerHub/openDockerHubInBrowser.ts
@@ -3,11 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from "vscode";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
+import * as vscode from "vscode";
 import { dockerHubUrl } from "../../../constants";
 import { ext } from "../../../extensionVariables";
-import { l10n } from 'vscode';
 import { DockerHubNamespaceTreeItem } from "../../../tree/registries/dockerHub/DockerHubNamespaceTreeItem";
 import { DockerHubRepositoryTreeItem } from "../../../tree/registries/dockerHub/DockerHubRepositoryTreeItem";
 import { registryExpectedContextValues } from "../../../tree/registries/registryContextValues";
@@ -17,7 +16,7 @@ export async function openDockerHubInBrowser(context: IActionContext, node?: Doc
     if (!node) {
         node = await ext.registriesTree.showTreeItemPicker<DockerHubNamespaceTreeItem>(registryExpectedContextValues.dockerHub.registry, {
             ...context,
-            noItemFoundErrorMessage: l10n.t('No Docker Hub registries available to browse')
+            noItemFoundErrorMessage: vscode.l10n.t('No Docker Hub registries available to browse')
         });
     }
 

--- a/src/commands/registries/dockerHub/openDockerHubInBrowser.ts
+++ b/src/commands/registries/dockerHub/openDockerHubInBrowser.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { dockerHubUrl } from "../../../constants";
 import { ext } from "../../../extensionVariables";
-import { localize } from "../../../localize";
+import { l10n } from 'vscode';
 import { DockerHubNamespaceTreeItem } from "../../../tree/registries/dockerHub/DockerHubNamespaceTreeItem";
 import { DockerHubRepositoryTreeItem } from "../../../tree/registries/dockerHub/DockerHubRepositoryTreeItem";
 import { registryExpectedContextValues } from "../../../tree/registries/registryContextValues";
@@ -17,7 +17,7 @@ export async function openDockerHubInBrowser(context: IActionContext, node?: Doc
     if (!node) {
         node = await ext.registriesTree.showTreeItemPicker<DockerHubNamespaceTreeItem>(registryExpectedContextValues.dockerHub.registry, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.commands.registries.dockerHub.noRegistries', 'No Docker Hub registries available to browse')
+            noItemFoundErrorMessage: l10n.t('No Docker Hub registries available to browse')
         });
     }
 

--- a/src/commands/registries/logInToDockerCli.ts
+++ b/src/commands/registries/logInToDockerCli.ts
@@ -4,11 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, parseError } from '@microsoft/vscode-azext-utils';
-import * as vscode from 'vscode';
 import * as stream from 'stream';
+import * as vscode from 'vscode';
 import { NULL_GUID } from '../../constants';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { registryExpectedContextValues } from '../../tree/registries/registryContextValues';
 import { RegistryTreeItemBase } from '../../tree/registries/RegistryTreeItemBase';
 
@@ -30,11 +29,11 @@ export async function logInToDockerCli(context: IActionContext, node?: RegistryT
     }
 
     if (!username || !password) {
-        ext.outputChannel.warn(l10n.t('Skipping login for "{0}" because it does not require authentication.', creds.registryPath));
+        ext.outputChannel.warn(vscode.l10n.t('Skipping login for "{0}" because it does not require authentication.', creds.registryPath));
     } else {
         const progressOptions: vscode.ProgressOptions = {
             location: vscode.ProgressLocation.Notification,
-            title: l10n.t('Logging in...'),
+            title: vscode.l10n.t('Logging in...'),
         };
 
         await vscode.window.withProgress(progressOptions, async () => {
@@ -57,7 +56,7 @@ export async function logInToDockerCli(context: IActionContext, node?: RegistryT
                     // Temporary work-around for this error- same as Azure CLI
                     // See https://github.com/Azure/azure-cli/issues/4843
                     context.errorHandling.suppressReportIssue = true;
-                    throw new Error(l10n.t('In order to log in to the Docker CLI using tokens, you currently need to go to your Docker config file and remove `"credsStore": "wincred"`, then try again. \nDoing this will disable wincred and cause Docker to store credentials directly in the .docker/config.json file. All registries that are currently logged in will be logged out.'));
+                    throw new Error(vscode.l10n.t('In order to log in to the Docker CLI using tokens, you currently need to go to your Docker config file and remove `"credsStore": "wincred"`, then try again. \nDoing this will disable wincred and cause Docker to store credentials directly in the .docker/config.json file. All registries that are currently logged in will be logged out.'));
                 } else {
                     throw err;
                 }

--- a/src/commands/registries/logInToDockerCli.ts
+++ b/src/commands/registries/logInToDockerCli.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as stream from 'stream';
 import { NULL_GUID } from '../../constants';
 import { ext } from '../../extensionVariables';
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { registryExpectedContextValues } from '../../tree/registries/registryContextValues';
 import { RegistryTreeItemBase } from '../../tree/registries/RegistryTreeItemBase';
 
@@ -30,11 +30,11 @@ export async function logInToDockerCli(context: IActionContext, node?: RegistryT
     }
 
     if (!username || !password) {
-        ext.outputChannel.warn(localize('vscode-docker.commands.registries.logIn.skipping', 'Skipping login for "{0}" because it does not require authentication.', creds.registryPath));
+        ext.outputChannel.warn(l10n.t('Skipping login for "{0}" because it does not require authentication.', creds.registryPath));
     } else {
         const progressOptions: vscode.ProgressOptions = {
             location: vscode.ProgressLocation.Notification,
-            title: localize('vscode-docker.commands.registries.logIn.loggingIn', 'Logging in...'),
+            title: l10n.t('Logging in...'),
         };
 
         await vscode.window.withProgress(progressOptions, async () => {
@@ -57,7 +57,7 @@ export async function logInToDockerCli(context: IActionContext, node?: RegistryT
                     // Temporary work-around for this error- same as Azure CLI
                     // See https://github.com/Azure/azure-cli/issues/4843
                     context.errorHandling.suppressReportIssue = true;
-                    throw new Error(localize('vscode-docker.commands.registries.logIn.dockerCliTokens', 'In order to log in to the Docker CLI using tokens, you currently need to go to your Docker config file and remove `"credsStore": "wincred"`, then try again. \nDoing this will disable wincred and cause Docker to store credentials directly in the .docker/config.json file. All registries that are currently logged in will be logged out.'));
+                    throw new Error(l10n.t('In order to log in to the Docker CLI using tokens, you currently need to go to your Docker config file and remove `"credsStore": "wincred"`, then try again. \nDoing this will disable wincred and cause Docker to store credentials directly in the .docker/config.json file. All registries that are currently logged in will be logged out.'));
                 } else {
                     throw err;
                 }

--- a/src/commands/registries/reconnectRegistry.ts
+++ b/src/commands/registries/reconnectRegistry.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { ext } from "../../extensionVariables";
 import { l10n } from 'vscode';
+import { ext } from "../../extensionVariables";
 import { RegistryConnectErrorTreeItem } from "../../tree/registries/RegistryConnectErrorTreeItem";
 
 export async function reconnectRegistry(context: IActionContext, node?: RegistryConnectErrorTreeItem): Promise<void> {

--- a/src/commands/registries/reconnectRegistry.ts
+++ b/src/commands/registries/reconnectRegistry.ts
@@ -5,13 +5,13 @@
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { RegistryConnectErrorTreeItem } from "../../tree/registries/RegistryConnectErrorTreeItem";
 
 export async function reconnectRegistry(context: IActionContext, node?: RegistryConnectErrorTreeItem): Promise<void> {
     if (!node?.cachedProvider || !node?.provider) {
         // This is not expected ever, so we'll throw an error which can be bubbled up to a Report Issue if it does
-        throw new Error(localize('vscode-docker.commands.registries.reconnectError', 'Unable to determine provider to re-enter credentials. Please disconnect and connect again.'));
+        throw new Error(l10n.t('Unable to determine provider to re-enter credentials. Please disconnect and connect again.'));
     }
 
     await ext.registriesRoot.disconnectRegistry(context, node.cachedProvider);

--- a/src/commands/selectCommandTemplate.ts
+++ b/src/commands/selectCommandTemplate.ts
@@ -3,11 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PortBinding, VoidCommandResponse } from '../runtimes/docker';
 import { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
-import { l10n } from 'vscode';
+import { PortBinding, VoidCommandResponse } from '../runtimes/docker';
 import { isDockerComposeClient } from '../runtimes/OrchestratorRuntimeManager';
 import { resolveVariables } from '../utils/resolveVariables';
 
@@ -163,7 +162,7 @@ export async function selectCommandTemplate(
     }
 
     if (!selectedTemplate) {
-        throw new Error(l10n.t('No command template was found for command \'{0}\'', command));
+        throw new Error(vscode.l10n.t('No command template was found for command \'{0}\'', command));
     }
 
     actionContext.telemetry.properties.isDefaultCommand = defaultTemplates.some(t => t.template === selectedTemplate.template) ? 'true' : 'false';
@@ -192,7 +191,7 @@ async function quickPickTemplate(templates: CommandTemplate[], templatePicker: T
     });
 
     const selection = await templatePicker(items, {
-        placeHolder: l10n.t('Choose a command template to execute')
+        placeHolder: vscode.l10n.t('Choose a command template to execute')
     });
 
     return selection.data;
@@ -227,7 +226,7 @@ function isMatchConstraintSatisfied(actionContext: IActionContext, matchContext:
         return matchContext.some(m => matcher.test(m));
     } catch {
         // Don't wait
-        void actionContext.ui.showWarningMessage(l10n.t('Invalid match expression \'{0}\'. This template will be skipped.', match));
+        void actionContext.ui.showWarningMessage(vscode.l10n.t('Invalid match expression \'{0}\'. This template will be skipped.', match));
     }
 
     return false;

--- a/src/commands/selectCommandTemplate.ts
+++ b/src/commands/selectCommandTemplate.ts
@@ -7,7 +7,7 @@ import { PortBinding, VoidCommandResponse } from '../runtimes/docker';
 import { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { isDockerComposeClient } from '../runtimes/OrchestratorRuntimeManager';
 import { resolveVariables } from '../utils/resolveVariables';
 
@@ -163,7 +163,7 @@ export async function selectCommandTemplate(
     }
 
     if (!selectedTemplate) {
-        throw new Error(localize('vscode-docker.commands.selectCommandTemplate.noTemplate', 'No command template was found for command \'{0}\'', command));
+        throw new Error(l10n.t('No command template was found for command \'{0}\'', command));
     }
 
     actionContext.telemetry.properties.isDefaultCommand = defaultTemplates.some(t => t.template === selectedTemplate.template) ? 'true' : 'false';
@@ -192,7 +192,7 @@ async function quickPickTemplate(templates: CommandTemplate[], templatePicker: T
     });
 
     const selection = await templatePicker(items, {
-        placeHolder: localize('vscode-docker.commands.selectCommandTemplate.chooseTemplate', 'Choose a command template to execute')
+        placeHolder: l10n.t('Choose a command template to execute')
     });
 
     return selection.data;
@@ -227,7 +227,7 @@ function isMatchConstraintSatisfied(actionContext: IActionContext, matchContext:
         return matchContext.some(m => matcher.test(m));
     } catch {
         // Don't wait
-        void actionContext.ui.showWarningMessage(localize('vscode-docker.commands.selectCommandTemplate.invalidMatch', 'Invalid match expression \'{0}\'. This template will be skipped.', match));
+        void actionContext.ui.showWarningMessage(l10n.t('Invalid match expression \'{0}\'. This template will be skipped.', match));
     }
 
     return false;

--- a/src/commands/volumes/inspectVolume.ts
+++ b/src/commands/volumes/inspectVolume.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, openReadOnlyJson } from "@microsoft/vscode-azext-utils";
-import { ext } from "../../extensionVariables";
 import { l10n } from 'vscode';
+import { ext } from "../../extensionVariables";
 import { VolumeTreeItem } from "../../tree/volumes/VolumeTreeItem";
 
 export async function inspectVolume(context: IActionContext, node?: VolumeTreeItem): Promise<void> {

--- a/src/commands/volumes/inspectVolume.ts
+++ b/src/commands/volumes/inspectVolume.ts
@@ -5,13 +5,13 @@
 
 import { IActionContext, openReadOnlyJson } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { VolumeTreeItem } from "../../tree/volumes/VolumeTreeItem";
 
 export async function inspectVolume(context: IActionContext, node?: VolumeTreeItem): Promise<void> {
     if (!node) {
         await ext.volumesTree.refresh(context);
-        node = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, { ...context, noItemFoundErrorMessage: localize('vscode-docker.commands.volumes.inspect.noVolumes', 'No volumes are available to inspect') });
+        node = await ext.volumesTree.showTreeItemPicker<VolumeTreeItem>(VolumeTreeItem.contextValue, { ...context, noItemFoundErrorMessage: l10n.t('No volumes are available to inspect') });
     }
 
     const inspectResult = await ext.runWithDefaults(client =>

--- a/src/commands/volumes/pruneVolumes.ts
+++ b/src/commands/volumes/pruneVolumes.ts
@@ -6,16 +6,16 @@
 import * as vscode from 'vscode';
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { convertToMB } from '../../utils/convertToMB';
 
 export async function pruneVolumes(context: IActionContext): Promise<void> {
-    const confirmPrune: string = localize('vscode-docker.commands.volumes.prune.confirm', 'Are you sure you want to remove all unused volumes? Removing volumes may result in data loss!');
+    const confirmPrune: string = l10n.t('Are you sure you want to remove all unused volumes? Removing volumes may result in data loss!');
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: localize('vscode-docker.commands.volumes.prune.remove', 'Remove') });
+    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: l10n.t('Remove') });
 
     await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: localize('vscode-docker.commands.volumes.pruning', 'Pruning volumes...') },
+        { location: vscode.ProgressLocation.Notification, title: l10n.t('Pruning volumes...') },
         async () => {
             const result = await ext.runWithDefaults(client =>
                 client.pruneVolumes({})
@@ -23,9 +23,9 @@ export async function pruneVolumes(context: IActionContext): Promise<void> {
 
             let message: string;
             if (result?.volumesDeleted?.length && Number.isInteger(result?.spaceReclaimed)) {
-                message = localize('vscode-docker.commands.volumes.prune.removed', 'Removed {0} unused volume(s) and reclaimed {1} MB of space.', result.volumesDeleted.length, convertToMB(result.spaceReclaimed));
+                message = l10n.t('Removed {0} unused volume(s) and reclaimed {1} MB of space.', result.volumesDeleted.length, convertToMB(result.spaceReclaimed));
             } else {
-                message = localize('vscode-docker.commands.volumes.prune.removed2', 'Removed unused volumes.');
+                message = l10n.t('Removed unused volumes.');
             }
 
             // Don't wait

--- a/src/commands/volumes/pruneVolumes.ts
+++ b/src/commands/volumes/pruneVolumes.ts
@@ -3,19 +3,18 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { convertToMB } from '../../utils/convertToMB';
 
 export async function pruneVolumes(context: IActionContext): Promise<void> {
-    const confirmPrune: string = l10n.t('Are you sure you want to remove all unused volumes? Removing volumes may result in data loss!');
+    const confirmPrune: string = vscode.l10n.t('Are you sure you want to remove all unused volumes? Removing volumes may result in data loss!');
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: l10n.t('Remove') });
+    await context.ui.showWarningMessage(confirmPrune, { modal: true }, { title: vscode.l10n.t('Remove') });
 
     await vscode.window.withProgress(
-        { location: vscode.ProgressLocation.Notification, title: l10n.t('Pruning volumes...') },
+        { location: vscode.ProgressLocation.Notification, title: vscode.l10n.t('Pruning volumes...') },
         async () => {
             const result = await ext.runWithDefaults(client =>
                 client.pruneVolumes({})
@@ -23,9 +22,9 @@ export async function pruneVolumes(context: IActionContext): Promise<void> {
 
             let message: string;
             if (result?.volumesDeleted?.length && Number.isInteger(result?.spaceReclaimed)) {
-                message = l10n.t('Removed {0} unused volume(s) and reclaimed {1} MB of space.', result.volumesDeleted.length, convertToMB(result.spaceReclaimed));
+                message = vscode.l10n.t('Removed {0} unused volume(s) and reclaimed {1} MB of space.', result.volumesDeleted.length, convertToMB(result.spaceReclaimed));
             } else {
-                message = l10n.t('Removed unused volumes.');
+                message = vscode.l10n.t('Removed unused volumes.');
             }
 
             // Don't wait

--- a/src/commands/volumes/removeVolume.ts
+++ b/src/commands/volumes/removeVolume.ts
@@ -3,16 +3,15 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { VolumeTreeItem } from '../../tree/volumes/VolumeTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function removeVolume(context: IActionContext, node?: VolumeTreeItem, nodes?: VolumeTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: l10n.t('No volumes are available to remove') },
+        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: vscode.l10n.t('No volumes are available to remove') },
         ext.volumesTree,
         VolumeTreeItem.contextValue,
         node,
@@ -21,15 +20,15 @@ export async function removeVolume(context: IActionContext, node?: VolumeTreeIte
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = l10n.t('Are you sure you want to remove volume "{0}"?', nodes[0].label);
+        confirmRemove = vscode.l10n.t('Are you sure you want to remove volume "{0}"?', nodes[0].label);
     } else {
-        confirmRemove = l10n.t('Are you sure you want to remove selected volumes?');
+        confirmRemove = vscode.l10n.t('Are you sure you want to remove selected volumes?');
     }
 
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: l10n.t('Remove') });
+    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: vscode.l10n.t('Remove') });
 
-    const removing: string = l10n.t('Removing volume(s)...');
+    const removing: string = vscode.l10n.t('Removing volume(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removing }, async () => {
         await Promise.all(nodes.map(async n => await n.deleteTreeItem(context)));
     });

--- a/src/commands/volumes/removeVolume.ts
+++ b/src/commands/volumes/removeVolume.ts
@@ -6,13 +6,13 @@
 import * as vscode from 'vscode';
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { VolumeTreeItem } from '../../tree/volumes/VolumeTreeItem';
 import { multiSelectNodes } from '../../utils/multiSelectNodes';
 
 export async function removeVolume(context: IActionContext, node?: VolumeTreeItem, nodes?: VolumeTreeItem[]): Promise<void> {
     nodes = await multiSelectNodes(
-        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: localize('vscode-docker.commands.volumes.remove.noVolumes', 'No volumes are available to remove') },
+        { ...context, suppressCreatePick: true, noItemFoundErrorMessage: l10n.t('No volumes are available to remove') },
         ext.volumesTree,
         VolumeTreeItem.contextValue,
         node,
@@ -21,15 +21,15 @@ export async function removeVolume(context: IActionContext, node?: VolumeTreeIte
 
     let confirmRemove: string;
     if (nodes.length === 1) {
-        confirmRemove = localize('vscode-docker.commands.volumes.remove.confirmSingle', 'Are you sure you want to remove volume "{0}"?', nodes[0].label);
+        confirmRemove = l10n.t('Are you sure you want to remove volume "{0}"?', nodes[0].label);
     } else {
-        confirmRemove = localize('vscode-docker.commands.volumes.remove.confirmMulti', 'Are you sure you want to remove selected volumes?');
+        confirmRemove = l10n.t('Are you sure you want to remove selected volumes?');
     }
 
     // no need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: localize('vscode-docker.commands.volumes.remove.remove', 'Remove') });
+    await context.ui.showWarningMessage(confirmRemove, { modal: true }, { title: l10n.t('Remove') });
 
-    const removing: string = localize('vscode-docker.commands.volumes.remove.removing', 'Removing volume(s)...');
+    const removing: string = l10n.t('Removing volume(s)...');
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: removing }, async () => {
         await Promise.all(nodes.map(async n => await n.deleteTreeItem(context)));
     });

--- a/src/debugging/DebugHelper.ts
+++ b/src/debugging/DebugHelper.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
-import { CancellationToken, ConfigurationTarget, DebugConfiguration, ExtensionContext, WorkspaceFolder, debug, workspace } from 'vscode';
-import { l10n } from 'vscode';
+import { CancellationToken, ConfigurationTarget, debug, DebugConfiguration, ExtensionContext, l10n, workspace, WorkspaceFolder } from 'vscode';
 import { DockerRunTaskDefinition } from '../tasks/DockerRunTaskProvider';
 import { DockerTaskScaffoldContext, getDefaultContainerName } from '../tasks/TaskHelper';
 import { DockerServerReadyAction } from './DockerDebugConfigurationBase';

--- a/src/debugging/DebugHelper.ts
+++ b/src/debugging/DebugHelper.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { CancellationToken, ConfigurationTarget, DebugConfiguration, ExtensionContext, WorkspaceFolder, debug, workspace } from 'vscode';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { DockerRunTaskDefinition } from '../tasks/DockerRunTaskProvider';
 import { DockerTaskScaffoldContext, getDefaultContainerName } from '../tasks/TaskHelper';
 import { DockerServerReadyAction } from './DockerDebugConfigurationBase';
@@ -95,7 +95,7 @@ export function resolveDockerServerReadyAction(debugConfiguration: DockerDebugCo
 
     if (numBrowserOptions > 1) {
         // Multiple user-provided options is not valid
-        throw new Error(localize('vscode-docker.debug.helper.oneBrowserAction', 'Only at most one of the \'launchBrowser\', \'serverReadyAction\', and \'dockerServerReadyAction\' properties may be set at a time.'));
+        throw new Error(l10n.t('Only at most one of the \'launchBrowser\', \'serverReadyAction\', and \'dockerServerReadyAction\' properties may be set at a time.'));
     } else if (numBrowserOptions === 1 && !debugConfiguration.dockerServerReadyAction) {
         // One user-provided option that is not DockerServerReadyAction--return nothing
         return undefined;

--- a/src/debugging/DockerDebugConfigurationProvider.ts
+++ b/src/debugging/DockerDebugConfigurationProvider.ts
@@ -3,11 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext, callWithTelemetryAndErrorHandling, registerEvent } from '@microsoft/vscode-azext-utils';
-import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, DebugSession, MessageItem, ProviderResult, WorkspaceFolder, commands, debug, window, workspace } from 'vscode';
+import { callWithTelemetryAndErrorHandling, IActionContext, registerEvent } from '@microsoft/vscode-azext-utils';
+import { CancellationToken, commands, debug, DebugConfiguration, DebugConfigurationProvider, DebugSession, l10n, MessageItem, ProviderResult, window, workspace, WorkspaceFolder } from 'vscode';
 import { DockerOrchestration } from '../constants';
 import { ext } from '../extensionVariables';
-import { l10n } from 'vscode';
 import { getAssociatedDockerRunTask } from '../tasks/TaskHelper';
 import { DebugHelper, DockerDebugContext, ResolvedDebugConfiguration } from './DebugHelper';
 import { DockerPlatform, getPlatform } from './DockerPlatformHelper';

--- a/src/debugging/DockerDebugConfigurationProvider.ts
+++ b/src/debugging/DockerDebugConfigurationProvider.ts
@@ -7,7 +7,7 @@ import { IActionContext, callWithTelemetryAndErrorHandling, registerEvent } from
 import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, DebugSession, MessageItem, ProviderResult, WorkspaceFolder, commands, debug, window, workspace } from 'vscode';
 import { DockerOrchestration } from '../constants';
 import { ext } from '../extensionVariables';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { getAssociatedDockerRunTask } from '../tasks/TaskHelper';
 import { DebugHelper, DockerDebugContext, ResolvedDebugConfiguration } from './DebugHelper';
 import { DockerPlatform, getPlatform } from './DockerPlatformHelper';
@@ -43,12 +43,12 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
     }
 
     public provideDebugConfigurations(folder: WorkspaceFolder | undefined, token?: CancellationToken): ProviderResult<DebugConfiguration[]> {
-        const add: MessageItem = { title: localize('vscode-docker.debug.configProvider.addDockerFiles', 'Add Docker Files') };
+        const add: MessageItem = { title: l10n.t('Add Docker Files') };
 
         // Prompt them to add Docker files since they probably haven't
         /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
         window.showErrorMessage(
-            localize('vscode-docker.debug.configProvider.toDebugAddDockerFiles', 'To debug in a Docker container on supported platforms, use the command "Docker: Add Docker Files to Workspace", or click "Add Docker Files".'),
+            l10n.t('To debug in a Docker container on supported platforms, use the command "Docker: Add Docker Files to Workspace", or click "Add Docker Files".'),
             ...[add])
             .then((result) => {
                 if (result === add) {
@@ -72,7 +72,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
                     if (!folder) {
                         actionContext.errorHandling.suppressReportIssue = true;
-                        throw new Error(localize('vscode-docker.debug.configProvider.workspaceFolder', 'To debug with Docker you must first open a folder or workspace in VS Code.'));
+                        throw new Error(l10n.t('To debug with Docker you must first open a folder or workspace in VS Code.'));
                     }
                 }
 
@@ -83,7 +83,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
                 }
 
                 if (!debugConfiguration.request) {
-                    throw new Error(localize('vscode-docker.debug.configProvider.requestRequired', 'The property "request" must be specified in the debug config.'));
+                    throw new Error(l10n.t('The property "request" must be specified in the debug config.'));
                 }
 
                 const debugPlatform = getPlatform(debugConfiguration);
@@ -120,9 +120,9 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
 
     private async validateResolvedConfiguration(resolvedConfiguration: ResolvedDebugConfiguration): Promise<void> {
         if (!resolvedConfiguration.type) {
-            throw new Error(localize('vscode-docker.debug.configProvider.noDebugType', 'No debug type was resolved.'));
+            throw new Error(l10n.t('No debug type was resolved.'));
         } else if (!resolvedConfiguration.request) {
-            throw new Error(localize('vscode-docker.debug.configProvider.noDebugRequest', 'No debug request was resolved.'));
+            throw new Error(l10n.t('No debug request was resolved.'));
         }
     }
 
@@ -130,7 +130,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
         const helper = this.helpers[platform];
 
         if (!helper) {
-            throw new Error(localize('vscode-docker.debug.configProvider.unsupportedPlatform', 'The platform \'{0}\' is not currently supported for Docker debugging.', platform));
+            throw new Error(l10n.t('The platform \'{0}\' is not currently supported for Docker debugging.', platform));
         }
 
         return helper;
@@ -163,7 +163,7 @@ export class DockerDebugConfigurationProvider implements DebugConfigurationProvi
                 }
 
                 if (portMappings.length > 0) {
-                    ext.outputChannel.info(localize('vscode-docker.debug.configProvider.portMappings', 'The application is listening on the following port(s) (Host => Container):'));
+                    ext.outputChannel.info(l10n.t('The application is listening on the following port(s) (Host => Container):'));
                     ext.outputChannel.info(portMappings.join('\n'));
                 }
             } catch {

--- a/src/debugging/DockerDebugScaffoldingProvider.ts
+++ b/src/debugging/DockerDebugScaffoldingProvider.ts
@@ -5,7 +5,7 @@
 
 import { DialogResponses } from '@microsoft/vscode-azext-utils';
 import { MessageItem, window } from 'vscode';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { DockerBuildTaskDefinition } from '../tasks/DockerBuildTaskProvider';
 import { DockerRunTaskDefinition } from '../tasks/DockerRunTaskProvider';
 import { NetCoreTaskScaffoldingOptions, netCoreTaskHelper } from '../tasks/netcore/NetCoreTaskHelper';
@@ -100,7 +100,7 @@ export class DockerDebugScaffoldingProvider implements IDockerDebugScaffoldingPr
                 title: 'Overwrite'
             };
 
-            overwrite = (overwriteMessageItem === await window.showWarningMessage(localize('vscode-docker.debug.scaffoldProvider.confirm', 'Docker launch configurations and/or tasks already exist. Do you want to overwrite them?'), ...[overwriteMessageItem, DialogResponses.no]));
+            overwrite = (overwriteMessageItem === await window.showWarningMessage(l10n.t('Docker launch configurations and/or tasks already exist. Do you want to overwrite them?'), ...[overwriteMessageItem, DialogResponses.no]));
 
             if (overwrite) {
                 // Try again if needed

--- a/src/debugging/DockerDebugScaffoldingProvider.ts
+++ b/src/debugging/DockerDebugScaffoldingProvider.ts
@@ -4,18 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DialogResponses } from '@microsoft/vscode-azext-utils';
-import { MessageItem, window } from 'vscode';
-import { l10n } from 'vscode';
+import { l10n, MessageItem, window } from 'vscode';
 import { DockerBuildTaskDefinition } from '../tasks/DockerBuildTaskProvider';
 import { DockerRunTaskDefinition } from '../tasks/DockerRunTaskProvider';
-import { NetCoreTaskScaffoldingOptions, netCoreTaskHelper } from '../tasks/netcore/NetCoreTaskHelper';
+import { netCoreTaskHelper, NetCoreTaskScaffoldingOptions } from '../tasks/netcore/NetCoreTaskHelper';
 import { nodeTaskHelper } from '../tasks/node/NodeTaskHelper';
 import { pythonTaskHelper } from '../tasks/python/PythonTaskHelper';
 import { addTask } from '../tasks/TaskHelper';
 import { PythonProjectType, PythonTarget } from '../utils/pythonUtils';
-import { DockerDebugScaffoldContext, addDebugConfiguration } from './DebugHelper';
+import { addDebugConfiguration, DockerDebugScaffoldContext } from './DebugHelper';
 import { DockerDebugConfiguration } from './DockerDebugConfigurationProvider';
-import { NetCoreDebugScaffoldingOptions, netCoreDebugHelper } from './netcore/NetCoreDebugHelper';
+import { netCoreDebugHelper, NetCoreDebugScaffoldingOptions } from './netcore/NetCoreDebugHelper';
 import { nodeDebugHelper } from './node/NodeDebugHelper';
 import { pythonDebugHelper } from './python/PythonDebugHelper';
 

--- a/src/debugging/DockerServerReadyAction.ts
+++ b/src/debugging/DockerServerReadyAction.ts
@@ -7,13 +7,12 @@
 // Adapted from: https://github.com/microsoft/vscode/blob/8827cf5a607b6ab7abf45817604bc21883314db7/extensions/debug-server-ready/src/extension.ts
 //
 
+import { callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as readline from 'readline';
 import * as stream from 'stream';
 import * as util from 'util';
 import * as vscode from 'vscode';
-import { IActionContext, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
 import { ext } from '../extensionVariables';
-import { l10n } from 'vscode';
 import { ResolvedDebugConfiguration } from './DebugHelper';
 
 const PATTERN = 'listening on.* (https?://\\S+|[0-9]+)'; // matches "listening on port 3000" or "Now listening on: https://localhost:5001"
@@ -53,7 +52,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
         const format = args.uriFormat || URI_FORMAT;
 
         if (!args || !args.containerName) {
-            throw new Error(l10n.t('No container name was resolved or provided to DockerServerReadyAction.'));
+            throw new Error(vscode.l10n.t('No container name was resolved or provided to DockerServerReadyAction.'));
         }
 
         await callWithTelemetryAndErrorHandling('dockerServerReadyAction.serverReadyDetector.openExternalWithString', async (context: IActionContext) => {
@@ -66,7 +65,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
                 // nothing captured by reg exp -> use the uriFormat as the target url without substitution
                 // verify that format does not contain '%s'
                 if (format.indexOf('%s') >= 0) {
-                    const errMsg = l10n.t('Format uri (\'{0}\') uses a substitution placeholder but pattern did not capture anything.', format);
+                    const errMsg = vscode.l10n.t('Format uri (\'{0}\') uses a substitution placeholder but pattern did not capture anything.', format);
                     void vscode.window.showErrorMessage(errMsg, { modal: true });
                     return;
                 }
@@ -76,7 +75,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
                 // verify that format only contains a single '%s'
                 const s = format.split('%s');
                 if (s.length !== 2) {
-                    const errMsg = l10n.t('Format uri (\'{0}\') must contain exactly one substitution placeholder.', format);
+                    const errMsg = vscode.l10n.t('Format uri (\'{0}\') must contain exactly one substitution placeholder.', format);
                     void vscode.window.showErrorMessage(errMsg, { modal: true });
                     return;
                 }
@@ -89,7 +88,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
                 const containerPort = this.getContainerPort(captureString);
 
                 if (containerPort === undefined) {
-                    const errMsg = l10n.t('Captured string (\'{0}\') must contain a port number.', captureString);
+                    const errMsg = vscode.l10n.t('Captured string (\'{0}\') must contain a port number.', captureString);
                     void vscode.window.showErrorMessage(errMsg, { modal: true });
                     return;
                 }
@@ -106,7 +105,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
                     // There are exactly two substitutions (which is expected)...
                     captureString = util.format(format, containerProtocol, hostPort);
                 } else {
-                    const errMsg = l10n.t('Format uri (\'{0}\') must contain exactly two substitution placeholders.', format);
+                    const errMsg = vscode.l10n.t('Format uri (\'{0}\') must contain exactly two substitution placeholders.', format);
                     void vscode.window.showErrorMessage(errMsg, { modal: true });
                     return;
                 }
@@ -140,7 +139,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
         const hostPort = containerInspectInfo?.ports.find(p => p.containerPort === containerPort)?.hostPort;
 
         if (!hostPort) {
-            throw new Error(l10n.t('Could not determine host port mapped to container port {0} in container \'{1}\'.', containerPort, containerName));
+            throw new Error(vscode.l10n.t('Could not determine host port mapped to container port {0} in container \'{1}\'.', containerPort, containerName));
         }
 
         return hostPort;
@@ -167,7 +166,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
                             webRoot: args.webRoot || WEB_ROOT
                         });
                 } else {
-                    const errMsg = l10n.t('The action \'debugWithChrome\' requires the \'Debugger for Chrome\' extension.');
+                    const errMsg = vscode.l10n.t('The action \'debugWithChrome\' requires the \'Debugger for Chrome\' extension.');
                     void vscode.window.showErrorMessage(errMsg, { modal: true });
                 }
                 break;

--- a/src/debugging/DockerServerReadyAction.ts
+++ b/src/debugging/DockerServerReadyAction.ts
@@ -13,7 +13,7 @@ import * as util from 'util';
 import * as vscode from 'vscode';
 import { IActionContext, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
 import { ext } from '../extensionVariables';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { ResolvedDebugConfiguration } from './DebugHelper';
 
 const PATTERN = 'listening on.* (https?://\\S+|[0-9]+)'; // matches "listening on port 3000" or "Now listening on: https://localhost:5001"
@@ -53,7 +53,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
         const format = args.uriFormat || URI_FORMAT;
 
         if (!args || !args.containerName) {
-            throw new Error(localize('vscode-docker.debug.serverReady.noContainer', 'No container name was resolved or provided to DockerServerReadyAction.'));
+            throw new Error(l10n.t('No container name was resolved or provided to DockerServerReadyAction.'));
         }
 
         await callWithTelemetryAndErrorHandling('dockerServerReadyAction.serverReadyDetector.openExternalWithString', async (context: IActionContext) => {
@@ -66,7 +66,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
                 // nothing captured by reg exp -> use the uriFormat as the target url without substitution
                 // verify that format does not contain '%s'
                 if (format.indexOf('%s') >= 0) {
-                    const errMsg = localize('vscode-docker.debug.serverReady.noCapture', 'Format uri (\'{0}\') uses a substitution placeholder but pattern did not capture anything.', format);
+                    const errMsg = l10n.t('Format uri (\'{0}\') uses a substitution placeholder but pattern did not capture anything.', format);
                     void vscode.window.showErrorMessage(errMsg, { modal: true });
                     return;
                 }
@@ -76,7 +76,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
                 // verify that format only contains a single '%s'
                 const s = format.split('%s');
                 if (s.length !== 2) {
-                    const errMsg = localize('vscode-docker.debug.serverReady.oneSubstitution', 'Format uri (\'{0}\') must contain exactly one substitution placeholder.', format);
+                    const errMsg = l10n.t('Format uri (\'{0}\') must contain exactly one substitution placeholder.', format);
                     void vscode.window.showErrorMessage(errMsg, { modal: true });
                     return;
                 }
@@ -89,7 +89,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
                 const containerPort = this.getContainerPort(captureString);
 
                 if (containerPort === undefined) {
-                    const errMsg = localize('vscode-docker.debug.serverReady.noCapturedPort', 'Captured string (\'{0}\') must contain a port number.', captureString);
+                    const errMsg = l10n.t('Captured string (\'{0}\') must contain a port number.', captureString);
                     void vscode.window.showErrorMessage(errMsg, { modal: true });
                     return;
                 }
@@ -106,7 +106,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
                     // There are exactly two substitutions (which is expected)...
                     captureString = util.format(format, containerProtocol, hostPort);
                 } else {
-                    const errMsg = localize('vscode-docker.debug.serverReady.twoSubstitutions', 'Format uri (\'{0}\') must contain exactly two substitution placeholders.', format);
+                    const errMsg = l10n.t('Format uri (\'{0}\') must contain exactly two substitution placeholders.', format);
                     void vscode.window.showErrorMessage(errMsg, { modal: true });
                     return;
                 }
@@ -140,7 +140,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
         const hostPort = containerInspectInfo?.ports.find(p => p.containerPort === containerPort)?.hostPort;
 
         if (!hostPort) {
-            throw new Error(localize('vscode-docker.debug.serverReady.noHostPortA', 'Could not determine host port mapped to container port {0} in container \'{1}\'.', containerPort, containerName));
+            throw new Error(l10n.t('Could not determine host port mapped to container port {0} in container \'{1}\'.', containerPort, containerName));
         }
 
         return hostPort;
@@ -167,7 +167,7 @@ class ServerReadyDetector implements DockerServerReadyDetector {
                             webRoot: args.webRoot || WEB_ROOT
                         });
                 } else {
-                    const errMsg = localize('vscode-docker.debug.serverReady.noChrome', 'The action \'debugWithChrome\' requires the \'Debugger for Chrome\' extension.');
+                    const errMsg = l10n.t('The action \'debugWithChrome\' requires the \'Debugger for Chrome\' extension.');
                     void vscode.window.showErrorMessage(errMsg, { modal: true });
                 }
                 break;

--- a/src/debugging/netcore/AspNetSslHelper.ts
+++ b/src/debugging/netcore/AspNetSslHelper.ts
@@ -3,15 +3,14 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IActionContext, parseError } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { IActionContext, parseError } from '@microsoft/vscode-azext-utils';
-import { isMac, isWindows } from '../../utils/osUtils';
-import { MessageItem } from 'vscode';
-import { l10n } from 'vscode';
+import { l10n, MessageItem } from 'vscode';
 import { cryptoUtils } from '../../utils/cryptoUtils';
 import { execAsync } from '../../utils/execAsync';
+import { isMac, isWindows } from '../../utils/osUtils';
 import { PlatformOS } from '../../utils/platform';
 
 const knownConfiguredProjects = new Set<string>();

--- a/src/debugging/netcore/AspNetSslHelper.ts
+++ b/src/debugging/netcore/AspNetSslHelper.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { IActionContext, parseError } from '@microsoft/vscode-azext-utils';
 import { isMac, isWindows } from '../../utils/osUtils';
 import { MessageItem } from 'vscode';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { cryptoUtils } from '../../utils/cryptoUtils';
 import { execAsync } from '../../utils/execAsync';
 import { PlatformOS } from '../../utils/platform';
@@ -24,8 +24,8 @@ export async function trustCertificateIfNecessary(context: IActionContext): Prom
 
     if (isWindows()) {
         if (!(await isCertificateTrusted())) {
-            const trust: MessageItem = { title: localize('vscode-docker.debugging.netCore.trust', 'Trust') };
-            const message = localize('vscode-docker.debugging.netCore.notTrusted', 'The ASP.NET Core HTTPS development certificate is not trusted. To trust the certificate, run `dotnet dev-certs https --trust`, or click "Trust" below.');
+            const trust: MessageItem = { title: l10n.t('Trust') };
+            const message = l10n.t('The ASP.NET Core HTTPS development certificate is not trusted. To trust the certificate, run `dotnet dev-certs https --trust`, or click "Trust" below.');
 
             // Don't wait
             void context.ui
@@ -39,7 +39,7 @@ export async function trustCertificateIfNecessary(context: IActionContext): Prom
         }
     } else if (isMac()) {
         if (!(await isCertificateTrusted())) {
-            const message = localize('vscode-docker.debugging.netCore.notTrustedRunManual', 'The ASP.NET Core HTTPS development certificate is not trusted. To trust the certificate, run `dotnet dev-certs https --trust`.');
+            const message = l10n.t('The ASP.NET Core HTTPS development certificate is not trusted. To trust the certificate, run `dotnet dev-certs https --trust`.');
 
             // Don't wait
             void context.ui.showWarningMessage(
@@ -67,7 +67,7 @@ export function getHostSecretsFolders(): { hostCertificateFolder: string, hostUs
         appDataEnvironmentVariable = process.env.AppData;
 
         if (appDataEnvironmentVariable === undefined) {
-            throw new Error(localize('vscode-docker.debug.coreclr.sslManager.appDataUndefined', 'The environment variable \'AppData\' is not defined. This variable is used to locate the HTTPS certificate and user secrets folders.'));
+            throw new Error(l10n.t('The environment variable \'AppData\' is not defined. This variable is used to locate the HTTPS certificate and user secrets folders.'));
         }
     }
 

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -9,7 +9,7 @@ import { CommandLineArgs, composeArgs, ContainerOS, VoidCommandResponse, withArg
 import { DialogResponses, IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { DebugConfiguration, MessageItem, ProgressLocation, window } from 'vscode';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { NetCoreTaskHelper, NetCoreTaskOptions } from '../../tasks/netcore/NetCoreTaskHelper';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { getNetCoreProjectInfo } from '../../utils/netCoreUtils';
@@ -60,7 +60,7 @@ export class NetCoreDebugHelper implements DebugHelper {
             case 'attach':
                 return this.resolveAttachDebugConfiguration(context, debugConfiguration);
             default:
-                throw Error(localize('vscode-docker.debug.netcore.unknownDebugRequest', 'Unknown request {0} specified in the debug config.', debugConfiguration.request));
+                throw Error(l10n.t('Unknown request {0} specified in the debug config.', debugConfiguration.request));
         }
     }
 
@@ -180,7 +180,7 @@ export class NetCoreDebugHelper implements DebugHelper {
     private async inferAppOutput(helperOptions: NetCoreDebugOptions): Promise<string> {
         const projectInfo = await getNetCoreProjectInfo('GetProjectProperties', helperOptions.appProject);
         if (projectInfo.length < 3) {
-            throw new Error(localize('vscode-docker.debug.netcore.unknownOutputPath', 'Unable to determine assembly output path.'));
+            throw new Error(l10n.t('Unable to determine assembly output path.'));
         }
 
         return projectInfo[2]; // First line is assembly name, second is target framework, third+ are output path(s)
@@ -200,7 +200,7 @@ export class NetCoreDebugHelper implements DebugHelper {
         await window.withProgress(
             {
                 location: ProgressLocation.Notification,
-                title: localize('vscode-docker.debug.netcore.acquiringDebuggers', 'Acquiring .NET Debugger...'),
+                title: l10n.t('Acquiring .NET Debugger...'),
             }, async () => {
                 if (platformOS === 'Windows') {
                     await installDebuggersIfNecessary([{ runtime: 'win7-x64', version: 'latest' }]);
@@ -274,12 +274,12 @@ export class NetCoreDebugHelper implements DebugHelper {
             const containerInfo = inspectInfo ? JSON.parse(inspectInfo.raw) : undefined;
             if (containerInfo?.HostConfig?.Isolation === 'hyperv') {
                 context.errorHandling.suppressReportIssue = true;
-                throw new Error(localize('vscode-docker.debug.netcore.isolationNotSupported', 'Attaching a debugger to a Hyper-V container is not supported.'));
+                throw new Error(l10n.t('Attaching a debugger to a Hyper-V container is not supported.'));
             }
         }
 
         const yesItem: MessageItem = DialogResponses.yes;
-        const message = localize('vscode-docker.debug.netcore.attachingRequiresDebugger', 'Attaching to container requires .NET debugger in the container. Do you want to copy the debugger to the container?');
+        const message = l10n.t('Attaching to container requires .NET debugger in the container. Do you want to copy the debugger to the container?');
         const install = (yesItem === await window.showInformationMessage(message, ...[DialogResponses.yes, DialogResponses.no]));
         if (!install) {
             throw new UserCancelledError();
@@ -293,7 +293,7 @@ export class NetCoreDebugHelper implements DebugHelper {
 
         await window.withProgress({
             location: ProgressLocation.Notification,
-            title: localize('vscode-docker.debug.netcore.copyDebugger', 'Copying the .NET debugger to the container ({0} --> {1})...', vsDbgInstallBasePath, containerDebuggerDirectory),
+            title: l10n.t('Copying the .NET debugger to the container ({0} --> {1})...', vsDbgInstallBasePath, containerDebuggerDirectory),
         }, async () => {
             await ext.runWithDefaults(client =>
                 client.writeFile({
@@ -341,7 +341,7 @@ export class NetCoreDebugHelper implements DebugHelper {
         await ext.containersTree.refresh(context);
         const containerItem: ContainerTreeItem = await ext.containersTree.showTreeItemPicker(ContainerTreeItem.runningContainerRegExp, {
             ...context,
-            noItemFoundErrorMessage: localize('vscode-docker.debug.netcore.noContainers', 'No running containers are available to attach.')
+            noItemFoundErrorMessage: l10n.t('No running containers are available to attach.')
         });
         return containerItem.containerName;
     }

--- a/src/debugging/netcore/NetCoreDebugHelper.ts
+++ b/src/debugging/netcore/NetCoreDebugHelper.ts
@@ -3,13 +3,12 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { DialogResponses, IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { CommandLineArgs, composeArgs, ContainerOS, VoidCommandResponse, withArg, withQuotedArg } from '../../runtimes/docker';
-import { DialogResponses, IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { DebugConfiguration, MessageItem, ProgressLocation, window } from 'vscode';
+import { DebugConfiguration, l10n, MessageItem, ProgressLocation, window } from 'vscode';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
+import { CommandLineArgs, composeArgs, ContainerOS, VoidCommandResponse, withArg, withQuotedArg } from '../../runtimes/docker';
 import { NetCoreTaskHelper, NetCoreTaskOptions } from '../../tasks/netcore/NetCoreTaskHelper';
 import { ContainerTreeItem } from '../../tree/containers/ContainerTreeItem';
 import { getNetCoreProjectInfo } from '../../utils/netCoreUtils';
@@ -17,10 +16,10 @@ import { getDockerOSType, isArm64Mac } from '../../utils/osUtils';
 import { pathNormalize } from '../../utils/pathNormalize';
 import { PlatformOS } from '../../utils/platform';
 import { unresolveWorkspaceFolder } from '../../utils/resolveVariables';
-import { DebugHelper, DockerDebugContext, DockerDebugScaffoldContext, ResolvedDebugConfiguration, inferContainerName, resolveDockerServerReadyAction } from '../DebugHelper';
+import { DebugHelper, DockerDebugContext, DockerDebugScaffoldContext, inferContainerName, ResolvedDebugConfiguration, resolveDockerServerReadyAction } from '../DebugHelper';
 import { DockerAttachConfiguration, DockerDebugConfiguration } from '../DockerDebugConfigurationProvider';
 import { exportCertificateIfNecessary, getHostSecretsFolders, trustCertificateIfNecessary } from './AspNetSslHelper';
-import { VsDbgType, installDebuggersIfNecessary, vsDbgInstallBasePath } from './VsDbgHelper';
+import { installDebuggersIfNecessary, vsDbgInstallBasePath, VsDbgType } from './VsDbgHelper';
 
 export interface NetCoreDebugOptions extends NetCoreTaskOptions {
     appOutput?: string;

--- a/src/debugging/netcore/VsDbgHelper.ts
+++ b/src/debugging/netcore/VsDbgHelper.ts
@@ -6,11 +6,11 @@
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
+import { execAsync } from '../../utils/execAsync';
 import { streamToFile } from '../../utils/httpRequest';
 import { isWindows } from '../../utils/osUtils';
-import { execAsync } from '../../utils/execAsync';
 
 type VsDbgVersion = 'latest'; // There are other versions but we don't use them
 type VsDbgRuntime = 'linux-x64' | 'linux-musl-x64' | 'linux-arm64' | 'linux-musl-arm64' | 'win7-x64';

--- a/src/debugging/netcore/VsDbgHelper.ts
+++ b/src/debugging/netcore/VsDbgHelper.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { streamToFile } from '../../utils/httpRequest';
 import { isWindows } from '../../utils/osUtils';
 import { execAsync } from '../../utils/execAsync';
@@ -65,11 +65,11 @@ async function getLatestAcquisitionScriptIfNecessary(): Promise<boolean> {
         return false;
     }
 
-    ext.outputChannel.info(localize('vscode-docker.debugging.netCore.vsDbgHelper.acquiringScript', 'Acquiring latest VsDbg install script...'));
+    ext.outputChannel.info(l10n.t('Acquiring latest VsDbg install script...'));
     await streamToFile(acquisition.url, acquisition.scriptPath);
 
     await ext.context.globalState.update(scriptAcquiredDateKey, Date.now());
-    ext.outputChannel.info(localize('vscode-docker.debugging.netCore.vsDbgHelper.scriptAcquired', 'Script acquired.'));
+    ext.outputChannel.info(l10n.t('Script acquired.'));
     return true;
 }
 
@@ -85,7 +85,7 @@ async function executeAcquisitionScriptIfNecessary(runtime: VsDbgRuntime, versio
 
     const command = acquisition.getShellCommand(runtime, version);
 
-    ext.outputChannel.info(localize('vscode-docker.debugging.netCore.vsDbgHelper.installingDebugger', 'Installing VsDbg, Runtime = {0}, Version = {1}...', runtime, version));
+    ext.outputChannel.info(l10n.t('Installing VsDbg, Runtime = {0}, Version = {1}...', runtime, version));
     ext.outputChannel.info(command);
 
     await execAsync(command, {}, (output: string) => {
@@ -93,5 +93,5 @@ async function executeAcquisitionScriptIfNecessary(runtime: VsDbgRuntime, versio
     });
 
     await ext.context.globalState.update(scriptExecutedDateKey, Date.now());
-    ext.outputChannel.info(localize('vscode-docker.debugging.netCore.vsDbgHelper.debuggerInstalled', 'VsDbg installed, Runtime = {0}, Version = {1}...', runtime, version));
+    ext.outputChannel.info(l10n.t('VsDbg installed, Runtime = {0}, Version = {1}...', runtime, version));
 }

--- a/src/dockerHubSearch.ts
+++ b/src/dockerHubSearch.ts
@@ -7,7 +7,7 @@
 
 import { URL } from "url";
 import { ociClientId } from "./constants";
-import { localize } from "./localize";
+import { l10n } from 'vscode';
 import { httpRequest } from "./utils/httpRequest";
 
 export function tagsForImage(image: IHubSearchResponseResult): string {
@@ -27,16 +27,16 @@ export function tagsForImage(image: IHubSearchResponseResult): string {
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const popular = [
-    { "is_automated": false, "name": "redis", "is_trusted": false, "is_official": true, "star_count": 1300, "description": localize('vscode-docker.dockerHubSearch.redis', 'Redis is an open source key-value store that functions as a data structure server.') },
-    { "is_automated": false, "name": "ubuntu", "is_trusted": false, "is_official": true, "star_count": 2600, "description": localize('vscode-docker.dockerHubSearch.ubuntu', 'Ubuntu is a Debian-based Linux operating system based on free software.') },
-    { "is_automated": false, "name": "wordpress", "is_trusted": false, "is_official": true, "star_count": 582, "description": localize('vscode-docker.dockerHubSearch.wordPress', 'The WordPress rich content management system can utilize plugins, widgets, and themes.') },
-    { "is_automated": false, "name": "mysql", "is_trusted": false, "is_official": true, "star_count": 1300, "description": localize('vscode-docker.dockerHubSearch.mysql', 'MySQL is a widely used, open-source relational database management system (RDBMS).') },
-    { "is_automated": false, "name": "mongo", "is_trusted": false, "is_official": true, "star_count": 1100, "description": localize('vscode-docker.dockerHubSearch.mongodb', 'MongoDB document databases provide high availability and easy scalability.') },
-    { "is_automated": false, "name": "centos", "is_trusted": false, "is_official": true, "star_count": 1600, "description": localize('vscode-docker.dockerHubSearch.centos', 'The official build of CentOS.') },
-    { "is_automated": false, "name": "node", "is_trusted": false, "is_official": true, "star_count": 1200, "description": localize('vscode-docker.dockerHubSearch.node', 'Node.js is a JavaScript-based platform for server-side and networking applications.') },
-    { "is_automated": false, "name": "nginx", "is_trusted": false, "is_official": true, "star_count": 1600, "description": localize('vscode-docker.dockerHubSearch.nginx', 'Official build of Nginx.') },
-    { "is_automated": false, "name": "postgres", "is_trusted": false, "is_official": true, "star_count": 1200, "description": localize('vscode-docker.dockerHubSearch.postgres', 'The PostgreSQL object-relational database system provides reliability and data integrity.') },
-    { "is_automated": true, "name": "microsoft/aspnet", "is_trusted": true, "is_official": false, "star_count": 277, "description": localize('vscode-docker.dockerHubSearch.aspNet', 'ASP.NET is an open source server-side Web application framework') }
+    { "is_automated": false, "name": "redis", "is_trusted": false, "is_official": true, "star_count": 1300, "description": l10n.t('Redis is an open source key-value store that functions as a data structure server.') },
+    { "is_automated": false, "name": "ubuntu", "is_trusted": false, "is_official": true, "star_count": 2600, "description": l10n.t('Ubuntu is a Debian-based Linux operating system based on free software.') },
+    { "is_automated": false, "name": "wordpress", "is_trusted": false, "is_official": true, "star_count": 582, "description": l10n.t('The WordPress rich content management system can utilize plugins, widgets, and themes.') },
+    { "is_automated": false, "name": "mysql", "is_trusted": false, "is_official": true, "star_count": 1300, "description": l10n.t('MySQL is a widely used, open-source relational database management system (RDBMS).') },
+    { "is_automated": false, "name": "mongo", "is_trusted": false, "is_official": true, "star_count": 1100, "description": l10n.t('MongoDB document databases provide high availability and easy scalability.') },
+    { "is_automated": false, "name": "centos", "is_trusted": false, "is_official": true, "star_count": 1600, "description": l10n.t('The official build of CentOS.') },
+    { "is_automated": false, "name": "node", "is_trusted": false, "is_official": true, "star_count": 1200, "description": l10n.t('Node.js is a JavaScript-based platform for server-side and networking applications.') },
+    { "is_automated": false, "name": "nginx", "is_trusted": false, "is_official": true, "star_count": 1600, "description": l10n.t('Official build of Nginx.') },
+    { "is_automated": false, "name": "postgres", "is_trusted": false, "is_official": true, "star_count": 1200, "description": l10n.t('The PostgreSQL object-relational database system provides reliability and data integrity.') },
+    { "is_automated": true, "name": "microsoft/aspnet", "is_trusted": true, "is_official": false, "star_count": 277, "description": l10n.t('ASP.NET is an open source server-side Web application framework') }
 ];
 /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/src/dockerHubSearch.ts
+++ b/src/dockerHubSearch.ts
@@ -6,8 +6,8 @@
 'use strict';
 
 import { URL } from "url";
-import { ociClientId } from "./constants";
 import { l10n } from 'vscode';
+import { ociClientId } from "./constants";
 import { httpRequest } from "./utils/httpRequest";
 
 export function tagsForImage(image: IHubSearchResponseResult): string {

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
-import * as nls from 'vscode-nls';
-
-export const localize: nls.LocalizeFunc = nls.config()();

--- a/src/runtimes/files/ContainerFilesProvider.ts
+++ b/src/runtimes/files/ContainerFilesProvider.ts
@@ -3,19 +3,18 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
-import { DockerUri } from './DockerUri';
-import { getDockerOSType } from '../../utils/osUtils';
-import { AccumulatorStream, CommandNotSupportedError, DisposableLike, ListFilesItem } from '../docker';
-import { l10n } from 'vscode';
 import { ext } from '../../extensionVariables';
+import { getDockerOSType } from '../../utils/osUtils';
 import { tarPackStream, tarUnpackStream } from '../../utils/tarUtils';
+import { AccumulatorStream, CommandNotSupportedError, DisposableLike, ListFilesItem } from '../docker';
+import { DockerUri } from './DockerUri';
 
 class MethodNotImplementedError extends CommandNotSupportedError {
     public constructor() {
-        super(l10n.t('Method not implemented.'));
+        super(vscode.l10n.t('Method not implemented.'));
     }
 }
 

--- a/src/runtimes/files/ContainerFilesProvider.ts
+++ b/src/runtimes/files/ContainerFilesProvider.ts
@@ -9,13 +9,13 @@ import { callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils
 import { DockerUri } from './DockerUri';
 import { getDockerOSType } from '../../utils/osUtils';
 import { AccumulatorStream, CommandNotSupportedError, DisposableLike, ListFilesItem } from '../docker';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ext } from '../../extensionVariables';
 import { tarPackStream, tarUnpackStream } from '../../utils/tarUtils';
 
 class MethodNotImplementedError extends CommandNotSupportedError {
     public constructor() {
-        super(localize('docker.files.containerFilesProvider.methodNotImplemented', 'Method not implemented.'));
+        super(l10n.t('Method not implemented.'));
     }
 }
 

--- a/src/scaffolding/scaffold.ts
+++ b/src/scaffolding/scaffold.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { copyWizardContext } from './copyWizardContext';
 import { ChooseComposeStep } from './wizard/ChooseComposeStep';
 import { ChoosePlatformStep } from './wizard/ChoosePlatformStep';
@@ -37,7 +37,7 @@ export async function scaffold(wizardContext: Partial<ScaffoldingWizardContext>,
     const wizard = new AzureWizard<ScaffoldingWizardContext>(wizardContext as ScaffoldingWizardContext, {
         promptSteps: promptSteps,
         executeSteps: executeSteps,
-        title: localize('vscode-docker.scaffold.addDockerFiles', 'Add Docker Files'),
+        title: l10n.t('Add Docker Files'),
     });
 
     await wizard.prompt();

--- a/src/scaffolding/scaffold.ts
+++ b/src/scaffolding/scaffold.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { l10n } from 'vscode';
+import * as vscode from 'vscode';
 import { copyWizardContext } from './copyWizardContext';
 import { ChooseComposeStep } from './wizard/ChooseComposeStep';
 import { ChoosePlatformStep } from './wizard/ChoosePlatformStep';
@@ -37,7 +36,7 @@ export async function scaffold(wizardContext: Partial<ScaffoldingWizardContext>,
     const wizard = new AzureWizard<ScaffoldingWizardContext>(wizardContext as ScaffoldingWizardContext, {
         promptSteps: promptSteps,
         executeSteps: executeSteps,
-        title: l10n.t('Add Docker Files'),
+        title: vscode.l10n.t('Add Docker Files'),
     });
 
     await wizard.prompt();

--- a/src/scaffolding/scaffoldCompose.ts
+++ b/src/scaffolding/scaffoldCompose.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { l10n } from 'vscode';
+import * as vscode from 'vscode';
 import { copyWizardContext } from './copyWizardContext';
 import { ChoosePlatformStep } from './wizard/ChoosePlatformStep';
 import { ChooseWorkspaceFolderStep } from './wizard/ChooseWorkspaceFolderStep';
@@ -36,7 +35,7 @@ export async function scaffoldCompose(wizardContext: Partial<ScaffoldingWizardCo
     const wizard = new AzureWizard<ScaffoldingWizardContext>(wizardContext as ScaffoldingWizardContext, {
         promptSteps: promptSteps,
         executeSteps: executeSteps,
-        title: l10n.t('Add Docker Compose Files'),
+        title: vscode.l10n.t('Add Docker Compose Files'),
     });
 
     await wizard.prompt();

--- a/src/scaffolding/scaffoldCompose.ts
+++ b/src/scaffolding/scaffoldCompose.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { copyWizardContext } from './copyWizardContext';
 import { ChoosePlatformStep } from './wizard/ChoosePlatformStep';
 import { ChooseWorkspaceFolderStep } from './wizard/ChooseWorkspaceFolderStep';
@@ -36,7 +36,7 @@ export async function scaffoldCompose(wizardContext: Partial<ScaffoldingWizardCo
     const wizard = new AzureWizard<ScaffoldingWizardContext>(wizardContext as ScaffoldingWizardContext, {
         promptSteps: promptSteps,
         executeSteps: executeSteps,
-        title: localize('vscode-docker.scaffold.addDockerFiles', 'Add Docker Compose Files'),
+        title: l10n.t('Add Docker Compose Files'),
     });
 
     await wizard.prompt();

--- a/src/scaffolding/scaffoldDebugConfig.ts
+++ b/src/scaffolding/scaffoldDebugConfig.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { AzureWizard, AzureWizardPromptStep, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { copyWizardContext } from './copyWizardContext';
 import { ChoosePlatformStep } from './wizard/ChoosePlatformStep';
 import { ChooseWorkspaceFolderStep } from './wizard/ChooseWorkspaceFolderStep';
@@ -26,7 +26,7 @@ export async function scaffoldDebugConfig(wizardContext: Partial<ScaffoldingWiza
 
     const wizard = new AzureWizard<ScaffoldingWizardContext>(wizardContext as ScaffoldingWizardContext, {
         promptSteps: promptSteps,
-        title: localize('vscode-docker.scaffold.addDockerFiles', 'Initialize for Debugging'),
+        title: l10n.t('Initialize for Debugging'),
     });
 
     await wizard.prompt();

--- a/src/scaffolding/scaffoldDebugConfig.ts
+++ b/src/scaffolding/scaffoldDebugConfig.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { AzureWizard, AzureWizardPromptStep, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { l10n } from 'vscode';
+import * as vscode from 'vscode';
 import { copyWizardContext } from './copyWizardContext';
 import { ChoosePlatformStep } from './wizard/ChoosePlatformStep';
 import { ChooseWorkspaceFolderStep } from './wizard/ChooseWorkspaceFolderStep';
@@ -26,7 +25,7 @@ export async function scaffoldDebugConfig(wizardContext: Partial<ScaffoldingWiza
 
     const wizard = new AzureWizard<ScaffoldingWizardContext>(wizardContext as ScaffoldingWizardContext, {
         promptSteps: promptSteps,
-        title: l10n.t('Initialize for Debugging'),
+        title: vscode.l10n.t('Initialize for Debugging'),
     });
 
     await wizard.prompt();

--- a/src/scaffolding/wizard/ChooseComposeStep.ts
+++ b/src/scaffolding/wizard/ChooseComposeStep.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ScaffoldingWizardContext } from './ScaffoldingWizardContext';
 import { TelemetryPromptStep } from './TelemetryPromptStep';
 
 export class ChooseComposeStep extends TelemetryPromptStep<ScaffoldingWizardContext> {
     public async prompt(wizardContext: ScaffoldingWizardContext): Promise<void> {
         const opt: vscode.QuickPickOptions = {
-            placeHolder: localize('vscode-docker.scaffold.chooseComposeStep.includeCompose', 'Include optional Docker Compose files?')
+            placeHolder: l10n.t('Include optional Docker Compose files?')
         };
 
         const response = await wizardContext.ui.showQuickPick(

--- a/src/scaffolding/wizard/ChooseComposeStep.ts
+++ b/src/scaffolding/wizard/ChooseComposeStep.ts
@@ -4,14 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { l10n } from 'vscode';
 import { ScaffoldingWizardContext } from './ScaffoldingWizardContext';
 import { TelemetryPromptStep } from './TelemetryPromptStep';
 
 export class ChooseComposeStep extends TelemetryPromptStep<ScaffoldingWizardContext> {
     public async prompt(wizardContext: ScaffoldingWizardContext): Promise<void> {
         const opt: vscode.QuickPickOptions = {
-            placeHolder: l10n.t('Include optional Docker Compose files?')
+            placeHolder: vscode.l10n.t('Include optional Docker Compose files?')
         };
 
         const response = await wizardContext.ui.showQuickPick(

--- a/src/scaffolding/wizard/ChoosePlatformStep.ts
+++ b/src/scaffolding/wizard/ChoosePlatformStep.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { IAzureQuickPickItem, IWizardOptions } from '@microsoft/vscode-azext-utils';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { AllPlatforms, Platform } from '../../utils/platform';
 import { ChoosePortsStep } from './ChoosePortsStep';
 import { GatherInformationStep } from './GatherInformationStep';
@@ -25,7 +25,7 @@ export class ChoosePlatformStep extends TelemetryPromptStep<ScaffoldingWizardCon
         const opt: vscode.QuickPickOptions = {
             matchOnDescription: true,
             matchOnDetail: true,
-            placeHolder: localize('vscode-docker.scaffold.choosePlatformStep.selectPlatform', 'Select Application Platform')
+            placeHolder: l10n.t('Select Application Platform')
         };
 
         const platforms = this.platformsList || AllPlatforms as readonly Platform[];
@@ -79,7 +79,7 @@ export class ChoosePlatformStep extends TelemetryPromptStep<ScaffoldingWizardCon
                 };
 
             default:
-                throw new Error(localize('vscode-docker.scaffold.choosePlatformStep.unexpectedPlatform', 'Unexpected platform'));
+                throw new Error(l10n.t('Unexpected platform'));
         }
     }
 

--- a/src/scaffolding/wizard/ChoosePlatformStep.ts
+++ b/src/scaffolding/wizard/ChoosePlatformStep.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { IAzureQuickPickItem, IWizardOptions } from '@microsoft/vscode-azext-utils';
-import { l10n } from 'vscode';
+import * as vscode from 'vscode';
 import { AllPlatforms, Platform } from '../../utils/platform';
 import { ChoosePortsStep } from './ChoosePortsStep';
 import { GatherInformationStep } from './GatherInformationStep';
@@ -25,7 +24,7 @@ export class ChoosePlatformStep extends TelemetryPromptStep<ScaffoldingWizardCon
         const opt: vscode.QuickPickOptions = {
             matchOnDescription: true,
             matchOnDetail: true,
-            placeHolder: l10n.t('Select Application Platform')
+            placeHolder: vscode.l10n.t('Select Application Platform')
         };
 
         const platforms = this.platformsList || AllPlatforms as readonly Platform[];
@@ -79,7 +78,7 @@ export class ChoosePlatformStep extends TelemetryPromptStep<ScaffoldingWizardCon
                 };
 
             default:
-                throw new Error(l10n.t('Unexpected platform'));
+                throw new Error(vscode.l10n.t('Unexpected platform'));
         }
     }
 

--- a/src/scaffolding/wizard/ChoosePortsStep.ts
+++ b/src/scaffolding/wizard/ChoosePortsStep.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { l10n } from 'vscode';
 import { ScaffoldingWizardContext } from './ScaffoldingWizardContext';
 import { TelemetryPromptStep } from './TelemetryPromptStep';
 
@@ -19,12 +18,12 @@ export class ChoosePortsStep extends TelemetryPromptStep<ScaffoldingWizardContex
 
         const opt: vscode.InputBoxOptions = {
             placeHolder: suggestedPorts.join(', '),
-            prompt: l10n.t('What port(s) does your app listen on? Enter a comma-separated list, or empty for no exposed port.'),
+            prompt: vscode.l10n.t('What port(s) does your app listen on? Enter a comma-separated list, or empty for no exposed port.'),
             value: suggestedPorts.join(', '),
             validateInput: (value: string): string | undefined => {
                 const result = splitPorts(value);
                 if (!result) {
-                    return l10n.t('Ports must be a comma-separated list of positive integers (1 to 65535), or empty for no exposed port.');
+                    return vscode.l10n.t('Ports must be a comma-separated list of positive integers (1 to 65535), or empty for no exposed port.');
                 }
 
                 return undefined;

--- a/src/scaffolding/wizard/ChoosePortsStep.ts
+++ b/src/scaffolding/wizard/ChoosePortsStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ScaffoldingWizardContext } from './ScaffoldingWizardContext';
 import { TelemetryPromptStep } from './TelemetryPromptStep';
 
@@ -19,12 +19,12 @@ export class ChoosePortsStep extends TelemetryPromptStep<ScaffoldingWizardContex
 
         const opt: vscode.InputBoxOptions = {
             placeHolder: suggestedPorts.join(', '),
-            prompt: localize('vscode-docker.scaffold.choosePortsStep.whatPorts', 'What port(s) does your app listen on? Enter a comma-separated list, or empty for no exposed port.'),
+            prompt: l10n.t('What port(s) does your app listen on? Enter a comma-separated list, or empty for no exposed port.'),
             value: suggestedPorts.join(', '),
             validateInput: (value: string): string | undefined => {
                 const result = splitPorts(value);
                 if (!result) {
-                    return localize('vscode-docker.scaffold.choosePortsStep.portsFormat', 'Ports must be a comma-separated list of positive integers (1 to 65535), or empty for no exposed port.');
+                    return l10n.t('Ports must be a comma-separated list of positive integers (1 to 65535), or empty for no exposed port.');
                 }
 
                 return undefined;

--- a/src/scaffolding/wizard/ChooseWorkspaceFolderStep.ts
+++ b/src/scaffolding/wizard/ChooseWorkspaceFolderStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { quickPickWorkspaceFolder } from '../../utils/quickPickWorkspaceFolder';
 import { ScaffoldingWizardContext } from './ScaffoldingWizardContext';
 import { TelemetryPromptStep } from './TelemetryPromptStep';
@@ -11,7 +11,7 @@ import { TelemetryPromptStep } from './TelemetryPromptStep';
 export class ChooseWorkspaceFolderStep extends TelemetryPromptStep<ScaffoldingWizardContext> {
     public async prompt(wizardContext: ScaffoldingWizardContext): Promise<void> {
         try {
-            wizardContext.workspaceFolder = await quickPickWorkspaceFolder(wizardContext, localize('vscode-docker.scaffold.chooseWorkspaceFolderStep.noWorkspaceFolders', 'To add Docker files, please open a folder or workspace.'));
+            wizardContext.workspaceFolder = await quickPickWorkspaceFolder(wizardContext, l10n.t('To add Docker files, please open a folder or workspace.'));
         } catch (err) {
             // This will only fail if the user cancels or has no folder open. To prevent a common class of non-bugs from being filed, suppress report issue here.
             wizardContext.errorHandling.suppressReportIssue = true;

--- a/src/scaffolding/wizard/ScaffoldDebuggingStep.ts
+++ b/src/scaffolding/wizard/ScaffoldDebuggingStep.ts
@@ -3,12 +3,11 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import { AzureWizardExecuteStep } from '@microsoft/vscode-azext-utils';
-import { Progress } from 'vscode';
+import * as path from 'path';
+import { l10n, Progress } from 'vscode';
 import { DockerDebugScaffoldContext } from '../../debugging/DebugHelper';
 import { dockerDebugScaffoldingProvider } from '../../debugging/DockerDebugScaffoldingProvider';
-import { l10n } from 'vscode';
 import { unresolveWorkspaceFolder } from '../../utils/resolveVariables';
 import { NetCoreScaffoldingWizardContext } from './netCore/NetCoreScaffoldingWizardContext';
 import { PythonScaffoldingWizardContext } from './python/PythonScaffoldingWizardContext';

--- a/src/scaffolding/wizard/ScaffoldDebuggingStep.ts
+++ b/src/scaffolding/wizard/ScaffoldDebuggingStep.ts
@@ -8,7 +8,7 @@ import { AzureWizardExecuteStep } from '@microsoft/vscode-azext-utils';
 import { Progress } from 'vscode';
 import { DockerDebugScaffoldContext } from '../../debugging/DebugHelper';
 import { dockerDebugScaffoldingProvider } from '../../debugging/DockerDebugScaffoldingProvider';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { unresolveWorkspaceFolder } from '../../utils/resolveVariables';
 import { NetCoreScaffoldingWizardContext } from './netCore/NetCoreScaffoldingWizardContext';
 import { PythonScaffoldingWizardContext } from './python/PythonScaffoldingWizardContext';
@@ -18,7 +18,7 @@ export class ScaffoldDebuggingStep extends AzureWizardExecuteStep<ScaffoldingWiz
     public readonly priority: number = 1000;
 
     public async execute(wizardContext: ScaffoldingWizardContext, progress: Progress<{ message?: string; increment?: number; }>): Promise<void> {
-        progress.report({ message: localize('vscode-docker.scaffold.scaffoldDebuggingStep.progress', 'Adding debug configuration and tasks...') });
+        progress.report({ message: l10n.t('Adding debug configuration and tasks...') });
 
         const scaffoldContext: DockerDebugScaffoldContext = {
             folder: wizardContext.workspaceFolder,
@@ -65,7 +65,7 @@ export class ScaffoldDebuggingStep extends AzureWizardExecuteStep<ScaffoldingWiz
                 break;
 
             default:
-                throw new Error(localize('vscode-docker.scaffold.scaffoldDebuggingStep.invalidPlatform', 'Invalid platform for debug config scaffolding.'));
+                throw new Error(l10n.t('Invalid platform for debug config scaffolding.'));
         }
     }
 

--- a/src/scaffolding/wizard/ScaffoldFileStep.ts
+++ b/src/scaffolding/wizard/ScaffoldFileStep.ts
@@ -3,12 +3,11 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzureWizardExecuteStep, DialogResponses, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { AzureWizardExecuteStep, DialogResponses, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { getHandlebarsWithHelpers } from '../../utils/getHandlebarsWithHelpers';
 import { ScaffoldedFileType, ScaffoldingWizardContext } from './ScaffoldingWizardContext';
 
@@ -20,7 +19,7 @@ export class ScaffoldFileStep<TWizardContext extends ScaffoldingWizardContext> e
     }
 
     public async execute(wizardContext: TWizardContext, progress: vscode.Progress<{ message?: string; increment?: number; }>): Promise<void> {
-        progress.report({ message: l10n.t('Creating \'{0}\'...', this.fileType) });
+        progress.report({ message: vscode.l10n.t('Creating \'{0}\'...', this.fileType) });
 
         const handlebars = await getHandlebarsWithHelpers();
 
@@ -88,7 +87,7 @@ export class ScaffoldFileStep<TWizardContext extends ScaffoldingWizardContext> e
                 subPath = path.join('other', `${this.fileType}.template`);
                 break;
             default:
-                throw new Error(l10n.t('Unknown platform \'{0}\'', wizardContext.platform));
+                throw new Error(vscode.l10n.t('Unknown platform \'{0}\'', wizardContext.platform));
         }
 
         return (settingsTemplatesPath && await this.scanUpwardForFile(path.join(settingsTemplatesPath, subPath))) ||
@@ -141,12 +140,12 @@ export class ScaffoldFileStep<TWizardContext extends ScaffoldingWizardContext> e
         }
 
         // Otherwise, prompt
-        const prompt = l10n.t('Do you want to overwrite \'{0}\'?', this.fileType);
+        const prompt = vscode.l10n.t('Do you want to overwrite \'{0}\'?', this.fileType);
         const overwrite: vscode.MessageItem = {
-            title: l10n.t('Overwrite')
+            title: vscode.l10n.t('Overwrite')
         };
         const overwriteAll: vscode.MessageItem = {
-            title: l10n.t('Overwrite All')
+            title: vscode.l10n.t('Overwrite All')
         };
 
         const response = await wizardContext.ui.showWarningMessage(prompt, overwriteAll, overwrite, DialogResponses.cancel);

--- a/src/scaffolding/wizard/ScaffoldFileStep.ts
+++ b/src/scaffolding/wizard/ScaffoldFileStep.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzureWizardExecuteStep, DialogResponses, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { getHandlebarsWithHelpers } from '../../utils/getHandlebarsWithHelpers';
 import { ScaffoldedFileType, ScaffoldingWizardContext } from './ScaffoldingWizardContext';
 
@@ -20,7 +20,7 @@ export class ScaffoldFileStep<TWizardContext extends ScaffoldingWizardContext> e
     }
 
     public async execute(wizardContext: TWizardContext, progress: vscode.Progress<{ message?: string; increment?: number; }>): Promise<void> {
-        progress.report({ message: localize('vscode-docker.scaffold.scaffoldFileStep.progress', 'Creating \'{0}\'...', this.fileType) });
+        progress.report({ message: l10n.t('Creating \'{0}\'...', this.fileType) });
 
         const handlebars = await getHandlebarsWithHelpers();
 
@@ -88,7 +88,7 @@ export class ScaffoldFileStep<TWizardContext extends ScaffoldingWizardContext> e
                 subPath = path.join('other', `${this.fileType}.template`);
                 break;
             default:
-                throw new Error(localize('vscode-docker.scaffold.scaffoldFileStep.unknownPlatform', 'Unknown platform \'{0}\'', wizardContext.platform));
+                throw new Error(l10n.t('Unknown platform \'{0}\'', wizardContext.platform));
         }
 
         return (settingsTemplatesPath && await this.scanUpwardForFile(path.join(settingsTemplatesPath, subPath))) ||
@@ -141,12 +141,12 @@ export class ScaffoldFileStep<TWizardContext extends ScaffoldingWizardContext> e
         }
 
         // Otherwise, prompt
-        const prompt = localize('vscode-docker.scaffold.scaffoldFileStep.prompt', 'Do you want to overwrite \'{0}\'?', this.fileType);
+        const prompt = l10n.t('Do you want to overwrite \'{0}\'?', this.fileType);
         const overwrite: vscode.MessageItem = {
-            title: localize('vscode-docker.scaffold.scaffoldFileStep.overwrite', 'Overwrite')
+            title: l10n.t('Overwrite')
         };
         const overwriteAll: vscode.MessageItem = {
-            title: localize('vscode-docker.scaffold.scaffoldFileStep.overwriteAll', 'Overwrite All')
+            title: l10n.t('Overwrite All')
         };
 
         const response = await wizardContext.ui.showWarningMessage(prompt, overwriteAll, overwrite, DialogResponses.cancel);

--- a/src/scaffolding/wizard/VerifyDockerfileStep.ts
+++ b/src/scaffolding/wizard/VerifyDockerfileStep.ts
@@ -6,7 +6,6 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { l10n } from 'vscode';
 import { ScaffoldingWizardContext } from './ScaffoldingWizardContext';
 import { TelemetryPromptStep } from './TelemetryPromptStep';
 
@@ -19,11 +18,11 @@ export class VerifyDockerfileStep<TWizardContext extends ScaffoldingWizardContex
                     callback: async () => {
                         void vscode.commands.executeCommand('vscode-docker.configure', wizardContext); // They have already answered several questions, so we can copy in the current wizard context to save time
                     },
-                    title: l10n.t('Add Docker Files'),
+                    title: vscode.l10n.t('Add Docker Files'),
                 }
             ];
 
-            throw new Error(l10n.t('No Dockerfile is present in the workspace. Please add Docker files before adding Compose files.'));
+            throw new Error(vscode.l10n.t('No Dockerfile is present in the workspace. Please add Docker files before adding Compose files.'));
         }
     }
 

--- a/src/scaffolding/wizard/VerifyDockerfileStep.ts
+++ b/src/scaffolding/wizard/VerifyDockerfileStep.ts
@@ -6,7 +6,7 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ScaffoldingWizardContext } from './ScaffoldingWizardContext';
 import { TelemetryPromptStep } from './TelemetryPromptStep';
 
@@ -19,11 +19,11 @@ export class VerifyDockerfileStep<TWizardContext extends ScaffoldingWizardContex
                     callback: async () => {
                         void vscode.commands.executeCommand('vscode-docker.configure', wizardContext); // They have already answered several questions, so we can copy in the current wizard context to save time
                     },
-                    title: localize('vscode-docker.scaffold.verifyDockerfileStep.addDockerfiles', 'Add Docker Files'),
+                    title: l10n.t('Add Docker Files'),
                 }
             ];
 
-            throw new Error(localize('vscode-docker.scaffold.verifyDockerfileStep.noDockerfile', 'No Dockerfile is present in the workspace. Please add Docker files before adding Compose files.'));
+            throw new Error(l10n.t('No Dockerfile is present in the workspace. Please add Docker files before adding Compose files.'));
         }
     }
 

--- a/src/scaffolding/wizard/java/ChooseJavaArtifactStep.ts
+++ b/src/scaffolding/wizard/java/ChooseJavaArtifactStep.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from "../../../localize";
+import { l10n } from 'vscode';
 import { ChooseArtifactStep } from "../ChooseArtifactStep";
 import { ScaffoldingWizardContext } from "../ScaffoldingWizardContext";
 
 export class ChooseJavaArtifactStep extends ChooseArtifactStep<ScaffoldingWizardContext> {
     public constructor() {
         super(
-            localize('vscode-docker.scaffold.chooseJavaArtifactStep.promptText', 'Choose a build metadata file (pom.xml or build.gradle)'),
+            l10n.t('Choose a build metadata file (pom.xml or build.gradle)'),
             ['**/[Pp][Oo][Mm].[Xx][Mm][Ll]', '**/[Bb][Uu][Ii][Ll][Dd].[Gg][Rr][Aa][Dd][Ll][Ee]'],
-            localize('vscode-docker.scaffold.chooseJavaArtifactStep.noItemsFound', 'No build metadata files were found.')
+            l10n.t('No build metadata files were found.')
         );
     }
 

--- a/src/scaffolding/wizard/netCore/NetCoreChooseOsStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreChooseOsStep.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { PlatformOS } from '../../../utils/platform';
 import { TelemetryPromptStep } from '../TelemetryPromptStep';
 import { NetCoreScaffoldingWizardContext } from './NetCoreScaffoldingWizardContext';
@@ -15,7 +15,7 @@ export class NetCoreChooseOsStep extends TelemetryPromptStep<NetCoreScaffoldingW
         const opt: vscode.QuickPickOptions = {
             matchOnDescription: true,
             matchOnDetail: true,
-            placeHolder: localize('vscode-docker.scaffold.chooseOsStep.selectOS', 'Select Operating System'),
+            placeHolder: l10n.t('Select Operating System'),
         };
 
         const OSes: PlatformOS[] = ['Linux', 'Windows'];

--- a/src/scaffolding/wizard/netCore/NetCoreChooseOsStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreChooseOsStep.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
-import { l10n } from 'vscode';
+import * as vscode from 'vscode';
 import { PlatformOS } from '../../../utils/platform';
 import { TelemetryPromptStep } from '../TelemetryPromptStep';
 import { NetCoreScaffoldingWizardContext } from './NetCoreScaffoldingWizardContext';
@@ -15,7 +14,7 @@ export class NetCoreChooseOsStep extends TelemetryPromptStep<NetCoreScaffoldingW
         const opt: vscode.QuickPickOptions = {
             matchOnDescription: true,
             matchOnDetail: true,
-            placeHolder: l10n.t('Select Operating System'),
+            placeHolder: vscode.l10n.t('Select Operating System'),
         };
 
         const OSes: PlatformOS[] = ['Linux', 'Windows'];

--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as semver from 'semver';
 import * as vscode from 'vscode';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { hasTask } from '../../../tasks/TaskHelper';
 import { getValidImageNameFromPath } from '../../../utils/getValidImageName';
 import { getNetCoreProjectInfo } from '../../../utils/netCoreUtils';
@@ -38,7 +38,7 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
         const projectInfo = await getNetCoreProjectInfo('GetProjectProperties', wizardContext.artifact);
 
         if (projectInfo.length < 2) {
-            throw new Error(localize('vscode-docker.scaffold.netCoreGatherInformationStep.noProjectInfo', 'Unable to determine project info for \'{0}\'', wizardContext.artifact));
+            throw new Error(l10n.t('Unable to determine project info for \'{0}\'', wizardContext.artifact));
         }
 
         if (!wizardContext.netCoreAssemblyName) {
@@ -51,7 +51,7 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             const regexMatch = /net(coreapp)?([\d.]+)/i.exec(this.targetFramework);
 
             if (!regexMatch || regexMatch.length < 3) {
-                throw new Error(localize('vscode-docker.scaffold.netCoreGatherInformationStep.noNetCoreVersion', 'Unable to determine .NET target framework version for \'{0}\'', wizardContext.artifact));
+                throw new Error(l10n.t('Unable to determine .NET target framework version for \'{0}\'', wizardContext.artifact));
             }
 
             const [, , netCoreVersionString] = regexMatch;
@@ -104,7 +104,7 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             wizardContext.errorHandling.suppressReportIssue = true;
             wizardContext.errorHandling.buttons = [
                 {
-                    title: localize('vscode-docker.scaffold.netCoreGatherInformationStep.openCSharpExt', 'Open Extension'),
+                    title: l10n.t('Open Extension'),
                     callback: async () => vscode.commands.executeCommand('extension.open', cSharpExtensionId),
                 }
             ];
@@ -127,7 +127,7 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             await vscode.window.withProgress(
                 {
                     location: vscode.ProgressLocation.Notification,
-                    title: localize('vscode-docker.scaffold.netCoreGatherInformationStep.activatingCSharp', 'Activating C# extension...')
+                    title: l10n.t('Activating C# extension...')
                 },
                 async () => {
                     // Await the C# extension initialization, which includes Omnisharp server init
@@ -151,9 +151,9 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
         const cSharpExtensionVersion: semver.SemVer | undefined = cSharpExtension ? new semver.SemVer((<{ version: string }>cSharpExtension.packageJSON).version) : undefined;
 
         if (!cSharpExtension || !cSharpExtensionVersion) {
-            throw new Error(localize('vscode-docker.scaffold.netCoreGatherInformationStep.noCSharpExtension', 'Cannot generate Dockerfiles for a .NET project unless the C# extension is installed.'));
+            throw new Error(l10n.t('Cannot generate Dockerfiles for a .NET project unless the C# extension is installed.'));
         } else if (semver.lt(cSharpExtensionVersion, minCSharpVersionString)) {
-            throw new Error(localize('vscode-docker.scaffold.netCoreGatherInformationStep.badVersionCSharpExtension', 'Cannot generate Dockerfiles for a .NET project unless version {0} or higher of the C# extension is installed.', minCSharpVersionString));
+            throw new Error(l10n.t('Cannot generate Dockerfiles for a .NET project unless version {0} or higher of the C# extension is installed.', minCSharpVersionString));
         }
 
         return await cSharpExtension.activate();

--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -6,7 +6,6 @@
 import * as path from 'path';
 import * as semver from 'semver';
 import * as vscode from 'vscode';
-import { l10n } from 'vscode';
 import { hasTask } from '../../../tasks/TaskHelper';
 import { getValidImageNameFromPath } from '../../../utils/getValidImageName';
 import { getNetCoreProjectInfo } from '../../../utils/netCoreUtils';
@@ -38,7 +37,7 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
         const projectInfo = await getNetCoreProjectInfo('GetProjectProperties', wizardContext.artifact);
 
         if (projectInfo.length < 2) {
-            throw new Error(l10n.t('Unable to determine project info for \'{0}\'', wizardContext.artifact));
+            throw new Error(vscode.l10n.t('Unable to determine project info for \'{0}\'', wizardContext.artifact));
         }
 
         if (!wizardContext.netCoreAssemblyName) {
@@ -51,7 +50,7 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             const regexMatch = /net(coreapp)?([\d.]+)/i.exec(this.targetFramework);
 
             if (!regexMatch || regexMatch.length < 3) {
-                throw new Error(l10n.t('Unable to determine .NET target framework version for \'{0}\'', wizardContext.artifact));
+                throw new Error(vscode.l10n.t('Unable to determine .NET target framework version for \'{0}\'', wizardContext.artifact));
             }
 
             const [, , netCoreVersionString] = regexMatch;
@@ -104,7 +103,7 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             wizardContext.errorHandling.suppressReportIssue = true;
             wizardContext.errorHandling.buttons = [
                 {
-                    title: l10n.t('Open Extension'),
+                    title: vscode.l10n.t('Open Extension'),
                     callback: async () => vscode.commands.executeCommand('extension.open', cSharpExtensionId),
                 }
             ];
@@ -127,7 +126,7 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             await vscode.window.withProgress(
                 {
                     location: vscode.ProgressLocation.Notification,
-                    title: l10n.t('Activating C# extension...')
+                    title: vscode.l10n.t('Activating C# extension...')
                 },
                 async () => {
                     // Await the C# extension initialization, which includes Omnisharp server init
@@ -151,9 +150,9 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
         const cSharpExtensionVersion: semver.SemVer | undefined = cSharpExtension ? new semver.SemVer((<{ version: string }>cSharpExtension.packageJSON).version) : undefined;
 
         if (!cSharpExtension || !cSharpExtensionVersion) {
-            throw new Error(l10n.t('Cannot generate Dockerfiles for a .NET project unless the C# extension is installed.'));
+            throw new Error(vscode.l10n.t('Cannot generate Dockerfiles for a .NET project unless the C# extension is installed.'));
         } else if (semver.lt(cSharpExtensionVersion, minCSharpVersionString)) {
-            throw new Error(l10n.t('Cannot generate Dockerfiles for a .NET project unless version {0} or higher of the C# extension is installed.', minCSharpVersionString));
+            throw new Error(vscode.l10n.t('Cannot generate Dockerfiles for a .NET project unless version {0} or higher of the C# extension is installed.', minCSharpVersionString));
         }
 
         return await cSharpExtension.activate();

--- a/src/scaffolding/wizard/netCore/NetCoreScaffoldingWizardContext.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreScaffoldingWizardContext.ts
@@ -5,7 +5,7 @@
 
 import { AzureWizardPromptStep, IWizardOptions } from '@microsoft/vscode-azext-utils';
 import { CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN } from '../../../constants';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { PlatformOS } from '../../../utils/platform';
 import { ChooseArtifactStep } from '../ChooseArtifactStep';
 import { ChoosePortsStep } from '../ChoosePortsStep';
@@ -15,9 +15,9 @@ import { NetCoreChooseOsStep } from './NetCoreChooseOsStep';
 import { NetCoreGatherInformationStep } from './NetCoreGatherInformationStep';
 import { NetCoreTryGetRandomPortStep } from './NetCoreTryGetRandomPortStep';
 
-const chooseProjectFile = localize('vscode-docker.scaffold.platforms.netCore.chooseProject', 'Choose a project file');
+const chooseProjectFile = l10n.t('Choose a project file');
 const netCoreGlobPatterns = [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN];
-const noProjectFile = localize('vscode-docker.scaffold.platforms.netCore.noProject', 'No C# or F# project files were found in the workspace.');
+const noProjectFile = l10n.t('No C# or F# project files were found in the workspace.');
 
 export interface NetCoreScaffoldingWizardContext extends ScaffoldingWizardContext {
     netCoreAssemblyName?: string;

--- a/src/scaffolding/wizard/netCore/NetCoreScaffoldingWizardContext.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreScaffoldingWizardContext.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, IWizardOptions } from '@microsoft/vscode-azext-utils';
-import { CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN } from '../../../constants';
 import { l10n } from 'vscode';
+import { CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN } from '../../../constants';
 import { PlatformOS } from '../../../utils/platform';
 import { ChooseArtifactStep } from '../ChooseArtifactStep';
 import { ChoosePortsStep } from '../ChoosePortsStep';

--- a/src/scaffolding/wizard/node/NodeScaffoldingWizardContext.ts
+++ b/src/scaffolding/wizard/node/NodeScaffoldingWizardContext.ts
@@ -4,16 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, IWizardOptions } from '@microsoft/vscode-azext-utils';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { ChooseArtifactStep } from '../ChooseArtifactStep';
 import { ChoosePortsStep } from '../ChoosePortsStep';
 import { ScaffoldDebuggingStep } from '../ScaffoldDebuggingStep';
 import { ScaffoldingWizardContext } from '../ScaffoldingWizardContext';
 import { NodeGatherInformationStep } from './NodeGatherInformationStep';
 
-const choosePackageFile = localize('vscode-docker.scaffold.platforms.node.choosePackage', 'Choose a package.json file');
+const choosePackageFile = l10n.t('Choose a package.json file');
 const nodeGlobPatterns = ['**/{[Pp][Aa][Cc][Kk][Aa][Gg][Ee].[Jj][Ss][Oo][Nn]}'];
-const noPackageFile = localize('vscode-docker.scaffold.platforms.node.noPackage', 'No package.json files were found in the workspace.');
+const noPackageFile = l10n.t('No package.json files were found in the workspace.');
 
 export interface NodeScaffoldingWizardContext extends ScaffoldingWizardContext {
     nodeCmdParts?: string[];

--- a/src/scaffolding/wizard/python/ChoosePythonArtifactStep.ts
+++ b/src/scaffolding/wizard/python/ChoosePythonArtifactStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { Item, resolveFilesOfPattern } from '../../../utils/quickPickFile';
 import { ChooseArtifactStep } from '../ChooseArtifactStep';
 import { PythonScaffoldingWizardContext } from './PythonScaffoldingWizardContext';
@@ -20,9 +20,9 @@ const djangoExcludePattern = '{.[Vv][Ee][Nn][Vv]/**,**/[AaWw][Ss][Gg][Ii].[Pp][Y
 export class ChoosePythonArtifactStep extends ChooseArtifactStep<PythonScaffoldingWizardContext> {
     public constructor() {
         super(
-            localize('vscode-docker.scaffold.choosePythonArtifactStep.promptText', 'Choose the app\'s entry point (e.g. manage.py, app.py)'),
+            l10n.t('Choose the app\'s entry point (e.g. manage.py, app.py)'),
             ['**/manage.py', '**/app.py', '**/*.[Pp][Yy]'], // Including manage.py and app.py here pushes them to the top of the pick list; resolveFilesOfPattern dedupes
-            localize('vscode-docker.scaffold.choosePythonArtifactStep.noItemsFound', 'No Python files were found.')
+            l10n.t('No Python files were found.')
         );
     }
 
@@ -41,7 +41,7 @@ export class ChoosePythonArtifactStep extends ChooseArtifactStep<PythonScaffoldi
         });
 
         const enterModuleChoice: IAzureQuickPickItem = {
-            label: localize('vscode-docker.scaffold.choosePythonArtifactStep.chooseModule', 'Enter a Python module instead...'),
+            label: l10n.t('Enter a Python module instead...'),
             data: undefined,
         };
 
@@ -55,13 +55,13 @@ export class ChoosePythonArtifactStep extends ChooseArtifactStep<PythonScaffoldi
         if (result === enterModuleChoice) {
             // User wants a module target
             const module = await wizardContext.ui.showInputBox({
-                prompt: localize('vscode-docker.scaffold.choosePythonArtifactStep.enterModule', 'Enter a Python module name (e.g. myapp.manage)'),
+                prompt: l10n.t('Enter a Python module name (e.g. myapp.manage)'),
                 validateInput: (value: string): string | undefined => {
                     if (moduleRegex.test(value)) {
                         return undefined;
                     }
 
-                    return localize('vscode-docker.scaffold.choosePythonArtifactStep.moduleInvalid', 'Enter a valid Python module name (e.g. myapp.manage)');
+                    return l10n.t('Enter a valid Python module name (e.g. myapp.manage)');
                 },
             });
 

--- a/src/tasks/DockerBuildTaskProvider.ts
+++ b/src/tasks/DockerBuildTaskProvider.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { Task } from 'vscode';
 import { DockerPlatform } from '../debugging/DockerPlatformHelper';
 import { ext } from '../extensionVariables';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { cloneObject } from '../utils/cloneObject';
 import { resolveVariables } from '../utils/resolveVariables';
 import { DockerBuildOptions } from './DockerBuildTaskDefinitionBase';
@@ -81,13 +81,13 @@ export class DockerBuildTaskProvider extends DockerTaskProvider {
 
     private async validateResolvedDefinition(context: DockerBuildTaskContext, dockerBuild: DockerBuildOptions): Promise<void> {
         if (!dockerBuild.context) {
-            throw new Error(localize('vscode-docker.tasks.buildProvider.noBuildContext', 'No Docker build context was provided or resolved.'));
+            throw new Error(l10n.t('No Docker build context was provided or resolved.'));
         } else if (!await fse.pathExists(path.resolve(context.folder.uri.fsPath, resolveVariables(dockerBuild.context, context.folder)))) {
-            throw new Error(localize('vscode-docker.tasks.buildProvider.invalidBuildContext', 'The Docker build context \'{0}\' does not exist or could not be accessed.', dockerBuild.context));
+            throw new Error(l10n.t('The Docker build context \'{0}\' does not exist or could not be accessed.', dockerBuild.context));
         }
 
         if (dockerBuild.dockerfile && !await fse.pathExists(path.resolve(context.folder.uri.fsPath, resolveVariables(dockerBuild.dockerfile, context.folder)))) {
-            throw new Error(localize('vscode-docker.tasks.buildProvider.invalidDockerfile', 'The Dockerfile \'{0}\' does not exist or could not be accessed.', dockerBuild.dockerfile));
+            throw new Error(l10n.t('The Dockerfile \'{0}\' does not exist or could not be accessed.', dockerBuild.dockerfile));
         }
     }
 }

--- a/src/tasks/DockerBuildTaskProvider.ts
+++ b/src/tasks/DockerBuildTaskProvider.ts
@@ -5,10 +5,9 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { Task } from 'vscode';
+import { l10n, Task } from 'vscode';
 import { DockerPlatform } from '../debugging/DockerPlatformHelper';
 import { ext } from '../extensionVariables';
-import { l10n } from 'vscode';
 import { cloneObject } from '../utils/cloneObject';
 import { resolveVariables } from '../utils/resolveVariables';
 import { DockerBuildOptions } from './DockerBuildTaskDefinitionBase';

--- a/src/tasks/DockerComposeTaskProvider.ts
+++ b/src/tasks/DockerComposeTaskProvider.ts
@@ -8,7 +8,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Task } from 'vscode';
 import { ext } from '../extensionVariables';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { cloneObject } from '../utils/cloneObject';
 import { resolveVariables } from '../utils/resolveVariables';
 import { DockerComposeOptions, DockerComposeTaskDefinitionBase } from './DockerComposeTaskDefinitionBase';
@@ -74,25 +74,25 @@ export class DockerComposeTaskProvider extends DockerTaskProvider {
 
     private async validateResolvedDefinition(context: DockerComposeTaskContext, dockerCompose: DockerComposeOptions): Promise<void> {
         if (dockerCompose.up && dockerCompose.down) {
-            throw new Error(localize('vscode-docker.tasks.composeProvider.bothUpAndDown', 'Both "up" and "down" properties are present in the docker-compose task.'));
+            throw new Error(l10n.t('Both "up" and "down" properties are present in the docker-compose task.'));
         }
 
         if (!dockerCompose.up && !dockerCompose.down) {
-            throw new Error(localize('vscode-docker.tasks.composeProvider.noUpOrDown', 'Neither "up" nor "down" properties are present in the docker-compose task.'));
+            throw new Error(l10n.t('Neither "up" nor "down" properties are present in the docker-compose task.'));
         }
 
         if (dockerCompose.up?.services && dockerCompose.up?.profiles) {
-            throw new Error(localize('vscode-docker.tasks.composeProvider.bothServicesAndProfiles', 'Both "services" and "profiles" are present in the docker-compose task\'s "up" property.'));
+            throw new Error(l10n.t('Both "services" and "profiles" are present in the docker-compose task\'s "up" property.'));
         }
 
         for (const file of dockerCompose.files) {
             if (!(await fse.pathExists(path.resolve(context.folder.uri.fsPath, resolveVariables(file, context.folder))))) {
-                throw new Error(localize('vscode-docker.tasks.composeProvider.invalidFile', 'One or more docker-compose files does not exist or could not be accessed.'));
+                throw new Error(l10n.t('One or more docker-compose files does not exist or could not be accessed.'));
             }
         }
 
         if (dockerCompose.envFile && !(await fse.pathExists(path.resolve(context.folder.uri.fsPath, resolveVariables(dockerCompose.envFile, context.folder))))) {
-            throw new Error(localize('vscode-docker.tasks.composeProvider.invalidEnvFile', 'Environment file does not exist or could not be accessed.'));
+            throw new Error(l10n.t('Environment file does not exist or could not be accessed.'));
         }
     }
 

--- a/src/tasks/DockerComposeTaskProvider.ts
+++ b/src/tasks/DockerComposeTaskProvider.ts
@@ -3,12 +3,11 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { VoidCommandResponse } from '../runtimes/docker';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { Task } from 'vscode';
+import { l10n, Task } from 'vscode';
 import { ext } from '../extensionVariables';
-import { l10n } from 'vscode';
+import { VoidCommandResponse } from '../runtimes/docker';
 import { cloneObject } from '../utils/cloneObject';
 import { resolveVariables } from '../utils/resolveVariables';
 import { DockerComposeOptions, DockerComposeTaskDefinitionBase } from './DockerComposeTaskDefinitionBase';

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -3,18 +3,17 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RunContainerBindMount } from '../runtimes/docker';
-import { Task } from 'vscode';
+import { l10n, Task } from 'vscode';
 import { DockerPlatform } from '../debugging/DockerPlatformHelper';
 import { ext } from '../extensionVariables';
-import { l10n } from 'vscode';
+import { RunContainerBindMount } from '../runtimes/docker';
 import { cloneObject } from '../utils/cloneObject';
 import { DockerContainerVolume, DockerRunOptions } from './DockerRunTaskDefinitionBase';
 import { DockerTaskProvider } from './DockerTaskProvider';
 import { NetCoreRunTaskDefinition } from './netcore/NetCoreTaskHelper';
 import { NodeRunTaskDefinition } from './node/NodeTaskHelper';
 import { defaultVsCodeLabels, getAggregateLabels } from './TaskDefinitionBase';
-import { DockerRunTaskContext, TaskHelper, getAssociatedDockerBuildTask, throwIfCancellationRequested } from './TaskHelper';
+import { DockerRunTaskContext, getAssociatedDockerBuildTask, TaskHelper, throwIfCancellationRequested } from './TaskHelper';
 
 export interface DockerRunTaskDefinition extends NetCoreRunTaskDefinition, NodeRunTaskDefinition {
     label?: string;

--- a/src/tasks/DockerRunTaskProvider.ts
+++ b/src/tasks/DockerRunTaskProvider.ts
@@ -7,7 +7,7 @@ import { RunContainerBindMount } from '../runtimes/docker';
 import { Task } from 'vscode';
 import { DockerPlatform } from '../debugging/DockerPlatformHelper';
 import { ext } from '../extensionVariables';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { cloneObject } from '../utils/cloneObject';
 import { DockerContainerVolume, DockerRunOptions } from './DockerRunTaskDefinitionBase';
 import { DockerTaskProvider } from './DockerTaskProvider';
@@ -90,7 +90,7 @@ export class DockerRunTaskProvider extends DockerTaskProvider {
 
     private async validateResolvedDefinition(context: DockerRunTaskContext, dockerRun: DockerRunOptions): Promise<void> {
         if (!dockerRun.image) {
-            throw new Error(localize('vscode-docker.tasks.runProvider.noDockerImage', 'No Docker image name was provided or resolved.'));
+            throw new Error(l10n.t('No Docker image name was provided or resolved.'));
         }
     }
 

--- a/src/tasks/DockerTaskProvider.ts
+++ b/src/tasks/DockerTaskProvider.ts
@@ -3,11 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext, callWithTelemetryAndErrorHandling, parseError } from '@microsoft/vscode-azext-utils';
-import { CancellationToken, CustomExecution, ProviderResult, Task, TaskDefinition, TaskProvider } from 'vscode';
+import { callWithTelemetryAndErrorHandling, IActionContext, parseError } from '@microsoft/vscode-azext-utils';
+import { CancellationToken, CustomExecution, l10n, ProviderResult, Task, TaskDefinition, TaskProvider } from 'vscode';
 import { DockerPlatform, getPlatform } from '../debugging/DockerPlatformHelper';
 import { ext } from '../extensionVariables';
-import { l10n } from 'vscode';
 import { ExecError } from '../utils/execAsync';
 import { DockerBuildTask } from './DockerBuildTaskProvider';
 import { DockerPseudoterminal } from './DockerPseudoterminal';

--- a/src/tasks/DockerTaskProvider.ts
+++ b/src/tasks/DockerTaskProvider.ts
@@ -7,7 +7,7 @@ import { IActionContext, callWithTelemetryAndErrorHandling, parseError } from '@
 import { CancellationToken, CustomExecution, ProviderResult, Task, TaskDefinition, TaskProvider } from 'vscode';
 import { DockerPlatform, getPlatform } from '../debugging/DockerPlatformHelper';
 import { ext } from '../extensionVariables';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { ExecError } from '../utils/execAsync';
 import { DockerBuildTask } from './DockerBuildTaskProvider';
 import { DockerPseudoterminal } from './DockerPseudoterminal';
@@ -43,7 +43,7 @@ export abstract class DockerTaskProvider implements TaskProvider {
                 ext.activityMeasurementService.recordActivity('overallnoedit');
 
                 if (!context.folder) {
-                    throw new Error(localize('vscode-docker.tasks.provider.noScope', 'Unable to determine task scope to execute {0} task \'{1}\'. Please open a workspace folder.', this.telemetryName, task.name));
+                    throw new Error(l10n.t('Unable to determine task scope to execute {0} task \'{1}\'. Please open a workspace folder.', this.telemetryName, task.name));
                 }
 
                 context.actionContext = actionContext;

--- a/src/tasks/TaskHelper.ts
+++ b/src/tasks/TaskHelper.ts
@@ -3,13 +3,12 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { CancellationToken, ConfigurationTarget, ExtensionContext, QuickPickItem, Task, WorkspaceFolder, tasks, workspace } from 'vscode';
+import * as path from 'path';
+import { CancellationToken, ConfigurationTarget, ExtensionContext, l10n, QuickPickItem, Task, tasks, workspace, WorkspaceFolder } from 'vscode';
 import { DebugConfigurationBase } from '../debugging/DockerDebugConfigurationBase';
 import { DockerDebugConfiguration } from '../debugging/DockerDebugConfigurationProvider';
 import { DockerPlatform } from '../debugging/DockerPlatformHelper';
-import { l10n } from 'vscode';
 import { getValidImageName, getValidImageNameWithTag } from '../utils/getValidImageName';
 import { pathNormalize } from '../utils/pathNormalize';
 import { resolveVariables } from '../utils/resolveVariables';

--- a/src/tasks/TaskHelper.ts
+++ b/src/tasks/TaskHelper.ts
@@ -9,7 +9,7 @@ import { CancellationToken, ConfigurationTarget, ExtensionContext, QuickPickItem
 import { DebugConfigurationBase } from '../debugging/DockerDebugConfigurationBase';
 import { DockerDebugConfiguration } from '../debugging/DockerDebugConfigurationProvider';
 import { DockerPlatform } from '../debugging/DockerPlatformHelper';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { getValidImageName, getValidImageNameWithTag } from '../utils/getValidImageName';
 import { pathNormalize } from '../utils/pathNormalize';
 import { resolveVariables } from '../utils/resolveVariables';
@@ -181,7 +181,7 @@ export async function getOfficialBuildTaskForDockerfile(context: IActionContext,
             return { label: t.name };
         });
 
-        const item = await context.ui.showQuickPick(items, { placeHolder: localize('vscode-docker.tasks.helper.chooseBuildDefinition', 'Choose the Docker Build definition.') });
+        const item = await context.ui.showQuickPick(items, { placeHolder: l10n.t('Choose the Docker Build definition.') });
         return buildTasks.find(t => t.name === item.label);
     }
 

--- a/src/tasks/netcore/NetCoreTaskHelper.ts
+++ b/src/tasks/netcore/NetCoreTaskHelper.ts
@@ -3,16 +3,15 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { parseError } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { parseError } from '@microsoft/vscode-azext-utils';
-import { WorkspaceFolder } from 'vscode';
+import { l10n, WorkspaceFolder } from 'vscode';
 import { getContainerSecretsFolders, getHostSecretsFolders } from '../../debugging/netcore/AspNetSslHelper';
 import { NetCoreDebugOptions } from '../../debugging/netcore/NetCoreDebugHelper';
 import { vsDbgInstallBasePath } from '../../debugging/netcore/VsDbgHelper';
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { PlatformOS } from '../../utils/platform';
 import { quickPickProjectFileItem } from '../../utils/quickPickFile';
 import { resolveVariables, unresolveWorkspaceFolder } from '../../utils/resolveVariables';
@@ -20,7 +19,7 @@ import { DockerBuildOptions, DockerBuildTaskDefinitionBase } from '../DockerBuil
 import { DockerBuildTaskDefinition } from '../DockerBuildTaskProvider';
 import { DockerContainerVolume, DockerRunOptions, DockerRunTaskDefinitionBase } from '../DockerRunTaskDefinitionBase';
 import { DockerRunTaskDefinition } from '../DockerRunTaskProvider';
-import { DockerBuildTaskContext, DockerRunTaskContext, DockerTaskContext, DockerTaskScaffoldContext, TaskHelper, addVolumeWithoutConflicts, getDefaultContainerName, getDefaultImageName, inferImageName } from '../TaskHelper';
+import { addVolumeWithoutConflicts, DockerBuildTaskContext, DockerRunTaskContext, DockerTaskContext, DockerTaskScaffoldContext, getDefaultContainerName, getDefaultImageName, inferImageName, TaskHelper } from '../TaskHelper';
 import { updateBlazorManifest } from './updateBlazorManifest';
 
 export interface NetCoreTaskOptions {

--- a/src/tasks/netcore/NetCoreTaskHelper.ts
+++ b/src/tasks/netcore/NetCoreTaskHelper.ts
@@ -12,7 +12,7 @@ import { getContainerSecretsFolders, getHostSecretsFolders } from '../../debuggi
 import { NetCoreDebugOptions } from '../../debugging/netcore/NetCoreDebugHelper';
 import { vsDbgInstallBasePath } from '../../debugging/netcore/VsDbgHelper';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { PlatformOS } from '../../utils/platform';
 import { quickPickProjectFileItem } from '../../utils/quickPickFile';
 import { resolveVariables, unresolveWorkspaceFolder } from '../../utils/resolveVariables';
@@ -162,7 +162,7 @@ export class NetCoreTaskHelper implements TaskHelper {
                 await updateBlazorManifest(context, runDefinition);
             }
         } catch (err) {
-            context.terminal.writeWarningLine(localize('vscode-docker.tasks.netCore.failedBlazorUpdate', 'Failed to update Blazor static web assets manifest. Static web assets may not work.\nThe error was: {0}', parseError(err).message));
+            context.terminal.writeWarningLine(l10n.t('Failed to update Blazor static web assets manifest. Static web assets may not work.\nThe error was: {0}', parseError(err).message));
         }
     }
 
@@ -173,7 +173,7 @@ export class NetCoreTaskHelper implements TaskHelper {
             result = resolveVariables(helperOptions.appProject, context.folder);
         } else {
             // Find a .csproj or .fsproj in the folder
-            const item = await quickPickProjectFileItem(context.actionContext, undefined, context.folder, localize('vscode-docker.tasks.netCore.noCsproj', 'No .NET project file (.csproj or .fsproj) could be found.'));
+            const item = await quickPickProjectFileItem(context.actionContext, undefined, context.folder, l10n.t('No .NET project file (.csproj or .fsproj) could be found.'));
             result = item.absoluteFilePath;
         }
 

--- a/src/tasks/netcore/updateBlazorManifest.ts
+++ b/src/tasks/netcore/updateBlazorManifest.ts
@@ -6,7 +6,7 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as xml2js from 'xml2js';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { getNetCoreProjectInfo } from '../../utils/netCoreUtils';
 import { pathNormalize } from '../../utils/pathNormalize';
 import { PlatformOS } from '../../utils/platform';
@@ -39,7 +39,7 @@ export async function updateBlazorManifest(context: DockerRunTaskContext, runDef
     const contents = await getNetCoreProjectInfo('GetBlazorManifestLocations', runDefinition.netCore.appProject);
 
     if (contents.length < 2) {
-        throw new Error(localize('vscode-docker.tasks.netCore.noBlazorManifest1', 'Unable to determine Blazor manifest locations from output file.'));
+        throw new Error(l10n.t('Unable to determine Blazor manifest locations from output file.'));
     }
 
     await transformBlazorManifest(context, contents[0].trim(), contents[1].trim(), runDefinition.dockerRun.volumes, runDefinition.dockerRun.os);
@@ -58,7 +58,7 @@ async function transformBlazorManifest(context: DockerRunTaskContext, inputManif
 
     os = os || 'Linux';
 
-    context.terminal.writeOutputLine(localize('vscode-docker.tasks.netCore.attemptingBlazorContainerize', 'Attempting to containerize Blazor static web assets manifest...'));
+    context.terminal.writeOutputLine(l10n.t('Attempting to containerize Blazor static web assets manifest...'));
 
     if (path.extname(inputManifest) === '.json') {
         await transformJsonBlazorManifest(inputManifest, outputManifest, volumes, os);
@@ -71,7 +71,7 @@ async function transformJsonBlazorManifest(inputManifest: string, outputManifest
     const manifest = <JsonManifest>await fse.readJson(inputManifest);
 
     if (!manifest?.ContentRoots) {
-        throw new Error(localize('vscode-docker.tasks.netCore.failedBlazorManifestJson', 'Failed to parse Blazor static web assets manifest.'));
+        throw new Error(l10n.t('Failed to parse Blazor static web assets manifest.'));
     }
 
     if (!Array.isArray(manifest.ContentRoots)) {
@@ -92,7 +92,7 @@ async function transformXmlBlazorManifest(inputManifest: string, outputManifest:
     const manifest = <XmlManifest>await xml2js.parseStringPromise(contents);
 
     if (!manifest?.StaticWebAssets) {
-        throw new Error(localize('vscode-docker.tasks.netCore.failedBlazorManifest', 'Failed to parse Blazor static web assets manifest.'));
+        throw new Error(l10n.t('Failed to parse Blazor static web assets manifest.'));
     }
 
     if (!Array.isArray(manifest.StaticWebAssets.ContentRoot)) {

--- a/src/tasks/netcore/updateBlazorManifest.ts
+++ b/src/tasks/netcore/updateBlazorManifest.ts
@@ -5,8 +5,8 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import * as xml2js from 'xml2js';
 import { l10n } from 'vscode';
+import * as xml2js from 'xml2js';
 import { getNetCoreProjectInfo } from '../../utils/netCoreUtils';
 import { pathNormalize } from '../../utils/pathNormalize';
 import { PlatformOS } from '../../utils/platform';

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -7,7 +7,7 @@
 
 import * as semver from 'semver';
 import * as vscode from "vscode";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 
 // Adapted from https://github.com/microsoft/vscode-python/blob/main/src/client/api.ts
 interface PythonExtensionAPI {
@@ -32,7 +32,7 @@ export namespace PythonExtensionHelper {
             return debuggerPath;
         }
 
-        throw new Error(localize('vscode-docker.tasks.pythonExt.noDebugger', 'Unable to find the debugger in the Python extension.'));
+        throw new Error(l10n.t('Unable to find the debugger in the Python extension.'));
     }
 
     export async function getPythonExtension(): Promise<vscode.Extension<PythonExtensionAPI>> | undefined {
@@ -40,10 +40,10 @@ export namespace PythonExtensionHelper {
         const minPyExtensionVersion = new semver.SemVer('2020.11.367453362');
 
         const pyExt = vscode.extensions.getExtension(pyExtensionId);
-        const button = localize('vscode-docker.tasks.pythonExt.openExtension', 'Open Extension');
+        const button = l10n.t('Open Extension');
 
         if (!pyExt) {
-            const response = await vscode.window.showErrorMessage(localize('vscode-docker.tasks.pythonExt.pythonExtensionNeeded', 'For debugging Python apps in a container to work, the Python extension must be installed.'), button);
+            const response = await vscode.window.showErrorMessage(l10n.t('For debugging Python apps in a container to work, the Python extension must be installed.'), button);
 
             if (response === button) {
                 await vscode.commands.executeCommand('extension.open', pyExtensionId);
@@ -55,7 +55,7 @@ export namespace PythonExtensionHelper {
         const version = new semver.SemVer(pyExt.packageJSON.version);
 
         if (semver.lt(version, minPyExtensionVersion)) {
-            await vscode.window.showErrorMessage(localize('vscode-docker.tasks.pythonExt.pythonExtensionNotSupported', 'The installed Python extension does not meet the minimum requirements, please update to the latest version and try again.'));
+            await vscode.window.showErrorMessage(l10n.t('The installed Python extension does not meet the minimum requirements, please update to the latest version and try again.'));
             return undefined;
         }
 

--- a/src/tasks/python/PythonExtensionHelper.ts
+++ b/src/tasks/python/PythonExtensionHelper.ts
@@ -7,7 +7,6 @@
 
 import * as semver from 'semver';
 import * as vscode from "vscode";
-import { l10n } from 'vscode';
 
 // Adapted from https://github.com/microsoft/vscode-python/blob/main/src/client/api.ts
 interface PythonExtensionAPI {
@@ -32,7 +31,7 @@ export namespace PythonExtensionHelper {
             return debuggerPath;
         }
 
-        throw new Error(l10n.t('Unable to find the debugger in the Python extension.'));
+        throw new Error(vscode.l10n.t('Unable to find the debugger in the Python extension.'));
     }
 
     export async function getPythonExtension(): Promise<vscode.Extension<PythonExtensionAPI>> | undefined {
@@ -40,10 +39,10 @@ export namespace PythonExtensionHelper {
         const minPyExtensionVersion = new semver.SemVer('2020.11.367453362');
 
         const pyExt = vscode.extensions.getExtension(pyExtensionId);
-        const button = l10n.t('Open Extension');
+        const button = vscode.l10n.t('Open Extension');
 
         if (!pyExt) {
-            const response = await vscode.window.showErrorMessage(l10n.t('For debugging Python apps in a container to work, the Python extension must be installed.'), button);
+            const response = await vscode.window.showErrorMessage(vscode.l10n.t('For debugging Python apps in a container to work, the Python extension must be installed.'), button);
 
             if (response === button) {
                 await vscode.commands.executeCommand('extension.open', pyExtensionId);
@@ -55,7 +54,7 @@ export namespace PythonExtensionHelper {
         const version = new semver.SemVer(pyExt.packageJSON.version);
 
         if (semver.lt(version, minPyExtensionVersion)) {
-            await vscode.window.showErrorMessage(l10n.t('The installed Python extension does not meet the minimum requirements, please update to the latest version and try again.'));
+            await vscode.window.showErrorMessage(vscode.l10n.t('The installed Python extension does not meet the minimum requirements, please update to the latest version and try again.'));
             return undefined;
         }
 

--- a/src/telemetry/surveys/awareness.ts
+++ b/src/telemetry/surveys/awareness.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { Survey } from './SurveyManager';
 
 const minimumOverallSessions = 2;
@@ -12,11 +12,11 @@ const maximumNotEditOnlySessions = 0;
 
 export const awareness: Survey = {
     id: 'aware',
-    prompt: localize('vscode-docker.survey.aware.prompt', 'The Docker extension is always adding new features. Would you like to learn more about them?'),
+    prompt: l10n.t('The Docker extension is always adding new features. Would you like to learn more about them?'),
     buttons: new Map<string, string | undefined>([
-        [localize('vscode-docker.survey.aware.button.watch', 'Watch a video'), 'https://aka.ms/AA8lh3s'],
-        [localize('vscode-docker.survey.aware.button.read', 'Read docs'), 'https://aka.ms/AA9j59w'],
-        [localize('vscode-docker.survey.aware.button.never', 'Don\'t show again'), undefined],
+        [l10n.t('Watch a video'), 'https://aka.ms/AA8lh3s'],
+        [l10n.t('Read docs'), 'https://aka.ms/AA9j59w'],
+        [l10n.t('Don\'t show again'), undefined],
     ]),
     activationDelayMs: 30 * 1000,
     isEligible: isEligible,

--- a/src/telemetry/surveys/awareness.ts
+++ b/src/telemetry/surveys/awareness.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
 import { Survey } from './SurveyManager';
 
 const minimumOverallSessions = 2;

--- a/src/telemetry/surveys/nps2.ts
+++ b/src/telemetry/surveys/nps2.ts
@@ -4,16 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { Survey } from './SurveyManager';
 
 export const nps2: Survey = {
     id: 'nps2',
     buttons: new Map<string, string | undefined>([
-        [localize('vscode-docker.survey.nps.take', 'Take survey'), 'https://aka.ms/vscodedockernpsinproduct'],
-        [localize('vscode-docker.survey.nps.never', 'Don\'t ask again'), undefined],
+        [l10n.t('Take survey'), 'https://aka.ms/vscodedockernpsinproduct'],
+        [l10n.t('Don\'t ask again'), undefined],
     ]),
-    prompt: localize('vscode-docker.survey.nps.prompt', 'Would you be willing to take a quick feedback survey about the Docker Extension for VS Code?'),
+    prompt: l10n.t('Would you be willing to take a quick feedback survey about the Docker Extension for VS Code?'),
     activationDelayMs: 60 * 1000,
     isEligible: isNPSEligible,
 };

--- a/src/telemetry/surveys/nps2.ts
+++ b/src/telemetry/surveys/nps2.ts
@@ -4,16 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { l10n } from 'vscode';
 import { Survey } from './SurveyManager';
 
 export const nps2: Survey = {
     id: 'nps2',
     buttons: new Map<string, string | undefined>([
-        [l10n.t('Take survey'), 'https://aka.ms/vscodedockernpsinproduct'],
-        [l10n.t('Don\'t ask again'), undefined],
+        [vscode.l10n.t('Take survey'), 'https://aka.ms/vscodedockernpsinproduct'],
+        [vscode.l10n.t('Don\'t ask again'), undefined],
     ]),
-    prompt: l10n.t('Would you be willing to take a quick feedback survey about the Docker Extension for VS Code?'),
+    prompt: vscode.l10n.t('Would you be willing to take a quick feedback survey about the Docker Extension for VS Code?'),
     activationDelayMs: 60 * 1000,
     isEligible: isNPSEligible,
 };

--- a/src/telemetry/surveys/survey3.ts
+++ b/src/telemetry/surveys/survey3.ts
@@ -4,17 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { Survey } from './SurveyManager';
 
 const minimumOverallSessions = 10;
 
 export const survey3: Survey = {
     id: 'survey3',
-    prompt: localize('vscode-docker.surveys.survey3.prompt', 'How can we make the Docker extension better?'),
+    prompt: l10n.t('How can we make the Docker extension better?'),
     buttons: new Map<string, string | undefined>([
-        [localize('vscode-docker.surveys.survey3.button.take', 'Take survey'), 'https://aka.ms/dockerextensionsurvey'],
-        [localize('vscode-docker.surveys.survey3.button.never', 'Don\'t ask again'), undefined],
+        [l10n.t('Take survey'), 'https://aka.ms/dockerextensionsurvey'],
+        [l10n.t('Don\'t ask again'), undefined],
     ]),
     activationDelayMs: 60 * 1000,
     isEligible: isEligible,

--- a/src/telemetry/surveys/survey3.ts
+++ b/src/telemetry/surveys/survey3.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
+import { ext } from '../../extensionVariables';
 import { Survey } from './SurveyManager';
 
 const minimumOverallSessions = 10;

--- a/src/tree/LocalRootTreeItemBase.ts
+++ b/src/tree/LocalRootTreeItemBase.ts
@@ -9,7 +9,7 @@ import { ConfigurationTarget, ThemeColor, ThemeIcon, WorkspaceConfiguration, wor
 import { showDockerInstallNotification } from "../commands/dockerInstaller";
 import { configPrefix } from "../constants";
 import { ext } from "../extensionVariables";
-import { localize } from "../localize";
+import { l10n } from 'vscode';
 import { runtimeInstallStatusProvider } from "../utils/RuntimeInstallStatusProvider";
 import { DockerExtensionKind, IVSCodeRemoteInfo, RemoteKind, getVSCodeRemoteInfo } from "../utils/getVSCodeRemoteInfo";
 import { LocalGroupTreeItemBase } from "./LocalGroupTreeItemBase";
@@ -82,7 +82,7 @@ export abstract class LocalRootTreeItemBase<TItem extends AnyContainerObject, TP
 
     protected getTreeItemForEmptyList(): AzExtTreeItem[] {
         return [new GenericTreeItem(this, {
-            label: localize('vscode-docker.tree.noItemsFound', 'No items found'),
+            label: l10n.t('No items found'),
             iconPath: new ThemeIcon('info'),
             contextValue: 'dockerNoItems'
         })];
@@ -224,31 +224,31 @@ export abstract class LocalRootTreeItemBase<TItem extends AnyContainerObject, TP
     public getSettingWizardInfoList(): ITreeSettingWizardInfo[] {
         return [
             {
-                label: localize('vscode-docker.tree.config.label.label', 'Label'),
+                label: l10n.t('Label'),
                 setting: labelKey,
                 currentValue: this.labelSetting,
-                description: localize('vscode-docker.tree.config.label.description', 'The primary property to display.'),
+                description: l10n.t('The primary property to display.'),
                 settingInfo: this.labelSettingInfo
             },
             {
-                label: localize('vscode-docker.tree.config.description.label', 'Description'),
+                label: l10n.t('Description'),
                 setting: descriptionKey,
                 currentValue: this.descriptionSetting,
-                description: localize('vscode-docker.tree.config.description.description', 'Any secondary properties to display.'),
+                description: l10n.t('Any secondary properties to display.'),
                 settingInfo: this.descriptionSettingInfo
             },
             {
-                label: localize('vscode-docker.tree.config.groupBy.label', 'Group By'),
+                label: l10n.t('Group By'),
                 setting: groupByKey,
                 currentValue: this.groupBySetting,
-                description: localize('vscode-docker.tree.config.groupBy.description', 'The property used for grouping.'),
+                description: l10n.t('The property used for grouping.'),
                 settingInfo: this.groupBySettingInfo
             },
             {
-                label: localize('vscode-docker.tree.config.sortBy.label', 'Sort By'),
+                label: l10n.t('Sort By'),
                 setting: sortByKey,
                 currentValue: this.sortBySetting,
-                description: localize('vscode-docker.tree.config.sortBy.description', 'The property used for sorting.'),
+                description: l10n.t('The property used for sorting.'),
                 settingInfo: this.sortBySettingInfo
             },
         ];
@@ -285,22 +285,22 @@ export abstract class LocalRootTreeItemBase<TItem extends AnyContainerObject, TP
     private async getDockerErrorTreeItems(context: IActionContext, error: unknown, dockerInstalled: boolean): Promise<AzExtTreeItem[]> {
         const parsedError = parseError(error);
         if (isCommandNotSupportedError(error)) {
-            return [new GenericTreeItem(this, { label: localize('vscode-docker.tree.contextNotSupported', 'This view is not supported in the current context.'), contextValue: 'contextNotSupported' })];
+            return [new GenericTreeItem(this, { label: l10n.t('This view is not supported in the current context.'), contextValue: 'contextNotSupported' })];
         } else if (parsedError.isUserCancelledError) {
-            return [new GenericTreeItem(this, { label: localize('vscode-docker.tree.changingContexts', 'Changing context...'), contextValue: 'changingContexts' })];
+            return [new GenericTreeItem(this, { label: l10n.t('Changing context...'), contextValue: 'changingContexts' })];
         }
 
         const result: AzExtTreeItem[] = dockerInstalled
             ? [
-                new GenericTreeItem(this, { label: localize('vscode-docker.tree.dockerNotRunning', 'Failed to connect. Is {0} running?', (await ext.runtimeManager.getClient()).displayName), contextValue: 'connectionError', iconPath: new ThemeIcon('warning', new ThemeColor('problemsWarningIcon.foreground')) }),
-                new GenericTreeItem(this, { label: localize('vscode-docker.tree.dockerNotRunningError', '  Error: {0}', parsedError.message), contextValue: 'connectionError' }),
-                new OpenUrlTreeItem(this, localize('vscode-docker.tree.additionalTroubleshooting', 'Additional Troubleshooting...'), 'https://aka.ms/AA37qt2')
+                new GenericTreeItem(this, { label: l10n.t('Failed to connect. Is {0} running?', (await ext.runtimeManager.getClient()).displayName), contextValue: 'connectionError', iconPath: new ThemeIcon('warning', new ThemeColor('problemsWarningIcon.foreground')) }),
+                new GenericTreeItem(this, { label: l10n.t('  Error: {0}', parsedError.message), contextValue: 'connectionError' }),
+                new OpenUrlTreeItem(this, l10n.t('Additional Troubleshooting...'), 'https://aka.ms/AA37qt2')
             ]
-            : [new GenericTreeItem(this, { label: localize('vscode-docker.tree.dockerNotInstalled', 'Failed to connect. Is {0} installed?', (await ext.runtimeManager.getClient()).displayName), contextValue: 'connectionError', iconPath: new ThemeIcon('warning', new ThemeColor('problemsWarningIcon.foreground')) })];
+            : [new GenericTreeItem(this, { label: l10n.t('Failed to connect. Is {0} installed?', (await ext.runtimeManager.getClient()).displayName), contextValue: 'connectionError', iconPath: new ThemeIcon('warning', new ThemeColor('problemsWarningIcon.foreground')) })];
 
         const remoteInfo: IVSCodeRemoteInfo = getVSCodeRemoteInfo(context);
         if (remoteInfo.extensionKind === DockerExtensionKind.workspace && remoteInfo.remoteKind === RemoteKind.devContainer) {
-            const ti = new OpenUrlTreeItem(this, localize('vscode-docker.tree.runningInDevContainer', 'Running Docker in a dev container...'), 'https://aka.ms/AA5xva6');
+            const ti = new OpenUrlTreeItem(this, l10n.t('Running Docker in a dev container...'), 'https://aka.ms/AA5xva6');
             result.push(ti);
         }
 

--- a/src/tree/LocalRootTreeItemBase.ts
+++ b/src/tree/LocalRootTreeItemBase.ts
@@ -3,23 +3,22 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isCommandNotSupportedError, ListContainersItem, ListContextItem, ListImagesItem, ListNetworkItem, ListVolumeItem } from "../runtimes/docker";
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, GenericTreeItem, IActionContext, parseError } from "@microsoft/vscode-azext-utils";
-import { ConfigurationTarget, ThemeColor, ThemeIcon, WorkspaceConfiguration, workspace } from "vscode";
+import { ConfigurationTarget, l10n, ThemeColor, ThemeIcon, workspace, WorkspaceConfiguration } from "vscode";
 import { showDockerInstallNotification } from "../commands/dockerInstaller";
 import { configPrefix } from "../constants";
 import { ext } from "../extensionVariables";
-import { l10n } from 'vscode';
+import { isCommandNotSupportedError, ListContainersItem, ListContextItem, ListImagesItem, ListNetworkItem, ListVolumeItem } from "../runtimes/docker";
+import { DockerExtensionKind, getVSCodeRemoteInfo, IVSCodeRemoteInfo, RemoteKind } from "../utils/getVSCodeRemoteInfo";
 import { runtimeInstallStatusProvider } from "../utils/RuntimeInstallStatusProvider";
-import { DockerExtensionKind, IVSCodeRemoteInfo, RemoteKind, getVSCodeRemoteInfo } from "../utils/getVSCodeRemoteInfo";
+import { DatedDockerImage } from "./images/ImagesTreeItem";
 import { LocalGroupTreeItemBase } from "./LocalGroupTreeItemBase";
 import { OpenUrlTreeItem } from "./OpenUrlTreeItem";
 import { CommonGroupBy, CommonProperty, CommonSortBy, sortByProperties } from "./settings/CommonProperties";
 import { ITreeArraySettingInfo, ITreeSettingInfo } from "./settings/ITreeSettingInfo";
-import { ITreeSettingWizardInfo, ITreeSettingsWizardContext } from "./settings/ITreeSettingsWizardContext";
+import { ITreeSettingsWizardContext, ITreeSettingWizardInfo } from "./settings/ITreeSettingsWizardContext";
 import { TreeSettingListStep } from "./settings/TreeSettingListStep";
 import { TreeSettingStep } from "./settings/TreeSettingStep";
-import { DatedDockerImage } from "./images/ImagesTreeItem";
 import { TreePrefix } from "./TreePrefix";
 
 type DockerStatus = 'NotInstalled' | 'Installed' | 'Running';

--- a/src/tree/RefreshManager.ts
+++ b/src/tree/RefreshManager.ts
@@ -7,7 +7,7 @@ import { AzExtTreeItem, callWithTelemetryAndErrorHandling, IActionContext, parse
 import * as os from 'os';
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { EventAction, EventType, isCancellationError } from '../runtimes/docker';
 import { debounce } from '../utils/debounce';
 import { AllTreePrefixes, TreePrefix } from './TreePrefix';
@@ -158,7 +158,7 @@ export class RefreshManager extends vscode.Disposable {
                     } else {
                         // Emit a message and rethrow to get telemetry
                         ext.outputChannel.error(
-                            localize('vscode-docker.tree.refreshManager.eventSetupFailure', 'Failed to set up event listener: {0}', error.message)
+                            l10n.t('Failed to set up event listener: {0}', error.message)
                         );
 
                         throw error;

--- a/src/tree/RefreshManager.ts
+++ b/src/tree/RefreshManager.ts
@@ -7,7 +7,6 @@ import { AzExtTreeItem, callWithTelemetryAndErrorHandling, IActionContext, parse
 import * as os from 'os';
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
-import { l10n } from 'vscode';
 import { EventAction, EventType, isCancellationError } from '../runtimes/docker';
 import { debounce } from '../utils/debounce';
 import { AllTreePrefixes, TreePrefix } from './TreePrefix';
@@ -158,7 +157,7 @@ export class RefreshManager extends vscode.Disposable {
                     } else {
                         // Emit a message and rethrow to get telemetry
                         ext.outputChannel.error(
-                            l10n.t('Failed to set up event listener: {0}', error.message)
+                            vscode.l10n.t('Failed to set up event listener: {0}', error.message)
                         );
 
                         throw error;

--- a/src/tree/containers/ContainerProperties.ts
+++ b/src/tree/containers/ContainerProperties.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { l10n, ThemeColor, ThemeIcon } from "vscode";
 import { ListContainersItem } from "../../runtimes/docker";
-import { ThemeColor, ThemeIcon } from "vscode";
-import { l10n } from 'vscode';
 import { commonProperties, CommonProperty, getCommonPropertyValue } from "../settings/CommonProperties";
 import { ITreePropertyInfo } from "../settings/ITreeSettingInfo";
 

--- a/src/tree/containers/ContainerProperties.ts
+++ b/src/tree/containers/ContainerProperties.ts
@@ -5,7 +5,7 @@
 
 import { ListContainersItem } from "../../runtimes/docker";
 import { ThemeColor, ThemeIcon } from "vscode";
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { commonProperties, CommonProperty, getCommonPropertyValue } from "../settings/CommonProperties";
 import { ITreePropertyInfo } from "../settings/ITreeSettingInfo";
 
@@ -20,7 +20,7 @@ export const containerProperties: ITreePropertyInfo<ContainerProperty>[] = [
     { property: 'Ports', exampleValue: '8080' },
     { property: 'State', exampleValue: 'exited' },
     { property: 'Status', exampleValue: 'Exited (0) 2 hours ago' },
-    { property: 'Compose Project Name', description: localize('vscode-docker.tree.containers.properties.composeProjectName', 'Value used to associate containers launched by a \'docker-compose up\' command') },
+    { property: 'Compose Project Name', description: l10n.t('Value used to associate containers launched by a \'docker-compose up\' command') },
 ];
 
 export function getContainerStateIcon(state: string): ThemeIcon {
@@ -61,7 +61,7 @@ export function getContainerPropertyValue(item: ListContainersItem, property: Co
         case 'Status':
             // The rapidly-refreshing status during a container's first minute causes a lot of problems with excessive refreshing
             // This normalizes things like "10 seconds" and "Less than a second" to "Less than a minute", meaning the refreshes don't happen constantly
-            return item.status?.replace(/(\d+ seconds?)|(Less than a second)/i, localize('vscode-docker.tree.containers.lessThanMinute', 'Less than a minute'));
+            return item.status?.replace(/(\d+ seconds?)|(Less than a second)/i, l10n.t('Less than a minute'));
         case 'Compose Project Name':
             return getComposeProjectName(item);
         case 'Image':
@@ -71,7 +71,7 @@ export function getContainerPropertyValue(item: ListContainersItem, property: Co
     }
 }
 
-export const NonComposeGroupName = localize('vscode-docker.tree.containers.otherContainers', 'Individual Containers');
+export const NonComposeGroupName = l10n.t('Individual Containers');
 
 export function getComposeProjectName(container: ListContainersItem): string {
     if (!container.labels) {

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -3,19 +3,18 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ListContainersItem } from "../../runtimes/docker";
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
-import { ThemeIcon } from "vscode";
+import { l10n, ThemeIcon } from "vscode";
 import { ext } from "../../extensionVariables";
-import { l10n } from 'vscode';
+import { ListContainersItem } from "../../runtimes/docker";
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { OpenUrlTreeItem } from "../OpenUrlTreeItem";
 import { CommonGroupBy, groupByNoneProperty } from "../settings/CommonProperties";
 import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettingInfo";
-import { ContainerGroupTreeItem } from "./ContainerGroupTreeItem";
-import { ContainerProperty, containerProperties, getContainerPropertyValue, NonComposeGroupName } from "./ContainerProperties";
-import { ContainerTreeItem } from "./ContainerTreeItem";
 import { TreePrefix } from "../TreePrefix";
+import { ContainerGroupTreeItem } from "./ContainerGroupTreeItem";
+import { containerProperties, ContainerProperty, getContainerPropertyValue, NonComposeGroupName } from "./ContainerProperties";
+import { ContainerTreeItem } from "./ContainerTreeItem";
 
 export type DockerContainerInfo = ListContainersItem & {
     showFiles: boolean;

--- a/src/tree/containers/ContainersTreeItem.ts
+++ b/src/tree/containers/ContainersTreeItem.ts
@@ -7,7 +7,7 @@ import { ListContainersItem } from "../../runtimes/docker";
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
 import { ThemeIcon } from "vscode";
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { OpenUrlTreeItem } from "../OpenUrlTreeItem";
 import { CommonGroupBy, groupByNoneProperty } from "../settings/CommonProperties";
@@ -23,8 +23,8 @@ export type DockerContainerInfo = ListContainersItem & {
 
 export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInfo, ContainerProperty> {
     public treePrefix: TreePrefix = 'containers';
-    public label: string = localize('vscode-docker.tree.containers.label', 'Containers');
-    public configureExplorerTitle: string = localize('vscode-docker.tree.containers.configure', 'Configure containers explorer');
+    public label: string = l10n.t('Containers');
+    public configureExplorerTitle: string = l10n.t('Configure containers explorer');
 
     public childType: LocalChildType<DockerContainerInfo> = ContainerTreeItem;
     public childGroupType: LocalChildGroupType<DockerContainerInfo, ContainerProperty> = ContainerGroupTreeItem;
@@ -92,7 +92,7 @@ export class ContainersTreeItem extends LocalRootTreeItemBase<DockerContainerInf
 
     protected getTreeItemForEmptyList(): AzExtTreeItem[] {
         if (this.newContainerUser) {
-            const dockerTutorialTreeItem = new OpenUrlTreeItem(this, localize('vscode-docker.tree.container.gettingStarted', 'Tutorial: Get started with Docker'), 'https://aka.ms/getstartedwithdocker');
+            const dockerTutorialTreeItem = new OpenUrlTreeItem(this, l10n.t('Tutorial: Get started with Docker'), 'https://aka.ms/getstartedwithdocker');
             dockerTutorialTreeItem.iconPath = new ThemeIcon('link-external');
             return [dockerTutorialTreeItem];
         }

--- a/src/tree/containers/files/DirectoryTreeItem.ts
+++ b/src/tree/containers/files/DirectoryTreeItem.ts
@@ -3,12 +3,11 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
 import * as vscode from 'vscode';
 import { ContainerOS, ListFilesItem } from '../../../runtimes/docker';
-import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
 import { DockerUri } from '../../../runtimes/files/DockerUri';
 import { FileTreeItem } from "./FileTreeItem";
-import { l10n } from 'vscode';
 
 export type DirectoryItemProvider = (path: string | undefined) => Promise<ListFilesItem[]>;
 
@@ -74,7 +73,7 @@ export class DirectoryTreeItem extends AzExtParentTreeItem {
                 return new FileTreeItem(this, name, itemUri.with({ fileType: vscode.FileType.File }));
 
             default:
-                throw new Error(l10n.t('Unrecognized directory item type.'));
+                throw new Error(vscode.l10n.t('Unrecognized directory item type.'));
         }
     }
 

--- a/src/tree/containers/files/DirectoryTreeItem.ts
+++ b/src/tree/containers/files/DirectoryTreeItem.ts
@@ -8,7 +8,7 @@ import { ContainerOS, ListFilesItem } from '../../../runtimes/docker';
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
 import { DockerUri } from '../../../runtimes/files/DockerUri';
 import { FileTreeItem } from "./FileTreeItem";
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 
 export type DirectoryItemProvider = (path: string | undefined) => Promise<ListFilesItem[]>;
 
@@ -74,7 +74,7 @@ export class DirectoryTreeItem extends AzExtParentTreeItem {
                 return new FileTreeItem(this, name, itemUri.with({ fileType: vscode.FileType.File }));
 
             default:
-                throw new Error(localize('vscode-docker.files.unrecognizedDirectoryItemType', 'Unrecognized directory item type.'));
+                throw new Error(l10n.t('Unrecognized directory item type.'));
         }
     }
 

--- a/src/tree/containers/files/FilesTreeItem.ts
+++ b/src/tree/containers/files/FilesTreeItem.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzExtParentTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
 import * as vscode from 'vscode';
 import { ContainerOS } from '../../../runtimes/docker';
-import { AzExtParentTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
-import { l10n } from 'vscode';
 import { DockerUri } from '../../../runtimes/files/DockerUri';
 import { DirectoryTreeItem } from "./DirectoryTreeItem";
 
@@ -15,7 +14,7 @@ export class FilesTreeItem extends DirectoryTreeItem {
         super(
             parent,
             fs,
-            l10n.t('Files'),
+            vscode.l10n.t('Files'),
             DockerUri.create(containerId, '/', { fileType: vscode.FileType.Directory, ctime: 0, mtime: 0, size: 0 }),
             containerOSProvider);
     }

--- a/src/tree/containers/files/FilesTreeItem.ts
+++ b/src/tree/containers/files/FilesTreeItem.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { ContainerOS } from '../../../runtimes/docker';
 import { AzExtParentTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { DockerUri } from '../../../runtimes/files/DockerUri';
 import { DirectoryTreeItem } from "./DirectoryTreeItem";
 
@@ -15,7 +15,7 @@ export class FilesTreeItem extends DirectoryTreeItem {
         super(
             parent,
             fs,
-            localize('vscode-docker.tree.containers.files.filesTitle', 'Files'),
+            l10n.t('Files'),
             DockerUri.create(containerId, '/', { fileType: vscode.FileType.Directory, ctime: 0, mtime: 0, size: 0 }),
             containerOSProvider);
     }

--- a/src/tree/contexts/ContextsTreeItem.ts
+++ b/src/tree/contexts/ContextsTreeItem.ts
@@ -3,18 +3,18 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ListContextItem } from '../../runtimes/docker';
 import { AzExtTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
-import { ext } from '../../extensionVariables';
 import { l10n } from 'vscode';
-import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase, descriptionKey, labelKey } from "../LocalRootTreeItemBase";
+import { ext } from '../../extensionVariables';
+import { ListContextItem } from '../../runtimes/docker';
+import { descriptionKey, labelKey, LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { CommonGroupBy, groupByNoneProperty } from "../settings/CommonProperties";
 import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettingInfo";
 import { ITreeSettingWizardInfo } from '../settings/ITreeSettingsWizardContext';
-import { ContextGroupTreeItem } from './ContextGroupTreeItem';
-import { ContextProperty, contextProperties } from "./ContextProperties";
-import { ContextTreeItem } from './ContextTreeItem';
 import { TreePrefix } from '../TreePrefix';
+import { ContextGroupTreeItem } from './ContextGroupTreeItem';
+import { contextProperties, ContextProperty } from "./ContextProperties";
+import { ContextTreeItem } from './ContextTreeItem';
 
 export class ContextsTreeItem extends LocalRootTreeItemBase<ListContextItem, ContextProperty> {
     public treePrefix: TreePrefix = 'contexts';

--- a/src/tree/contexts/ContextsTreeItem.ts
+++ b/src/tree/contexts/ContextsTreeItem.ts
@@ -6,7 +6,7 @@
 import { ListContextItem } from '../../runtimes/docker';
 import { AzExtTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase, descriptionKey, labelKey } from "../LocalRootTreeItemBase";
 import { CommonGroupBy, groupByNoneProperty } from "../settings/CommonProperties";
 import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettingInfo";
@@ -18,8 +18,8 @@ import { TreePrefix } from '../TreePrefix';
 
 export class ContextsTreeItem extends LocalRootTreeItemBase<ListContextItem, ContextProperty> {
     public treePrefix: TreePrefix = 'contexts';
-    public label: string = localize('vscode-docker.tree.Contexts.label', 'Contexts');
-    public configureExplorerTitle: string = localize('vscode-docker.tree.Contexts.configure', 'Configure Docker Contexts Explorer');
+    public label: string = l10n.t('Contexts');
+    public configureExplorerTitle: string = l10n.t('Configure Docker Contexts Explorer');
     public childType: LocalChildType<ListContextItem> = ContextTreeItem;
     public childGroupType: LocalChildGroupType<ListContextItem, ContextProperty> = ContextGroupTreeItem;
 
@@ -68,17 +68,17 @@ export class ContextsTreeItem extends LocalRootTreeItemBase<ListContextItem, Con
     public getSettingWizardInfoList(): ITreeSettingWizardInfo[] {
         return [
             {
-                label: localize('vscode-docker.tree.contextConfig.label.label', 'Label'),
+                label: l10n.t('Label'),
                 setting: labelKey,
                 currentValue: this.labelSetting,
-                description: localize('vscode-docker.tree.contextConfig.label.description', 'The primary property to display.'),
+                description: l10n.t('The primary property to display.'),
                 settingInfo: this.labelSettingInfo
             },
             {
-                label: localize('vscode-docker.tree.contextConfig.description.label', 'Description'),
+                label: l10n.t('Description'),
                 setting: descriptionKey,
                 currentValue: this.descriptionSetting,
-                description: localize('vscode-docker.tree.contextConfig.description.description', 'Any secondary properties to display.'),
+                description: l10n.t('Any secondary properties to display.'),
                 settingInfo: this.descriptionSettingInfo
             }
         ];

--- a/src/tree/help/HelpsTreeItem.ts
+++ b/src/tree/help/HelpsTreeItem.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
-import { ThemeIcon } from "vscode";
-import { l10n } from 'vscode';
+import { l10n, ThemeIcon } from "vscode";
 import { getThemedIconPath } from '../getThemedIconPath';
 import { OpenUrlTreeItem } from "../OpenUrlTreeItem";
 

--- a/src/tree/help/HelpsTreeItem.ts
+++ b/src/tree/help/HelpsTreeItem.ts
@@ -5,7 +5,7 @@
 
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
 import { ThemeIcon } from "vscode";
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { getThemedIconPath } from '../getThemedIconPath';
 import { OpenUrlTreeItem } from "../OpenUrlTreeItem";
 
@@ -39,7 +39,7 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
     private get readDocumentationTreeItem(): AzExtTreeItem {
         const node = new OpenUrlTreeItem(
             this,
-            localize('views.help.readDocumentation', 'Read Extension Documentation'),
+            l10n.t('Read Extension Documentation'),
             'https://aka.ms/helppanel_docs',
             new ThemeIcon('book')
         );
@@ -51,7 +51,7 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
     private get watchVideosTreeItem(): AzExtTreeItem {
         const node = new OpenUrlTreeItem(
             this,
-            localize('views.help.watchVideos', 'Watch Extension Tutorial Videos'),
+            l10n.t('Watch Extension Tutorial Videos'),
             'https://aka.ms/helppanel_videos',
             new ThemeIcon('play-circle')
         );
@@ -63,7 +63,7 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
     private get getStartedTreeItem(): AzExtTreeItem {
         const node = new OpenUrlTreeItem(
             this,
-            localize('views.help.getStarted', 'Get Started with Docker Tutorial'),
+            l10n.t('Get Started with Docker Tutorial'),
             'https://aka.ms/helppanel_getstarted',
             new ThemeIcon('star-empty')
         );
@@ -76,7 +76,7 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
         const node = new GenericTreeItem(
             this,
             {
-                label: localize('views.help.openWalkthrough', 'Open Docker Extension Walkthrough'),
+                label: l10n.t('Open Docker Extension Walkthrough'),
                 contextValue: 'OpenWalkthrough',
                 commandId: 'vscode-docker.help.openWalkthrough',
                 iconPath: new ThemeIcon('extensions'),
@@ -91,7 +91,7 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
     private get reviewIssuesTreeItem(): AzExtTreeItem {
         const node = new OpenUrlTreeItem(
             this,
-            localize('views.help.reviewIssues', 'Review Issues'),
+            l10n.t('Review Issues'),
             'https://aka.ms/helppanel_reviewissues',
             new ThemeIcon('issues')
         );
@@ -104,7 +104,7 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
         const node = new GenericTreeItem(
             this,
             {
-                label: localize('views.help.reportIssue', 'Report Issue'),
+                label: l10n.t('Report Issue'),
                 contextValue: 'Report Issue',
                 commandId: 'vscode-docker.help.reportIssue',
                 iconPath: new ThemeIcon('comment'),
@@ -120,7 +120,7 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
         const node = new GenericTreeItem(
             this,
             {
-                label: localize('views.help.installDocker', 'Install Docker'),
+                label: l10n.t('Install Docker'),
                 contextValue: 'Install Docker',
                 commandId: 'vscode-docker.installDocker',
                 iconPath: getThemedIconPath('docker'),

--- a/src/tree/images/ImageTreeItem.ts
+++ b/src/tree/images/ImageTreeItem.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtParentTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
-import { MarkdownString, ThemeColor, ThemeIcon } from "vscode";
+import { l10n, MarkdownString, ThemeColor, ThemeIcon } from "vscode";
 import { ext } from '../../extensionVariables';
-import { l10n } from 'vscode';
 import { getTreeId } from "../LocalRootTreeItemBase";
 import { resolveTooltipMarkdown } from "../resolveTooltipMarkdown";
 import { getCommonPropertyValue } from "../settings/CommonProperties";

--- a/src/tree/images/ImageTreeItem.ts
+++ b/src/tree/images/ImageTreeItem.ts
@@ -6,7 +6,7 @@
 import { AzExtParentTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
 import { MarkdownString, ThemeColor, ThemeIcon } from "vscode";
 import { ext } from '../../extensionVariables';
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { getTreeId } from "../LocalRootTreeItemBase";
 import { resolveTooltipMarkdown } from "../resolveTooltipMarkdown";
 import { getCommonPropertyValue } from "../settings/CommonProperties";
@@ -47,7 +47,7 @@ export class ImageTreeItem extends ToolTipTreeItem {
     }
 
     public get description(): string | undefined {
-        return `${ext.imagesRoot.getTreeItemDescription(this._item)}${this._item.outdated ? localize('vscode-docker.tree.images.outdated', ' (Out of date)') : ''}`;
+        return `${ext.imagesRoot.getTreeItemDescription(this._item)}${this._item.outdated ? l10n.t(' (Out of date)') : ''}`;
     }
 
     public get iconPath(): ThemeIcon {

--- a/src/tree/images/ImagesTreeItem.ts
+++ b/src/tree/images/ImagesTreeItem.ts
@@ -7,7 +7,7 @@ import { ListImagesCommandOptions, ListImagesItem } from "../../runtimes/docker"
 import { AzExtParentTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
 import { danglingImagesMementoKey } from "../../commands/images/showDanglingImages";
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { CommonGroupBy, groupByNoneProperty } from "../settings/CommonProperties";
 import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettingInfo";
@@ -28,13 +28,13 @@ export class ImagesTreeItem extends LocalRootTreeItemBase<DatedDockerImage, Imag
         super(parent);
         this.sortBySettingInfo.properties.push({
             property: 'Size',
-            description: localize('vscode-docker.tree.images.sortBySize', 'Sort by image size')
+            description: l10n.t('Sort by image size')
         });
     }
 
     public treePrefix: TreePrefix = 'images';
-    public label: string = localize('vscode-docker.tree.images.label', 'Images');
-    public configureExplorerTitle: string = localize('vscode-docker.tree.images.configure', 'Configure images explorer');
+    public label: string = l10n.t('Images');
+    public configureExplorerTitle: string = l10n.t('Configure images explorer');
 
     public childType: LocalChildType<DatedDockerImage> = ImageTreeItem;
     public childGroupType: LocalChildGroupType<DatedDockerImage, ImageProperty> = ImageGroupTreeItem;

--- a/src/tree/images/ImagesTreeItem.ts
+++ b/src/tree/images/ImagesTreeItem.ts
@@ -3,19 +3,19 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ListImagesCommandOptions, ListImagesItem } from "../../runtimes/docker";
 import { AzExtParentTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
+import { l10n } from 'vscode';
 import { danglingImagesMementoKey } from "../../commands/images/showDanglingImages";
 import { ext } from "../../extensionVariables";
-import { l10n } from 'vscode';
+import { ListImagesCommandOptions, ListImagesItem } from "../../runtimes/docker";
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { CommonGroupBy, groupByNoneProperty } from "../settings/CommonProperties";
 import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettingInfo";
+import { TreePrefix } from "../TreePrefix";
 import { OutdatedImageChecker } from "./imageChecker/OutdatedImageChecker";
 import { ImageGroupTreeItem } from './ImageGroupTreeItem';
-import { ImageProperty, getImagePropertyValue, imageProperties } from "./ImageProperties";
+import { getImagePropertyValue, imageProperties, ImageProperty } from "./ImageProperties";
 import { ImageTreeItem } from "./ImageTreeItem";
-import { TreePrefix } from "../TreePrefix";
 
 export interface DatedDockerImage extends ListImagesItem {
     outdated?: boolean;

--- a/src/tree/networks/NetworksTreeItem.ts
+++ b/src/tree/networks/NetworksTreeItem.ts
@@ -8,7 +8,7 @@ import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { workspace } from "vscode";
 import { builtInNetworks, configPrefix } from "../../constants";
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { CommonGroupBy, getCommonPropertyValue, groupByNoneProperty } from "../settings/CommonProperties";
 import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettingInfo";
@@ -19,8 +19,8 @@ import { TreePrefix } from "../TreePrefix";
 
 export class NetworksTreeItem extends LocalRootTreeItemBase<ListNetworkItem, NetworkProperty> {
     public treePrefix: TreePrefix = 'networks';
-    public label: string = localize('vscode-docker.tree.networks.label', 'Networks');
-    public configureExplorerTitle: string = localize('vscode-docker.tree.networks.configure', 'Configure networks explorer');
+    public label: string = l10n.t('Networks');
+    public configureExplorerTitle: string = l10n.t('Configure networks explorer');
     public childType: LocalChildType<ListNetworkItem> = NetworkTreeItem;
     public childGroupType: LocalChildGroupType<ListNetworkItem, NetworkProperty> = NetworkGroupTreeItem;
 

--- a/src/tree/networks/NetworksTreeItem.ts
+++ b/src/tree/networks/NetworksTreeItem.ts
@@ -3,19 +3,18 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ListNetworkItem } from "../../runtimes/docker";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { workspace } from "vscode";
+import { l10n, workspace } from "vscode";
 import { builtInNetworks, configPrefix } from "../../constants";
 import { ext } from "../../extensionVariables";
-import { l10n } from 'vscode';
+import { ListNetworkItem } from "../../runtimes/docker";
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { CommonGroupBy, getCommonPropertyValue, groupByNoneProperty } from "../settings/CommonProperties";
 import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettingInfo";
-import { NetworkGroupTreeItem } from "./NetworkGroupTreeItem";
-import { NetworkProperty, networkProperties } from "./NetworkProperties";
-import { NetworkTreeItem } from "./NetworkTreeItem";
 import { TreePrefix } from "../TreePrefix";
+import { NetworkGroupTreeItem } from "./NetworkGroupTreeItem";
+import { networkProperties, NetworkProperty } from "./NetworkProperties";
+import { NetworkTreeItem } from "./NetworkTreeItem";
 
 export class NetworksTreeItem extends LocalRootTreeItemBase<ListNetworkItem, NetworkProperty> {
     public treePrefix: TreePrefix = 'networks';

--- a/src/tree/registries/ConnectedRegistriesTreeItem.ts
+++ b/src/tree/registries/ConnectedRegistriesTreeItem.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
-import { ThemeIcon } from "vscode";
-import { l10n } from 'vscode';
+import { l10n, ThemeIcon } from "vscode";
 
 export class ConnectedRegistriesTreeItem extends AzExtParentTreeItem {
     public contextValue: string = 'connectedRegistries';

--- a/src/tree/registries/ConnectedRegistriesTreeItem.ts
+++ b/src/tree/registries/ConnectedRegistriesTreeItem.ts
@@ -5,12 +5,12 @@
 
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
 import { ThemeIcon } from "vscode";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 
 export class ConnectedRegistriesTreeItem extends AzExtParentTreeItem {
     public contextValue: string = 'connectedRegistries';
     public childTypeLabel: string = 'registry';
-    public label: string = localize('vscode-docker.tree.registries.connectedRegistriesLabel', 'Connected Registries');
+    public label: string = l10n.t('Connected Registries');
     public children: AzExtTreeItem[] = [];
 
     public constructor(parent: AzExtParentTreeItem | undefined) {

--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, GenericTreeItem, IActionContext, IAzureQuickPickItem, UserCancelledError, parseError } from "@microsoft/vscode-azext-utils";
-import { ThemeIcon } from "vscode";
+import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, GenericTreeItem, IActionContext, IAzureQuickPickItem, parseError, UserCancelledError } from "@microsoft/vscode-azext-utils";
+import { l10n, ThemeIcon } from "vscode";
 import { ext } from "../../extensionVariables";
-import { l10n } from 'vscode';
 import { TreePrefix } from "../TreePrefix";
 import { getRegistryProviders } from "./all/getRegistryProviders";
 import { ConnectedRegistriesTreeItem } from "./ConnectedRegistriesTreeItem";

--- a/src/tree/registries/RegistriesTreeItem.ts
+++ b/src/tree/registries/RegistriesTreeItem.ts
@@ -6,7 +6,7 @@
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, GenericTreeItem, IActionContext, IAzureQuickPickItem, UserCancelledError, parseError } from "@microsoft/vscode-azext-utils";
 import { ThemeIcon } from "vscode";
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { TreePrefix } from "../TreePrefix";
 import { getRegistryProviders } from "./all/getRegistryProviders";
 import { ConnectedRegistriesTreeItem } from "./ConnectedRegistriesTreeItem";
@@ -26,7 +26,7 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
     public treePrefix: TreePrefix = 'registries';
     public static contextValue: string = 'registries';
     public contextValue: string = RegistriesTreeItem.contextValue;
-    public label: string = localize('vscode-docker.tree.registries.registriesLabel', 'Registries');
+    public label: string = l10n.t('Registries');
     public childTypeLabel: string = 'registry provider';
     public autoSelectInTreeItemPicker: boolean = true;
 
@@ -42,7 +42,7 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
     public async loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
         if (this._cachedProviders.length === 0) {
             return [new GenericTreeItem(this, {
-                label: localize('vscode-docker.tree.registries.connectRegistry', 'Connect Registry...'),
+                label: l10n.t('Connect Registry...'),
                 contextValue: 'connectRegistry',
                 iconPath: new ThemeIcon('plug'),
                 includeInTreeItemPicker: true,
@@ -56,7 +56,7 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
                 async cachedProvider => {
                     const provider = getRegistryProviders().find(rp => rp.id === cachedProvider.id);
                     if (!provider) {
-                        throw new Error(localize('vscode-docker.tree.registries.noProvider', 'Failed to find registry provider with id "{0}".', cachedProvider.id));
+                        throw new Error(l10n.t('Failed to find registry provider with id "{0}".', cachedProvider.id));
                     }
 
                     const parent = provider.isSingleRegistry ? this._connectedRegistriesTreeItem : this;
@@ -89,13 +89,13 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
         });
         picks = picks.sort((p1, p2) => p1.label.localeCompare(p2.label));
 
-        const placeHolder: string = localize('vscode-docker.tree.registries.selectProvider', 'Select the provider for your registry');
+        const placeHolder: string = l10n.t('Select the provider for your registry');
         provider = provider ?? (await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true })).data;
         if (!provider) {
             throw new UserCancelledError();
         } else if (provider.onlyOneAllowed && this._cachedProviders.find(c => c.id === provider.id)) {
             // Don't wait, no input to wait for anyway
-            void context.ui.showWarningMessage(localize('vscode-docker.tree.registries.providerConnected', 'The "{0}" registry provider is already connected.', provider.label));
+            void context.ui.showWarningMessage(l10n.t('The "{0}" registry provider is already connected.', provider.label));
             throw new UserCancelledError('registryProviderAlreadyAdded');
         }
 
@@ -141,10 +141,10 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
                 const label: string = (provider && provider.label) || crp.id;
                 const descriptions: string[] = [];
                 if (crp.username) {
-                    descriptions.push(localize('vscode-docker.tree.registries.usernameDesc', 'Username: "{0}"', crp.username));
+                    descriptions.push(l10n.t('Username: "{0}"', crp.username));
                 }
                 if (crp.url) {
-                    descriptions.push(localize('vscode-docker.tree.registries.urlDesc', 'URL: "{0}"', crp.url));
+                    descriptions.push(l10n.t('URL: "{0}"', crp.url));
                 }
                 return {
                     label,
@@ -153,7 +153,7 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
                     data: crp
                 };
             });
-            const placeHolder: string = localize('vscode-docker.tree.registries.selectDisconnect', 'Select the registry to disconnect');
+            const placeHolder: string = l10n.t('Select the registry to disconnect');
             cachedProvider = (await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true })).data;
         }
 
@@ -169,7 +169,7 @@ export class RegistriesTreeItem extends AzExtParentTreeItem {
             }
         } catch (err) {
             // Don't wait, no input to wait for anyway
-            void context.ui.showWarningMessage(localize('vscode-docker.tree.registries.disconnectError', 'The registry password could not be removed from the cache: {0}', parseError(err).message));
+            void context.ui.showWarningMessage(l10n.t('The registry password could not be removed from the cache: {0}', parseError(err).message));
         }
 
         const index = this._cachedProviders.findIndex(n => n === cachedProvider);

--- a/src/tree/registries/azure/AzureTaskTreeItem.ts
+++ b/src/tree/registries/azure/AzureTaskTreeItem.ts
@@ -5,8 +5,7 @@
 
 import type { Task as AcrTask, TaskRun as AcrTaskRun } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, nonNullValue, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
-import { ThemeIcon } from "vscode";
-import { l10n } from 'vscode';
+import { l10n, ThemeIcon } from "vscode";
 import { getAzExtAzureUtils } from "../../../utils/lazyPackages";
 import { AzureRegistryTreeItem } from "./AzureRegistryTreeItem";
 import { AzureTaskRunTreeItem } from "./AzureTaskRunTreeItem";

--- a/src/tree/registries/azure/AzureTaskTreeItem.ts
+++ b/src/tree/registries/azure/AzureTaskTreeItem.ts
@@ -6,7 +6,7 @@
 import type { Task as AcrTask, TaskRun as AcrTaskRun } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, nonNullValue, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { ThemeIcon } from "vscode";
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { getAzExtAzureUtils } from "../../../utils/lazyPackages";
 import { AzureRegistryTreeItem } from "./AzureRegistryTreeItem";
 import { AzureTaskRunTreeItem } from "./AzureTaskRunTreeItem";
@@ -32,7 +32,7 @@ export class AzureTaskTreeItem extends AzExtParentTreeItem {
     }
 
     public get label(): string {
-        return this._task ? this.taskName : localize('vscode-docker.tree.registries.azure.runsWithoutTask', 'Runs without a task');
+        return this._task ? this.taskName : l10n.t('Runs without a task');
     }
 
     public get taskName(): string {
@@ -58,7 +58,7 @@ export class AzureTaskTreeItem extends AzExtParentTreeItem {
 
         if (clearCache && runListResult.length === 0 && this._task) {
             const ti = new GenericTreeItem(this, {
-                label: localize('vscode-docker.tree.registries.azure.runTask', 'Run Task...'),
+                label: l10n.t('Run Task...'),
                 commandId: 'vscode-docker.registries.azure.runTask',
                 contextValue: 'runTask'
             });

--- a/src/tree/registries/azure/AzureTasksTreeItem.ts
+++ b/src/tree/registries/azure/AzureTasksTreeItem.ts
@@ -5,8 +5,7 @@
 
 import type { Task } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
-import { ThemeIcon } from "vscode";
-import { l10n } from 'vscode';
+import { l10n, ThemeIcon } from "vscode";
 import { getAzExtAzureUtils } from "../../../utils/lazyPackages";
 import { OpenUrlTreeItem } from "../../OpenUrlTreeItem";
 import { AzureRegistryTreeItem } from "./AzureRegistryTreeItem";

--- a/src/tree/registries/azure/AzureTasksTreeItem.ts
+++ b/src/tree/registries/azure/AzureTasksTreeItem.ts
@@ -6,7 +6,7 @@
 import type { Task } from "@azure/arm-containerregistry"; // These are only dev-time imports so don't need to be lazy
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
 import { ThemeIcon } from "vscode";
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { getAzExtAzureUtils } from "../../../utils/lazyPackages";
 import { OpenUrlTreeItem } from "../../OpenUrlTreeItem";
 import { AzureRegistryTreeItem } from "./AzureRegistryTreeItem";
@@ -39,7 +39,7 @@ export class AzureTasksTreeItem extends AzExtParentTreeItem {
         const taskListResult: Task[] = await azExtAzureUtils.uiUtils.listAllIterator(registryClient.tasks.list(registryTI.resourceGroup, registryTI.registryName));
 
         if (clearCache && taskListResult.length === 0) {
-            return [new OpenUrlTreeItem(this, localize('vscode-docker.tree.registries.azure.learnBuildTask', 'Learn how to create a build task...'), 'https://aka.ms/acr/task')];
+            return [new OpenUrlTreeItem(this, l10n.t('Learn how to create a build task...'), 'https://aka.ms/acr/task')];
         } else {
             const result: AzExtTreeItem[] = await this.createTreeItemsWithErrorHandling(
                 taskListResult,

--- a/src/tree/registries/azure/SubscriptionTreeItem.ts
+++ b/src/tree/registries/azure/SubscriptionTreeItem.ts
@@ -3,11 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Registry as AcrRegistry, ContainerRegistryManagementClient } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
+import type { ContainerRegistryManagementClient, Registry as AcrRegistry } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
 import { SubscriptionTreeItemBase } from '@microsoft/vscode-azext-azureutils'; // This can't be made lazy, so users of this class must be lazy
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, IActionContext, ICreateChildImplContext, ISubscriptionContext, nonNullProp } from "@microsoft/vscode-azext-utils";
-import { window } from 'vscode';
-import { l10n } from 'vscode';
+import { l10n, window } from 'vscode';
 import { getArmContainerRegistry, getAzExtAzureUtils } from '../../../utils/lazyPackages';
 import { ICachedRegistryProvider } from "../ICachedRegistryProvider";
 import { IRegistryProviderTreeItem } from "../IRegistryProviderTreeItem";

--- a/src/tree/registries/azure/SubscriptionTreeItem.ts
+++ b/src/tree/registries/azure/SubscriptionTreeItem.ts
@@ -7,7 +7,7 @@ import type { Registry as AcrRegistry, ContainerRegistryManagementClient } from 
 import { SubscriptionTreeItemBase } from '@microsoft/vscode-azext-azureutils'; // This can't be made lazy, so users of this class must be lazy
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, IActionContext, ICreateChildImplContext, ISubscriptionContext, nonNullProp } from "@microsoft/vscode-azext-utils";
 import { window } from 'vscode';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { getArmContainerRegistry, getAzExtAzureUtils } from '../../../utils/lazyPackages';
 import { ICachedRegistryProvider } from "../ICachedRegistryProvider";
 import { IRegistryProviderTreeItem } from "../IRegistryProviderTreeItem";
@@ -60,7 +60,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase implements IR
             executeSteps: [
                 new AzureRegistryCreateStep()
             ],
-            title: localize('vscode-docker.tree.registries.azure.createNew', 'Create new Azure Container Registry')
+            title: l10n.t('Create new Azure Container Registry')
         });
 
         await wizard.prompt();

--- a/src/tree/registries/azure/createWizard/AzureRegistryCreateStep.ts
+++ b/src/tree/registries/azure/createWizard/AzureRegistryCreateStep.ts
@@ -5,9 +5,8 @@
 
 import type { AzExtLocation } from '@microsoft/vscode-azext-azureutils';
 import { AzureWizardExecuteStep, nonNullProp, parseError } from '@microsoft/vscode-azext-utils';
-import { Progress } from 'vscode';
+import { l10n, Progress } from 'vscode';
 import { ext } from '../../../../extensionVariables';
-import { l10n } from 'vscode';
 import { getArmContainerRegistry, getAzExtAzureUtils } from '../../../../utils/lazyPackages';
 import { IAzureRegistryWizardContext } from './IAzureRegistryWizardContext';
 

--- a/src/tree/registries/azure/createWizard/AzureRegistryCreateStep.ts
+++ b/src/tree/registries/azure/createWizard/AzureRegistryCreateStep.ts
@@ -7,7 +7,7 @@ import type { AzExtLocation } from '@microsoft/vscode-azext-azureutils';
 import { AzureWizardExecuteStep, nonNullProp, parseError } from '@microsoft/vscode-azext-utils';
 import { Progress } from 'vscode';
 import { ext } from '../../../../extensionVariables';
-import { localize } from '../../../../localize';
+import { l10n } from 'vscode';
 import { getArmContainerRegistry, getAzExtAzureUtils } from '../../../../utils/lazyPackages';
 import { IAzureRegistryWizardContext } from './IAzureRegistryWizardContext';
 
@@ -20,7 +20,7 @@ export class AzureRegistryCreateStep extends AzureWizardExecuteStep<IAzureRegist
         const azExtAzureUtils = await getAzExtAzureUtils();
         const armContainerRegistry = await getArmContainerRegistry();
         const client = azExtAzureUtils.createAzureClient(context, armContainerRegistry.ContainerRegistryManagementClient);
-        const creating: string = localize('vscode-docker.tree.registries.azure.createWizard.creating', 'Creating registry "{0}"...', newRegistryName);
+        const creating: string = l10n.t('Creating registry "{0}"...', newRegistryName);
         ext.outputChannel.info(creating);
         progress.report({ message: creating });
 
@@ -48,7 +48,7 @@ export class AzureRegistryCreateStep extends AzureWizardExecuteStep<IAzureRegist
             throw err;
         }
 
-        const created = localize('vscode-docker.tree.registries.azure.createWizard.created', 'Successfully created registry "{0}".', newRegistryName);
+        const created = l10n.t('Successfully created registry "{0}".', newRegistryName);
         ext.outputChannel.info(created);
     }
 

--- a/src/tree/registries/azure/createWizard/AzureRegistryNameStep.ts
+++ b/src/tree/registries/azure/createWizard/AzureRegistryNameStep.ts
@@ -5,7 +5,7 @@
 
 import type { ContainerRegistryManagementClient } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
 import { AzureNameStep } from '@microsoft/vscode-azext-utils';
-import { localize } from '../../../../localize';
+import { l10n } from 'vscode';
 import { getArmContainerRegistry, getAzExtAzureUtils } from '../../../../utils/lazyPackages';
 import { IAzureRegistryWizardContext } from './IAzureRegistryWizardContext';
 
@@ -20,8 +20,8 @@ export class AzureRegistryNameStep extends AzureNameStep<IAzureRegistryWizardCon
         const armContainerRegistry = await getArmContainerRegistry();
         const client = azExtAzureUtils.createAzureClient(context, armContainerRegistry.ContainerRegistryManagementClient);
         context.newRegistryName = (await context.ui.showInputBox({
-            placeHolder: localize('vscode-docker.tree.registries.azure.createWizard.name', 'Registry name'),
-            prompt: localize('vscode-docker.tree.registries.azure.createWizard.namePrompt', 'Provide a registry name'),
+            placeHolder: l10n.t('Registry name'),
+            prompt: l10n.t('Provide a registry name'),
             /* eslint-disable-next-line @typescript-eslint/promise-function-async */
             validateInput: (name: string) => validateRegistryName(name, client)
         })).trim();
@@ -40,9 +40,9 @@ async function validateRegistryName(name: string, client: ContainerRegistryManag
     const min = 5;
     const max = 50;
     if (name.length < min || name.length > max) {
-        return localize('vscode-docker.tree.registries.azure.createWizard.nameLength', 'The name must be between {0} and {1} characters.', min, max);
+        return l10n.t('The name must be between {0} and {1} characters.', min, max);
     } else if (name.match(/[^a-z0-9]/i)) {
-        return localize('vscode-docker.tree.registries.azure.createWizard.nameAlphanumeric', 'The name can only contain alphanumeric characters.');
+        return l10n.t('The name can only contain alphanumeric characters.');
     } else {
         const nameStatus = await client.registries.checkNameAvailability({ name, type: 'Microsoft.ContainerRegistry/registries' });
         return nameStatus.message;

--- a/src/tree/registries/azure/createWizard/AzureRegistrySkuStep.ts
+++ b/src/tree/registries/azure/createWizard/AzureRegistrySkuStep.ts
@@ -5,7 +5,7 @@
 
 import type { SkuName as AcrSkuName } from '@azure/arm-containerregistry'; // These are only dev-time imports so don't need to be lazy
 import { AzureWizardPromptStep, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
-import { localize } from '../../../../localize';
+import { l10n } from 'vscode';
 import { IAzureRegistryWizardContext } from './IAzureRegistryWizardContext';
 
 export class AzureRegistrySkuStep extends AzureWizardPromptStep<IAzureRegistryWizardContext> {
@@ -13,7 +13,7 @@ export class AzureRegistrySkuStep extends AzureWizardPromptStep<IAzureRegistryWi
         const skus: AcrSkuName[] = ["Basic", "Standard", "Premium"];
         const picks: IAzureQuickPickItem<AcrSkuName>[] = skus.map(s => { return { label: s, data: s }; });
 
-        const placeHolder: string = localize('vscode-docker.tree.registries.azure.createWizard.selectSku', 'Select a SKU');
+        const placeHolder: string = l10n.t('Select a SKU');
         context.newRegistrySku = (await context.ui.showQuickPick(picks, { placeHolder })).data;
     }
 

--- a/src/tree/registries/connectWizard/RegistryPasswordStep.ts
+++ b/src/tree/registries/connectWizard/RegistryPasswordStep.ts
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { IConnectRegistryWizardContext } from './IConnectRegistryWizardContext';
 
 export class RegistryPasswordStep extends AzureWizardPromptStep<IConnectRegistryWizardContext> {
     public async prompt(context: IConnectRegistryWizardContext): Promise<void> {
-        const prompt: string = context.passwordPrompt || localize('vscode-docker.tree.registries.connectWizard.enterPassword', 'Enter your password');
+        const prompt: string = context.passwordPrompt || l10n.t('Enter your password');
         context.secret = await context.ui.showInputBox({ prompt, validateInput, password: true });
     }
 
@@ -20,7 +20,7 @@ export class RegistryPasswordStep extends AzureWizardPromptStep<IConnectRegistry
 
 function validateInput(value: string | undefined): string | undefined {
     if (!value) {
-        return localize('vscode-docker.tree.registries.connectWizard.passwordEmpty', 'Password cannot be empty.');
+        return l10n.t('Password cannot be empty.');
     } else {
         return undefined;
     }

--- a/src/tree/registries/connectWizard/RegistryUrlStep.ts
+++ b/src/tree/registries/connectWizard/RegistryUrlStep.ts
@@ -5,13 +5,13 @@
 
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import { URL } from 'url';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { IConnectRegistryWizardContext } from './IConnectRegistryWizardContext';
 
 export class RegistryUrlStep extends AzureWizardPromptStep<IConnectRegistryWizardContext> {
     public async prompt(context: IConnectRegistryWizardContext): Promise<void> {
-        const prompt: string = context.urlPrompt || localize('vscode-docker.tree.registries.connectWizard.enterUrl', 'Enter the URL for the registry provider');
-        const placeHolder: string = localize('vscode-docker.tree.registries.connectWizard.exampleUrl', 'Example: http://localhost:5000');
+        const prompt: string = context.urlPrompt || l10n.t('Enter the URL for the registry provider');
+        const placeHolder: string = l10n.t('Example: http://localhost:5000');
         context.url = (await context.ui.showInputBox({
             prompt,
             placeHolder,
@@ -25,7 +25,7 @@ export class RegistryUrlStep extends AzureWizardPromptStep<IConnectRegistryWizar
 
     private validateUrl(context: IConnectRegistryWizardContext, value: string): string | undefined {
         if (!value) {
-            return localize('vscode-docker.tree.registries.connectWizard.urlEmpty', 'URL cannot be empty.');
+            return l10n.t('URL cannot be empty.');
         } else {
             let protocol: string | undefined;
             let host: string | undefined;
@@ -38,9 +38,9 @@ export class RegistryUrlStep extends AzureWizardPromptStep<IConnectRegistryWizar
             }
 
             if (!protocol || !host) {
-                return localize('vscode-docker.tree.registries.connectWizard.validUrl', 'Please enter a valid URL');
+                return l10n.t('Please enter a valid URL');
             } else if (context.existingProviders.find(rp => rp.url === value)) {
-                return localize('vscode-docker.tree.registries.connectWizard.urlConnected', 'URL "{0}" is already connected.', value);
+                return l10n.t('URL "{0}" is already connected.', value);
             } else {
                 return undefined;
             }

--- a/src/tree/registries/connectWizard/RegistryUsernameStep.ts
+++ b/src/tree/registries/connectWizard/RegistryUsernameStep.ts
@@ -5,12 +5,12 @@
 
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
 import { InputBoxOptions } from 'vscode';
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { IConnectRegistryWizardContext } from './IConnectRegistryWizardContext';
 
 export class RegistryUsernameStep extends AzureWizardPromptStep<IConnectRegistryWizardContext> {
     public async prompt(context: IConnectRegistryWizardContext): Promise<void> {
-        const prompt: string = context.usernamePrompt || (context.isUsernameOptional ? localize('vscode-docker.tree.registries.connectWizard.enterUsernameOptional', 'Enter your username, or press \'Enter\' for none') : localize('vscode-docker.tree.registries.connectWizard.enterUsernameRequired', 'Enter your username'));
+        const prompt: string = context.usernamePrompt || (context.isUsernameOptional ? l10n.t('Enter your username, or press \'Enter\' for none') : l10n.t('Enter your username'));
         const options: InputBoxOptions = {
             prompt,
             placeHolder: context.usernamePlaceholder,
@@ -30,9 +30,9 @@ export class RegistryUsernameStep extends AzureWizardPromptStep<IConnectRegistry
 
     private validateInput(context: IConnectRegistryWizardContext, value: string | undefined): string | undefined {
         if (!context.isUsernameOptional && !value) {
-            return localize('vscode-docker.tree.registries.connectWizard.usernameEmpty', 'Username cannot be empty.');
+            return l10n.t('Username cannot be empty.');
         } else if (context.existingProviders.find(rp => rp.url === context.url && rp.username === value)) {
-            return localize('vscode-docker.tree.registries.connectWizard.usernameConnected', 'Username "{0}" is already connected.', value);
+            return l10n.t('Username "{0}" is already connected.', value);
         } else {
             return undefined;
         }

--- a/src/tree/registries/connectWizard/RegistryUsernameStep.ts
+++ b/src/tree/registries/connectWizard/RegistryUsernameStep.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep } from '@microsoft/vscode-azext-utils';
-import { InputBoxOptions } from 'vscode';
-import { l10n } from 'vscode';
+import { InputBoxOptions, l10n } from 'vscode';
 import { IConnectRegistryWizardContext } from './IConnectRegistryWizardContext';
 
 export class RegistryUsernameStep extends AzureWizardPromptStep<IConnectRegistryWizardContext> {

--- a/src/tree/registries/dockerHub/dockerHubRegistryProvider.ts
+++ b/src/tree/registries/dockerHub/dockerHubRegistryProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { RegistryApi } from "../all/RegistryApi";
 import { IRegistryProvider } from "../IRegistryProvider";
 import { deleteRegistryPassword, setRegistryPassword } from '../registryPasswords';
@@ -16,11 +16,11 @@ export const dockerHubRegistryProvider: IRegistryProvider = {
     id: dockerHubRegistryProviderId,
     api: RegistryApi.DockerHubV2,
     connectWizardOptions: {
-        wizardTitle: localize('vscode-docker.tree.registries.dockerHub.signIn', 'Sign in to Docker Hub'),
+        wizardTitle: l10n.t('Sign in to Docker Hub'),
         includeUsername: true,
-        usernamePrompt: localize('vscode-docker.tree.registries.dockerHub.dockerID', 'Visit hub.docker.com to sign up for a Docker ID'),
-        usernamePlaceholder: localize('vscode-docker.tree.registries.dockerHub.enterID', 'Enter your Docker ID'),
-        passwordPrompt: localize('vscode-docker.tree.registries.dockerHub.enterPassword', 'Enter your password or personal access token'),
+        usernamePrompt: l10n.t('Visit hub.docker.com to sign up for a Docker ID'),
+        usernamePlaceholder: l10n.t('Enter your Docker ID'),
+        passwordPrompt: l10n.t('Enter your password or personal access token'),
         includePassword: true,
     },
     treeItemFactory: (parent, cachedProvider) => new DockerHubAccountTreeItem(parent, cachedProvider),

--- a/src/tree/registries/dockerV2/genericDockerV2RegistryProvider.ts
+++ b/src/tree/registries/dockerV2/genericDockerV2RegistryProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { RegistryApi } from "../all/RegistryApi";
 import { basicOAuthProvider } from '../auth/BasicOAuthProvider';
 import { IRegistryProvider } from "../IRegistryProvider";
@@ -11,16 +11,16 @@ import { deleteRegistryPassword, setRegistryPassword } from '../registryPassword
 import { GenericDockerV2RegistryTreeItem } from "./GenericDockerV2RegistryTreeItem";
 
 export const genericDockerV2RegistryProvider: IRegistryProvider = {
-    label: localize('vscode-docker.tree.registries.v2.label', 'Generic Docker Registry'),
-    description: localize('vscode-docker.tree.registries.v2.description', '(Preview)'),
-    detail: localize('vscode-docker.tree.registries.v2.detail', 'Connect any generic private registry that supports the "Docker V2" api.'),
+    label: l10n.t('Generic Docker Registry'),
+    description: l10n.t('(Preview)'),
+    detail: l10n.t('Connect any generic private registry that supports the "Docker V2" api.'),
     id: 'genericDockerV2',
     api: RegistryApi.DockerV2,
     isSingleRegistry: true,
     connectWizardOptions: {
-        wizardTitle: localize('vscode-docker.tree.registries.v2.title', 'Connect Docker Registry'),
+        wizardTitle: l10n.t('Connect Docker Registry'),
         includeUrl: true,
-        urlPrompt: localize('vscode-docker.tree.registries.v2.urlPrompt', 'Enter the URL for the registry'),
+        urlPrompt: l10n.t('Enter the URL for the registry'),
         includeUsername: true,
         isUsernameOptional: true,
         includePassword: true,

--- a/src/tree/registries/gitLab/gitLabRegistryProvider.ts
+++ b/src/tree/registries/gitLab/gitLabRegistryProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from '../../../localize';
+import { l10n } from 'vscode';
 import { RegistryApi } from "../all/RegistryApi";
 import { IRegistryProvider } from "../IRegistryProvider";
 import { deleteRegistryPassword, setRegistryPassword } from '../registryPasswords';
@@ -14,10 +14,10 @@ export const gitLabRegistryProvider: IRegistryProvider = {
     id: 'gitLab',
     api: RegistryApi.GitLabV4,
     connectWizardOptions: {
-        wizardTitle: localize('vscode-docker.tree.registries.gitlab.signIn', 'Sign in to GitLab'),
+        wizardTitle: l10n.t('Sign in to GitLab'),
         includeUsername: true,
         includePassword: true,
-        passwordPrompt: localize('vscode-docker.tree.registries.gitlab.pat', 'GitLab Personal Access Token (requires `api` or `read_api` scope)'),
+        passwordPrompt: l10n.t('GitLab Personal Access Token (requires `api` or `read_api` scope)'),
     },
     treeItemFactory: (parent, cachedProvider) => new GitLabAccountTreeItem(parent, cachedProvider),
     persistAuth: async (cachedProvider, secret) => await setRegistryPassword(cachedProvider, secret),

--- a/src/tree/registries/registryContextValues.ts
+++ b/src/tree/registries/registryContextValues.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtTreeItem } from "@microsoft/vscode-azext-utils";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { RegistryApi } from "./all/RegistryApi";
 import { azureRegistryProviderId } from "./azure/azureRegistryProvider";
 import { dockerHubRegistryProviderId } from "./dockerHub/dockerHubRegistryProvider";
@@ -54,7 +54,7 @@ function convertToRegExp(provider: Partial<ICachedRegistryProvider>, suffix: str
 function getCachedProvider(node: AzExtTreeItem & Partial<IRegistryProviderTreeItem>): ICachedRegistryProvider {
     while (!node.cachedProvider) {
         if (!node.parent) {
-            throw new Error(localize('vscode-docker.tree.registries.noCachedProvider', 'Failed to find cachedProvider'));
+            throw new Error(l10n.t('Failed to find cachedProvider'));
         } else {
             node = node.parent;
         }

--- a/src/tree/settings/CommonProperties.ts
+++ b/src/tree/settings/CommonProperties.ts
@@ -5,8 +5,7 @@
 
 import * as dayjs from 'dayjs';
 import * as relativeTime from 'dayjs/plugin/relativeTime';
-import { ThemeIcon } from 'vscode';
-import { l10n } from 'vscode';
+import { l10n, ThemeIcon } from 'vscode';
 import { convertToMB } from '../../utils/convertToMB';
 import { ITreePropertyInfo } from './ITreeSettingInfo';
 

--- a/src/tree/settings/CommonProperties.ts
+++ b/src/tree/settings/CommonProperties.ts
@@ -6,7 +6,7 @@
 import * as dayjs from 'dayjs';
 import * as relativeTime from 'dayjs/plugin/relativeTime';
 import { ThemeIcon } from 'vscode';
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { convertToMB } from '../../utils/convertToMB';
 import { ITreePropertyInfo } from './ITreeSettingInfo';
 
@@ -22,12 +22,12 @@ export const commonProperties: ITreePropertyInfo<Exclude<CommonProperty, 'Size'>
 
 export const groupByNoneProperty: ITreePropertyInfo<CommonGroupBy> = {
     property: 'None',
-    description: localize('vscode-docker.tree.settings.none', 'No grouping')
+    description: l10n.t('No grouping')
 };
 
 export const sortByProperties: ITreePropertyInfo<CommonSortBy>[] = [
-    { property: 'CreatedTime', description: localize('vscode-docker.tree.settings.createdTime', 'Sort by newest') },
-    { property: 'Label', description: localize('vscode-docker.tree.settings.label', 'Sort alphabetically by label') }
+    { property: 'CreatedTime', description: l10n.t('Sort by newest') },
+    { property: 'Label', description: l10n.t('Sort alphabetically by label') }
 ];
 
 export function getCommonPropertyValue(item: { createdAt?: Date, size?: number }, property: CommonProperty): string {
@@ -37,7 +37,7 @@ export function getCommonPropertyValue(item: { createdAt?: Date, size?: number }
         case 'Size':
             return Number.isInteger(item?.size) ? `${convertToMB(item.size)} MB` : '';
         default:
-            throw new RangeError(localize('vscode-docker.tree.settings.unexpected1', 'Unexpected property "{0}".', property));
+            throw new RangeError(l10n.t('Unexpected property "{0}".', property));
     }
 }
 
@@ -48,7 +48,7 @@ export function getCommonGroupIcon(property: CommonProperty | CommonGroupBy): Th
             icon = 'watch';
             break;
         default:
-            throw new RangeError(localize('vscode-docker.tree.settings.unexpected2', 'Unexpected property "{0}".', property));
+            throw new RangeError(l10n.t('Unexpected property "{0}".', property));
     }
 
     return new ThemeIcon(icon);

--- a/src/tree/settings/TreeSettingListStep.ts
+++ b/src/tree/settings/TreeSettingListStep.ts
@@ -5,7 +5,7 @@
 
 import { AzureWizardPromptStep, IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
 import { l10n } from 'vscode';
-import { ITreeSettingWizardInfo, ITreeSettingsWizardContext } from "./ITreeSettingsWizardContext";
+import { ITreeSettingsWizardContext, ITreeSettingWizardInfo } from "./ITreeSettingsWizardContext";
 
 export class TreeSettingListStep extends AzureWizardPromptStep<ITreeSettingsWizardContext> {
     public async prompt(context: ITreeSettingsWizardContext): Promise<void> {

--- a/src/tree/settings/TreeSettingListStep.ts
+++ b/src/tree/settings/TreeSettingListStep.ts
@@ -4,23 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { ITreeSettingWizardInfo, ITreeSettingsWizardContext } from "./ITreeSettingsWizardContext";
 
 export class TreeSettingListStep extends AzureWizardPromptStep<ITreeSettingsWizardContext> {
     public async prompt(context: ITreeSettingsWizardContext): Promise<void> {
-        const placeHolder = localize('vscode-docker.tree.settings.select', 'Select a setting to change.');
+        const placeHolder = l10n.t('Select a setting to change.');
         const picks: IAzureQuickPickItem<ITreeSettingWizardInfo | undefined>[] = context.infoList.map(info => {
             return {
-                label: localize('vscode-docker.tree.settings.currentLabel', '$(gear) {0}', info.label),
-                description: localize('vscode-docker.tree.settings.currentValue', 'Current: "{0}"', info.currentValue?.toString()),
+                label: l10n.t('$(gear) {0}', info.label),
+                description: l10n.t('Current: "{0}"', info.currentValue?.toString()),
                 detail: info.description,
                 data: info
             };
         });
         picks.push({
-            label: localize('vscode-docker.tree.settings.resetLabel', '$(history) Reset settings'),
-            detail: localize('vscode-docker.tree.settings.resetDetail', 'Restore settings to their original defaults.'),
+            label: l10n.t('$(history) Reset settings'),
+            detail: l10n.t('Restore settings to their original defaults.'),
             data: undefined
         });
         context.info = (await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true, ignoreFocusOut: false })).data;

--- a/src/tree/settings/TreeSettingStep.ts
+++ b/src/tree/settings/TreeSettingStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, IAzureQuickPickItem, IAzureQuickPickOptions, nonNullProp } from "@microsoft/vscode-azext-utils";
-import { localize } from "../../localize";
+import { l10n } from 'vscode';
 import { ITreePropertyInfo } from "./ITreeSettingInfo";
 import { ITreeSettingsWizardContext } from "./ITreeSettingsWizardContext";
 
@@ -42,7 +42,7 @@ function convertPropertyInfoToPick(info: ITreePropertyInfo<string>): IAzureQuick
     let detail: string | undefined;
 
     if (info.exampleValue) {
-        description = localize('vscode-docker.tree.settings.setting.description', 'e.g. "{0}"', info.exampleValue);
+        description = l10n.t('e.g. "{0}"', info.exampleValue);
         detail = info.description;
     } else {
         description = info.description;

--- a/src/tree/volumes/VolumesTreeItem.ts
+++ b/src/tree/volumes/VolumesTreeItem.ts
@@ -3,17 +3,17 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ListVolumeItem } from "../../runtimes/docker";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { ext } from "../../extensionVariables";
 import { l10n } from 'vscode';
+import { ext } from "../../extensionVariables";
+import { ListVolumeItem } from "../../runtimes/docker";
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { CommonGroupBy, getCommonPropertyValue, groupByNoneProperty } from "../settings/CommonProperties";
 import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettingInfo";
-import { VolumeGroupTreeItem } from "./VolumeGroupTreeItem";
-import { VolumeProperty, volumeProperties } from "./VolumeProperties";
-import { VolumeTreeItem } from "./VolumeTreeItem";
 import { TreePrefix } from "../TreePrefix";
+import { VolumeGroupTreeItem } from "./VolumeGroupTreeItem";
+import { volumeProperties, VolumeProperty } from "./VolumeProperties";
+import { VolumeTreeItem } from "./VolumeTreeItem";
 
 export class VolumesTreeItem extends LocalRootTreeItemBase<ListVolumeItem, VolumeProperty> {
     public treePrefix: TreePrefix = 'volumes';

--- a/src/tree/volumes/VolumesTreeItem.ts
+++ b/src/tree/volumes/VolumesTreeItem.ts
@@ -6,7 +6,7 @@
 import { ListVolumeItem } from "../../runtimes/docker";
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
-import { localize } from '../../localize';
+import { l10n } from 'vscode';
 import { LocalChildGroupType, LocalChildType, LocalRootTreeItemBase } from "../LocalRootTreeItemBase";
 import { CommonGroupBy, getCommonPropertyValue, groupByNoneProperty } from "../settings/CommonProperties";
 import { ITreeArraySettingInfo, ITreeSettingInfo } from "../settings/ITreeSettingInfo";
@@ -17,8 +17,8 @@ import { TreePrefix } from "../TreePrefix";
 
 export class VolumesTreeItem extends LocalRootTreeItemBase<ListVolumeItem, VolumeProperty> {
     public treePrefix: TreePrefix = 'volumes';
-    public label: string = localize('vscode-docker.tree.volumes.label', 'Volumes');
-    public configureExplorerTitle: string = localize('vscode-docker.tree.volumes.configure', 'Configure volumes explorer');
+    public label: string = l10n.t('Volumes');
+    public configureExplorerTitle: string = l10n.t('Configure volumes explorer');
     public childType: LocalChildType<ListVolumeItem> = VolumeTreeItem;
     public childGroupType: LocalChildGroupType<ListVolumeItem, VolumeProperty> = VolumeGroupTreeItem;
 

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -7,7 +7,7 @@ import { ISubscriptionContext } from '@microsoft/vscode-azext-utils';
 import { Request } from 'node-fetch';
 import { URLSearchParams } from 'url';
 import { l10n } from 'vscode';
-import { RequestOptionsLike, httpRequest } from './httpRequest';
+import { httpRequest, RequestOptionsLike } from './httpRequest';
 
 const refreshTokens: { [key: string]: string } = {};
 

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -6,7 +6,7 @@
 import { ISubscriptionContext } from '@microsoft/vscode-azext-utils';
 import { Request } from 'node-fetch';
 import { URLSearchParams } from 'url';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { RequestOptionsLike, httpRequest } from './httpRequest';
 
 const refreshTokens: { [key: string]: string } = {};
@@ -14,7 +14,7 @@ const refreshTokens: { [key: string]: string } = {};
 function parseResourceId(id: string): RegExpMatchArray {
     const matches: RegExpMatchArray | null = id.match(/\/subscriptions\/(.*)\/resourceGroups\/(.*)\/providers\/(.*)\/(.*)/i);
     if (matches === null || matches.length < 3) {
-        throw new Error(localize('vscode-docker.utils.azure.invalidResourceId', 'Invalid Azure Resource Id'));
+        throw new Error(l10n.t('Invalid Azure Resource Id'));
     }
     return matches;
 }

--- a/src/utils/httpRequest.ts
+++ b/src/utils/httpRequest.ts
@@ -6,7 +6,7 @@
 import * as fse from 'fs-extra';
 import { Request, RequestInit, Response, default as fetch } from 'node-fetch';
 import { URL, URLSearchParams } from 'url';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 
 export const enum ErrorHandling {
     ThrowOnError,
@@ -87,7 +87,7 @@ export class HttpResponse<T> implements ResponseLike {
 
 export class HttpErrorResponse extends Error {
     public constructor(public readonly response: ResponseLike) {
-        super(localize('vscode-docker.utils.httpRequest', 'Request to {0} failed with status {1}: {2}', response.url, response.status, response.statusText));
+        super(l10n.t('Request to {0} failed with status {1}: {2}', response.url, response.status, response.statusText));
     }
 
     // This method lets parseError from @microsoft/vscode-azext-utils get the HTTP status code as the error code

--- a/src/utils/httpRequest.ts
+++ b/src/utils/httpRequest.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fse from 'fs-extra';
-import { Request, RequestInit, Response, default as fetch } from 'node-fetch';
+import { default as fetch, Request, RequestInit, Response } from 'node-fetch';
 import { URL, URLSearchParams } from 'url';
 import { l10n } from 'vscode';
 

--- a/src/utils/migrateOldEnvironmentSettingsIfNeeded.ts
+++ b/src/utils/migrateOldEnvironmentSettingsIfNeeded.ts
@@ -5,7 +5,7 @@
 
 import { DialogResponses } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { cloneObject } from './cloneObject';
 
 const oldSettingsMap = {
@@ -29,7 +29,7 @@ export async function migrateOldEnvironmentSettingsIfNeeded(): Promise<void> {
             // Prompt if we haven't already
             if (!alreadyPrompted) {
                 const response = await vscode.window.showWarningMessage(
-                    localize('vscode-docker.checkForOldEnvironmentSettings.prompt', 'Some of your Docker extension settings have been renamed. Would you like us to migrate them for you?'),
+                    l10n.t('Some of your Docker extension settings have been renamed. Would you like us to migrate them for you?'),
                     DialogResponses.yes,
                     DialogResponses.no
                 );

--- a/src/utils/migrateOldEnvironmentSettingsIfNeeded.ts
+++ b/src/utils/migrateOldEnvironmentSettingsIfNeeded.ts
@@ -5,7 +5,6 @@
 
 import { DialogResponses } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
-import { l10n } from 'vscode';
 import { cloneObject } from './cloneObject';
 
 const oldSettingsMap = {
@@ -29,7 +28,7 @@ export async function migrateOldEnvironmentSettingsIfNeeded(): Promise<void> {
             // Prompt if we haven't already
             if (!alreadyPrompted) {
                 const response = await vscode.window.showWarningMessage(
-                    l10n.t('Some of your Docker extension settings have been renamed. Would you like us to migrate them for you?'),
+                    vscode.l10n.t('Some of your Docker extension settings have been renamed. Would you like us to migrate them for you?'),
                     DialogResponses.yes,
                     DialogResponses.no
                 );

--- a/src/utils/netCoreUtils.ts
+++ b/src/utils/netCoreUtils.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { parseError } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { ext } from '../extensionVariables';
 import { l10n } from 'vscode';
-import { getTempFileName } from './osUtils';
+import { ext } from '../extensionVariables';
 import { execAsync } from './execAsync';
-import { parseError } from '@microsoft/vscode-azext-utils';
+import { getTempFileName } from './osUtils';
 
 export async function getNetCoreProjectInfo(target: 'GetBlazorManifestLocations' | 'GetProjectProperties', project: string): Promise<string[]> {
     const targetsFile = path.join(ext.context.asAbsolutePath('resources'), 'netCore', `${target}.targets`);

--- a/src/utils/netCoreUtils.ts
+++ b/src/utils/netCoreUtils.ts
@@ -6,7 +6,7 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { ext } from '../extensionVariables';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { getTempFileName } from './osUtils';
 import { execAsync } from './execAsync';
 import { parseError } from '@microsoft/vscode-azext-utils';
@@ -22,7 +22,7 @@ export async function getNetCoreProjectInfo(target: 'GetBlazorManifestLocations'
             await execAsync(command, { timeout: 20000 });
         } catch (err) {
             const error = parseError(err);
-            throw new Error(localize('vscode-docker.netCoreUtils.noProjectInfo', 'Unable to determine project information for target \'{0}\' on project \'{1}\' {2}', target, project, error.message));
+            throw new Error(l10n.t('Unable to determine project information for target \'{0}\' on project \'{1}\' {2}', target, project, error.message));
         }
 
 
@@ -34,7 +34,7 @@ export async function getNetCoreProjectInfo(target: 'GetBlazorManifestLocations'
             }
         }
 
-        throw new Error(localize('vscode-docker.netCoreUtils.noProjectInfo2', 'Unable to determine project information for target \'{0}\' on project \'{1}\'', target, project));
+        throw new Error(l10n.t('Unable to determine project information for target \'{0}\' on project \'{1}\'', target, project));
     } finally {
         if (await fse.pathExists(outputFile)) {
             await fse.unlink(outputFile);

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -5,7 +5,7 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 
 export interface NodePackage {
     main?: string;
@@ -52,5 +52,5 @@ export async function inferCommand(nodePackage: NodePackage | undefined, inspect
         }
     }
 
-    throw new Error(localize('vscode-docker.utils.node.noCommand', 'Unable to infer the command to run the application within the container. Set the \'dockerRun.command\' property and include the Node.js \'{0}\' argument.', inspectArgWithPort));
+    throw new Error(l10n.t('Unable to infer the command to run the application within the container. Set the \'dockerRun.command\' property and include the Node.js \'{0}\' argument.', inspectArgWithPort));
 }

--- a/src/utils/promiseUtils.ts
+++ b/src/utils/promiseUtils.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { l10n } from 'vscode';
+import * as vscode from 'vscode';
 
 export async function delay(ms: number, token?: vscode.CancellationToken): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -58,7 +57,7 @@ export class TimeoutPromiseSource implements vscode.Disposable {
     private readonly emitter: vscode.EventEmitter<void>;
 
     public constructor(private readonly timeoutMs: number) {
-        this.cps = new CancellationPromiseSource(Error, l10n.t('Request timed out.'));
+        this.cps = new CancellationPromiseSource(Error, vscode.l10n.t('Request timed out.'));
         this.emitter = new vscode.EventEmitter<void>();
     }
 

--- a/src/utils/promiseUtils.ts
+++ b/src/utils/promiseUtils.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 
 export async function delay(ms: number, token?: vscode.CancellationToken): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -58,7 +58,7 @@ export class TimeoutPromiseSource implements vscode.Disposable {
     private readonly emitter: vscode.EventEmitter<void>;
 
     public constructor(private readonly timeoutMs: number) {
-        this.cps = new CancellationPromiseSource(Error, localize('vscode-docker.utils.promiseUtils.timeout', 'Request timed out.'));
+        this.cps = new CancellationPromiseSource(Error, l10n.t('Request timed out.'));
         this.emitter = new vscode.EventEmitter<void>();
     }
 

--- a/src/utils/quickPickFile.ts
+++ b/src/utils/quickPickFile.ts
@@ -3,11 +3,10 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from "path";
 import * as vscode from 'vscode';
-import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
 import { COMPOSE_FILE_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, DOCKERFILE_GLOB_PATTERN, FILE_SEARCH_MAX_RESULT, FSPROJ_GLOB_PATTERN, YAML_GLOB_PATTERN } from "../constants";
-import { l10n } from 'vscode';
 
 export interface Item extends vscode.QuickPickItem {
     relativeFilePath: string;
@@ -97,10 +96,10 @@ export async function quickPickDockerFileItem(context: IActionContext, dockerFil
 
     while (!selectedDockerFile) {
         const dockerFiles: Item[] | undefined = await resolveFilesOfPattern(rootFolder, globPatterns);
-        const message = l10n.t('Choose a Dockerfile to build.');
+        const message = vscode.l10n.t('Choose a Dockerfile to build.');
         selectedDockerFile = await quickPickFileItem(context, dockerFiles, message);
         if (!selectedDockerFile) {
-            const msg = l10n.t('Couldn\'t find a Dockerfile in your workspace. Would you like to add Docker files to the workspace?');
+            const msg = vscode.l10n.t('Couldn\'t find a Dockerfile in your workspace. Would you like to add Docker files to the workspace?');
             await context.ui.showWarningMessage(msg, { stepName: msg }, DialogResponses.yes, DialogResponses.cancel);
             await vscode.commands.executeCommand('vscode-docker.configure');
             // Try again
@@ -125,7 +124,7 @@ export async function quickPickDockerComposeFileItem(context: IActionContext, ro
                 selectedComposeFile = await quickPickFileItem(context, composeFiles, message);
             }
         } else {
-            const msg = l10n.t('Couldn\'t find any docker-compose files in your workspace. Would you like to add Docker files to the workspace?');
+            const msg = vscode.l10n.t('Couldn\'t find any docker-compose files in your workspace. Would you like to add Docker files to the workspace?');
             await context.ui.showWarningMessage(msg, { stepName: msg }, DialogResponses.yes, DialogResponses.cancel);
             await vscode.commands.executeCommand('vscode-docker.configureCompose');
             // Try again
@@ -158,7 +157,7 @@ export async function quickPickYamlFileItem(context: IActionContext, fileUri: vs
     }
 
     const items: Item[] = await resolveFilesOfPattern(rootFolder, [YAML_GLOB_PATTERN]);
-    const fileItem: Item = await quickPickFileItem(context, items, l10n.t('Choose a .yaml file to run.'));
+    const fileItem: Item = await quickPickFileItem(context, items, vscode.l10n.t('Choose a .yaml file to run.'));
 
     if (!fileItem) {
         throw new Error(noYamlFileMessage);
@@ -172,7 +171,7 @@ export async function quickPickProjectFileItem(context: IActionContext, fileUri:
     }
 
     const items: Item[] = await resolveFilesOfPattern(rootFolder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
-    const fileItem: Item = await quickPickFileItem(context, items, l10n.t('Choose a project file.'));
+    const fileItem: Item = await quickPickFileItem(context, items, vscode.l10n.t('Choose a project file.'));
 
     if (!fileItem) {
         throw new Error(noProjectFileMessage);

--- a/src/utils/quickPickFile.ts
+++ b/src/utils/quickPickFile.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 import * as vscode from 'vscode';
 import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
 import { COMPOSE_FILE_GLOB_PATTERN, CSPROJ_GLOB_PATTERN, DOCKERFILE_GLOB_PATTERN, FILE_SEARCH_MAX_RESULT, FSPROJ_GLOB_PATTERN, YAML_GLOB_PATTERN } from "../constants";
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 
 export interface Item extends vscode.QuickPickItem {
     relativeFilePath: string;
@@ -97,10 +97,10 @@ export async function quickPickDockerFileItem(context: IActionContext, dockerFil
 
     while (!selectedDockerFile) {
         const dockerFiles: Item[] | undefined = await resolveFilesOfPattern(rootFolder, globPatterns);
-        const message = localize('vscode-docker.utils.quickPick.chooseDockerfile', 'Choose a Dockerfile to build.');
+        const message = l10n.t('Choose a Dockerfile to build.');
         selectedDockerFile = await quickPickFileItem(context, dockerFiles, message);
         if (!selectedDockerFile) {
-            const msg = localize('vscode-docker.utils.quickPick.noDockerfile', 'Couldn\'t find a Dockerfile in your workspace. Would you like to add Docker files to the workspace?');
+            const msg = l10n.t('Couldn\'t find a Dockerfile in your workspace. Would you like to add Docker files to the workspace?');
             await context.ui.showWarningMessage(msg, { stepName: msg }, DialogResponses.yes, DialogResponses.cancel);
             await vscode.commands.executeCommand('vscode-docker.configure');
             // Try again
@@ -125,7 +125,7 @@ export async function quickPickDockerComposeFileItem(context: IActionContext, ro
                 selectedComposeFile = await quickPickFileItem(context, composeFiles, message);
             }
         } else {
-            const msg = localize('vscode-docker.utils.quickPick.noComposefile', 'Couldn\'t find any docker-compose files in your workspace. Would you like to add Docker files to the workspace?');
+            const msg = l10n.t('Couldn\'t find any docker-compose files in your workspace. Would you like to add Docker files to the workspace?');
             await context.ui.showWarningMessage(msg, { stepName: msg }, DialogResponses.yes, DialogResponses.cancel);
             await vscode.commands.executeCommand('vscode-docker.configureCompose');
             // Try again
@@ -158,7 +158,7 @@ export async function quickPickYamlFileItem(context: IActionContext, fileUri: vs
     }
 
     const items: Item[] = await resolveFilesOfPattern(rootFolder, [YAML_GLOB_PATTERN]);
-    const fileItem: Item = await quickPickFileItem(context, items, localize('vscode-docker.utils.quickPick.chooseYaml', 'Choose a .yaml file to run.'));
+    const fileItem: Item = await quickPickFileItem(context, items, l10n.t('Choose a .yaml file to run.'));
 
     if (!fileItem) {
         throw new Error(noYamlFileMessage);
@@ -172,7 +172,7 @@ export async function quickPickProjectFileItem(context: IActionContext, fileUri:
     }
 
     const items: Item[] = await resolveFilesOfPattern(rootFolder, [CSPROJ_GLOB_PATTERN, FSPROJ_GLOB_PATTERN]);
-    const fileItem: Item = await quickPickFileItem(context, items, localize('vscode-docker.utils.quickPick.chooseProject', 'Choose a project file.'));
+    const fileItem: Item = await quickPickFileItem(context, items, l10n.t('Choose a project file.'));
 
     if (!fileItem) {
         throw new Error(noProjectFileMessage);

--- a/src/utils/quickPickWorkspaceFolder.ts
+++ b/src/utils/quickPickWorkspaceFolder.ts
@@ -3,9 +3,8 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { l10n } from 'vscode';
+import * as vscode from 'vscode';
 import { isMac } from './osUtils';
 
 export async function quickPickWorkspaceFolder(context: IActionContext, noWorkspacesMessage: string): Promise<vscode.WorkspaceFolder> {
@@ -29,7 +28,7 @@ export async function quickPickWorkspaceFolder(context: IActionContext, noWorksp
                         void vscode.commands.executeCommand('workbench.action.files.openFolder');
                     }
                 },
-                title: l10n.t('Open Folder'),
+                title: vscode.l10n.t('Open Folder'),
             }
         ];
         throw new Error(noWorkspacesMessage);

--- a/src/utils/quickPickWorkspaceFolder.ts
+++ b/src/utils/quickPickWorkspaceFolder.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { localize } from '../localize';
+import { l10n } from 'vscode';
 import { isMac } from './osUtils';
 
 export async function quickPickWorkspaceFolder(context: IActionContext, noWorkspacesMessage: string): Promise<vscode.WorkspaceFolder> {
@@ -29,7 +29,7 @@ export async function quickPickWorkspaceFolder(context: IActionContext, noWorksp
                         void vscode.commands.executeCommand('workbench.action.files.openFolder');
                     }
                 },
-                title: localize('vscode-docker.quickPickWorkspaceFolder.openFolder', 'Open Folder'),
+                title: l10n.t('Open Folder'),
             }
         ];
         throw new Error(noWorkspacesMessage);


### PR DESCRIPTION
This PR addresses issue #3693 

The changes replace `vscode-nls` with the vscode localization (`l10n`) API as introduced in https://code.visualstudio.com/updates/v1_72#_localization-as-part-of-the-api. 