### PR TITLE
Organize imports on save 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,8 @@
     "files.insertFinalNewline": true,
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll": true
+        "source.fixAll": true,
+        "source.organizeImports": true
     },
     "typescript.preferences.importModuleSpecifier": "relative",
     "files.associations": {


### PR DESCRIPTION
This one-line change in `settings.json` allows VSCode to automatically organize imports when you save a `.ts` file in the repository. 

This change came to me while completing this [API change](https://github.com/microsoft/vscode-docker/pull/3846), which required changes to import statements in over 100 files. Instead of running the command `TypeScript: Organize imports` every time I add a new import to a file, I can just save the file and have VSCode do its magic. I think this will ensure imports are organized every time someone edits a file, creates a file without having to remember to run the command. 