### PR TITLE
Actually stream logs and clean up format

### DIFF
--- a/src/commands/registries/azure/tasks/scheduleRunRequest.ts
+++ b/src/commands/registries/azure/tasks/scheduleRunRequest.ts
@@ -8,12 +8,12 @@ import { IActionContext, IAzureQuickPickItem, nonNullProp } from '@microsoft/vsc
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
+import * as readline from 'readline';
 import * as tar from 'tar';
 import * as vscode from 'vscode';
 import { ext } from '../../../../extensionVariables';
 import { AzureRegistryTreeItem } from '../../../../tree/registries/azure/AzureRegistryTreeItem';
 import { registryExpectedContextValues } from "../../../../tree/registries/registryContextValues";
-import { bufferToString } from "../../../../utils/execAsync";
 import { getStorageBlob } from '../../../../utils/lazyPackages';
 import { delay } from '../../../../utils/promiseUtils';
 import { Item, quickPickDockerFileItem, quickPickYamlFileItem } from '../../../../utils/quickPickFile';
@@ -169,27 +169,38 @@ async function streamLogs(context: IActionContext, node: AzureRegistryTreeItem, 
     await new Promise<void>((resolve, reject) => {
         const timer = setInterval(
             async () => {
-                if (!exists && !(exists = await blobClient.exists())) {
-                    totalChecks++;
-                    if (totalChecks >= maxBlobChecks) {
-                        clearInterval(timer);
-                        reject('Not found');
+                try {
+                    if (!exists && !(exists = await blobClient.exists())) {
+                        totalChecks++;
+                        if (totalChecks >= maxBlobChecks) {
+                            clearInterval(timer);
+                            reject('Not found');
+                        }
                     }
-                }
 
-                const contentBuffer = await blobClient.downloadToBuffer(byteOffset);
-                const properties = await blobClient.getProperties();
+                    const properties = await blobClient.getProperties();
+                    if (properties.contentLength > byteOffset) {
+                        // New data available
+                        const response = await blobClient.download(byteOffset);
+                        byteOffset += response.contentLength;
 
-                byteOffset += contentBuffer.length;
-                const content = bufferToString(contentBuffer);
+                        const lineReader = readline.createInterface(response.readableStreamBody);
+                        for await (const line of lineReader) {
+                            const sanitizedLine = line
+                                // eslint-disable-next-line no-control-regex
+                                .replace(/[\x00-\x09\x0B-\x0C\x0E-\x1F]/g, '') // Remove non-printing control characters
+                                .replace(/^\d{4}\/\d{2}\/\d{2}\s\d{2}:\d{2}:\d{2}\s/, ''); // Remove the redundant timestamps at the beginning of some lines. Their format is "YYYY/MM/DD HH:MM:SS"
+                            ext.outputChannel.info(sanitizedLine);
+                        }
+                    }
 
-                if (content) {
-                    ext.outputChannel.info(content);
-                }
-
-                if (properties?.metadata?.complete) {
+                    if (properties.metadata?.complete) {
+                        clearInterval(timer);
+                        resolve();
+                    }
+                } catch (err) {
                     clearInterval(timer);
-                    resolve();
+                    reject(err);
                 }
             },
             blobCheckInterval

--- a/src/commands/registries/azure/tasks/scheduleRunRequest.ts
+++ b/src/commands/registries/azure/tasks/scheduleRunRequest.ts
@@ -188,8 +188,7 @@ async function streamLogs(context: IActionContext, node: AzureRegistryTreeItem, 
                         for await (const line of lineReader) {
                             const sanitizedLine = line
                                 // eslint-disable-next-line no-control-regex
-                                .replace(/[\x00-\x09\x0B-\x0C\x0E-\x1F]/g, '') // Remove non-printing control characters
-                                .replace(/^\d{4}\/\d{2}\/\d{2}\s\d{2}:\d{2}:\d{2}\s/, ''); // Remove the redundant timestamps at the beginning of some lines. Their format is "YYYY/MM/DD HH:MM:SS"
+                                .replace(/[\x00-\x09\x0B-\x0C\x0E-\x1F]/g, ''); // Remove non-printing control characters
                             ext.outputChannel.info(sanitizedLine);
                         }
                     }


### PR DESCRIPTION
Fixes #3616.

This will do something more closely resembling actual streaming--rather than downloading the entire log file to a buffer every 1 second--and also breaks apart the lines to log them individually (so VSCode's attached timestamps appear on every line)~~, and also removes the redundant timestamps from the source log (which is less accurate but looks so much better)~~.

IMO the PR is easier to read with [whitespace off](https://github.com/microsoft/vscode-docker/pull/3858/files?w=1).