### PR TITLE
Added Ignore Size Fix 

### DIFF
--- a/src/runtimes/docker/clients/DockerClientBase/DockerClientBase.ts
+++ b/src/runtimes/docker/clients/DockerClientBase/DockerClientBase.ts
@@ -81,7 +81,7 @@ import {
     withFlagArg,
     withNamedArg,
     withQuotedArg,
-    withVerbatimArg,
+    withVerbatimArg
 } from "../../utils/commandLineBuilder";
 import { CommandNotSupportedError } from '../../utils/CommandNotSupportedError';
 import { dayjs } from '../../utils/dayjs';
@@ -107,6 +107,7 @@ import { withDockerAddHostArg } from './withDockerAddHostArg';
 import { withDockerBuildArg } from './withDockerBuildArg';
 import { withDockerEnvArg } from './withDockerEnvArg';
 import { withDockerBooleanFilterArg, withDockerFilterArg } from './withDockerFilterArg';
+import { withDockerIgnoreSizeArg } from './withDockerIgnoreSizeArg';
 import { withDockerJsonFormatArg } from "./withDockerJsonFormatArg";
 import { withDockerLabelFilterArgs } from "./withDockerLabelFilterArgs";
 import { withDockerLabelsArg } from "./withDockerLabelsArg";
@@ -757,6 +758,7 @@ export abstract class DockerClientBase extends ConfigurableClient implements ICo
             withDockerFilterArg(options.networks?.map((network) => `network=${network}`)),
             withDockerNoTruncArg,
             withDockerJsonFormatArg,
+            withDockerIgnoreSizeArg
         )();
     }
 

--- a/src/runtimes/docker/clients/DockerClientBase/withDockerIgnoreSizeArg.ts
+++ b/src/runtimes/docker/clients/DockerClientBase/withDockerIgnoreSizeArg.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { withNamedArg } from '../../utils/commandLineBuilder';
+
+export const withDockerIgnoreSizeArg = withNamedArg('--size','false', { assignValue: true, shouldQuote: false });

--- a/src/runtimes/docker/utils/commandLineBuilder.ts
+++ b/src/runtimes/docker/utils/commandLineBuilder.ts
@@ -99,7 +99,7 @@ export function withNamedArg(
                 if (arg) {
                     const normalizedArg = shouldQuote ? quoted(arg) : escaped(arg);
                     if (assignValue) {
-                        return withArg(`${name}=${normalizedArg}`)(allArgs);
+                        return withArg(`${name}=${normalizedArg?.value}`)(allArgs);
                     }
 
                     return withArg(name, normalizedArg)(allArgs);


### PR DESCRIPTION
This PR addresses issue #3779 by adding a `--size=false` flag to the `docker container ls ...` command. 