### PR TITLE
Update  npm to Latest in Node Dockerfile Template

### DIFF
--- a/resources/templates/node/Dockerfile.template
+++ b/resources/templates/node/Dockerfile.template
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 ENV NODE_ENV=production
 WORKDIR /usr/src/app
 COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
-RUN npm install --production --silent && mv node_modules ../
+RUN npm install -g npm@latest && npm install --production --silent && mv node_modules ../
 COPY . .
 {{#each ports}}
 EXPOSE {{ . }}


### PR DESCRIPTION
This PR addresses issue #3855 

As the issue stated, the version of `npm` in `node:lts-alpine` is 9.5.0., which could potentially cause some file ownership issues inside app services https://azureossd.github.io/2022/06/30/Docker-User-Namespace-remapping-issues/index.html. By running `npm install -g npm@latest`, npm gets updated to the latest version (as of now , 9.6.2), which does not cause the potential ownership issues. Also, I think it never hurts to have the latest `npm`. 