### PR TITLE
Add Docker Context to Status Bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1858,6 +1858,11 @@
                         "DockerEndpoint"
                     ]
                 },
+                "docker.contexts.showInStatusBar": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%vscode-docker.config.docker.contexts.showInStatusBar%"
+                },
                 "docker.images.groupBy": {
                     "type": "string",
                     "default": "Repository",

--- a/package.nls.json
+++ b/package.nls.json
@@ -159,7 +159,7 @@
     "vscode-docker.config.docker.containers.sortBy": "The property to use to sort containers in Docker view: CreatedTime or Label",
     "vscode-docker.config.docker.contexts.description": "Any secondary properties to display for a Docker context (an array). Possible elements include: Name, Description and DockerEndpoint",
     "vscode-docker.config.docker.contexts.label": "The primary property to display for a Docker context: Name, Description or DockerEndpoint",
-    "vscode-docker.config.docker.contexts.showInStatusBar": "Show Docker context in the status bar",
+    "vscode-docker.config.docker.contexts.showInStatusBar": "Show current Docker context in the status bar",
     "vscode-docker.config.docker.images.groupBy": "The property to use to group images in Docker view: CreatedTime, FullTag, ImageId, None, Registry, Repository, RepositoryName, RepositoryNameAndTag, or Tag",
     "vscode-docker.config.docker.images.description": "Any secondary properties to display for a image (an array). Possible elements include: CreatedTime, FullTag, ImageId, Registry, Repository, RepositoryName, RepositoryNameAndTag, Tag, and Size",
     "vscode-docker.config.docker.images.label": "The primary property to display for a image: CreatedTime, FullTag, ImageId, Registry, Repository, RepositoryName, RepositoryNameAndTag, Tag, or Size",

--- a/package.nls.json
+++ b/package.nls.json
@@ -159,6 +159,7 @@
     "vscode-docker.config.docker.containers.sortBy": "The property to use to sort containers in Docker view: CreatedTime or Label",
     "vscode-docker.config.docker.contexts.description": "Any secondary properties to display for a Docker context (an array). Possible elements include: Name, Description and DockerEndpoint",
     "vscode-docker.config.docker.contexts.label": "The primary property to display for a Docker context: Name, Description or DockerEndpoint",
+    "vscode-docker.config.docker.contexts.showInStatusBar": "Show Docker context in the status bar",
     "vscode-docker.config.docker.images.groupBy": "The property to use to group images in Docker view: CreatedTime, FullTag, ImageId, None, Registry, Repository, RepositoryName, RepositoryNameAndTag, or Tag",
     "vscode-docker.config.docker.images.description": "Any secondary properties to display for a image (an array). Possible elements include: CreatedTime, FullTag, ImageId, Registry, Repository, RepositoryName, RepositoryNameAndTag, Tag, and Size",
     "vscode-docker.config.docker.images.label": "The primary property to display for a image: CreatedTime, FullTag, ImageId, Registry, Repository, RepositoryName, RepositoryNameAndTag, Tag, or Size",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import { AzureAccountExtensionListener } from './utils/AzureAccountExtensionList
 import { logDockerEnvironment, logSystemInfo } from './utils/diagnostics';
 import { DocumentSettingsClientFeature } from './utils/DocumentSettingsClientFeature';
 import { migrateOldEnvironmentSettingsIfNeeded } from './utils/migrateOldEnvironmentSettingsIfNeeded';
-import { registerDockerContextStatusBarEvent, registerDockerContextStatusBarItems } from './utils/registerDockerContextStatusBarItems';
+import { registerDockerContextStatusBarEvent } from './utils/registerDockerContextStatusBarItems';
 
 export type KeyInfo = { [keyName: string]: string };
 
@@ -120,7 +120,6 @@ export async function activateInternal(ctx: vscode.ExtensionContext, perfStats: 
         registerCommands();
 
         // Set up docker context status bar items
-        void registerDockerContextStatusBarItems(ctx);
         registerDockerContextStatusBarEvent(ctx);
 
         registerDebugProvider(ctx);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,7 +202,6 @@ function registerDockerClients(): void {
         }
 
         if (e.affectsConfiguration('docker.contexts.showInStatusBar')) {
-            dockerContextStatusBarItem.dispose();
             // Don't wait
             void registerContextStatusBarItems(ext.context);
         }
@@ -216,6 +215,7 @@ async function registerContextStatusBarItems({ subscriptions }: vscode.Extension
     // if it's undefined, it means there is no context set, so we don't need to show the status bar item
     // if user don't want context to clutter up status bar, we don't need to show
     if (!currentContext || !showInStatusBar) {
+        dockerContextStatusBarItem?.dispose();
         return;
     }
 

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -4,8 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtTreeDataProvider, AzExtTreeItem, IExperimentationServiceAdapter } from '@microsoft/vscode-azext-utils';
-import { ExtensionContext, TreeView } from 'vscode';
+import { ExtensionContext, StatusBarItem, TreeView } from 'vscode';
 import { ContainerRuntimeManager } from './runtimes/ContainerRuntimeManager';
+import { OrchestratorRuntimeManager } from './runtimes/OrchestratorRuntimeManager';
+import { runWithDefaults as runWithDefaultsImpl, streamWithDefaults as streamWithDefaultsImpl } from './runtimes/runners/runWithDefaults';
 import { IActivityMeasurementService } from './telemetry/ActivityMeasurementService';
 import { ContainersTreeItem } from './tree/containers/ContainersTreeItem';
 import { ContextsTreeItem } from './tree/contexts/ContextsTreeItem';
@@ -13,8 +15,6 @@ import { ImagesTreeItem } from './tree/images/ImagesTreeItem';
 import { NetworksTreeItem } from './tree/networks/NetworksTreeItem';
 import { RegistriesTreeItem } from './tree/registries/RegistriesTreeItem';
 import { VolumesTreeItem } from './tree/volumes/VolumesTreeItem';
-import { OrchestratorRuntimeManager } from './runtimes/OrchestratorRuntimeManager';
-import { runWithDefaults as runWithDefaultsImpl, streamWithDefaults as streamWithDefaultsImpl } from './runtimes/runners/runWithDefaults';
 import { AzExtLogOutputChannelWrapper } from './utils/AzExtLogOutputChannelWrapper';
 
 /**
@@ -62,4 +62,6 @@ export namespace ext {
     export let orchestratorManager: OrchestratorRuntimeManager;
     export const runWithDefaults = runWithDefaultsImpl;
     export const streamWithDefaults = streamWithDefaultsImpl;
+
+    export let dockerContextStatusBarItem: StatusBarItem;
 }

--- a/src/utils/registerDockerContextStatusBarItems.ts
+++ b/src/utils/registerDockerContextStatusBarItems.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext, registerEvent } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+import { ext } from "../extensionVariables";
+
+const dockerContextStatusBarSetting: string = 'contexts.showInStatusBar';
+
+export function registerDockerContextStatusBarEvent(ctx: vscode.ExtensionContext): void {
+    // Register an event to watch for changes to config, reconfigure if needed
+    registerEvent('docker.command.changed', vscode.workspace.onDidChangeConfiguration, (actionContext: IActionContext, e: vscode.ConfigurationChangeEvent) => {
+
+        actionContext.telemetry.suppressAll = true;
+        actionContext.errorHandling.suppressDisplay = true;
+
+        if (e.affectsConfiguration('docker.contexts.showInStatusBar')) {
+            // Don't wait
+            void registerDockerContextStatusBarItems(ctx);
+        }
+    });
+}
+
+export async function registerDockerContextStatusBarItems({ subscriptions }: vscode.ExtensionContext): Promise<void> {
+    const currentDockerContext = await ext.runtimeManager.contextManager.getCurrentContext();
+    const showInStatusBar = vscode.workspace.getConfiguration('docker').get(dockerContextStatusBarSetting, true);
+
+    // if it's undefined, it means there is no context set, so we don't need to show the status bar item
+    // if user don't want context to clutter up status bar, we don't need to show
+    // if dockerContextStatusBarItem is created, then we dispose
+    if (!currentDockerContext || !showInStatusBar) {
+        ext.dockerContextStatusBarItem?.dispose();
+        return;
+    }
+
+    const dockerContextUseCommand = 'vscode-docker.contexts.use';
+
+    // Register the status bar item for the current context
+    ext.dockerContextStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 20);
+    ext.dockerContextStatusBarItem.command = dockerContextUseCommand;
+    ext.dockerContextStatusBarItem.name = vscode.l10n.t('Docker Contexts');
+
+    async function updateStatusBar() {
+        const currentContextName = `Context: ${currentDockerContext.name}`;
+        ext.dockerContextStatusBarItem.text = currentContextName;
+        ext.dockerContextStatusBarItem.tooltip = vscode.l10n.t('Change Docker Context');
+        ext.dockerContextStatusBarItem.show();
+    }
+
+    subscriptions.push(
+        ext.dockerContextStatusBarItem,
+        vscode.workspace.onDidChangeConfiguration(updateStatusBar),
+        ext.runtimeManager.contextManager.onContextChanged(updateStatusBar)
+    );
+
+    // Don't wait
+    void updateStatusBar();
+}

--- a/src/utils/registerDockerContextStatusBarItems.ts
+++ b/src/utils/registerDockerContextStatusBarItems.ts
@@ -27,29 +27,31 @@ export function registerDockerContextStatusBarEvent(ctx: vscode.ExtensionContext
         ext.dockerContextStatusBarItem,
         ext.runtimeManager.contextManager.onContextChanged(registerDockerContextStatusBarItems)
     );
+
+    void registerDockerContextStatusBarItems();
 }
 
 export async function registerDockerContextStatusBarItems() {
 
     const config = vscode.workspace.getConfiguration('docker');
     let currentDockerContext: ListContextItem | undefined;
-    ext.dockerContextStatusBarItem?.dispose();
 
-    // if dockerContextStatusBarItem is created, then we dispose
     if (!config.get(dockerContextStatusBarSetting, false) ||
         !(currentDockerContext = await ext.runtimeManager.contextManager.getCurrentContext())) { // Intentional assignment and boolean check
+        ext.dockerContextStatusBarItem?.dispose();
         return;
     }
 
     const dockerContextUseCommand = 'vscode-docker.contexts.use';
-    const currentContextName = `Context: ${currentDockerContext.name}`;
-    currentDockerContext = await ext.runtimeManager.contextManager.getCurrentContext();
+
+    // if dockerContextStatusBarItem is created, then we dispose
+    ext.dockerContextStatusBarItem?.dispose();
 
     // Register the status bar item for the current context
     ext.dockerContextStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 20);
     ext.dockerContextStatusBarItem.command = dockerContextUseCommand;
     ext.dockerContextStatusBarItem.name = vscode.l10n.t('Docker Contexts');
-    ext.dockerContextStatusBarItem.text = currentContextName;
+    ext.dockerContextStatusBarItem.text = currentDockerContext.name;
     ext.dockerContextStatusBarItem.tooltip = vscode.l10n.t('Change Docker Context');
     ext.dockerContextStatusBarItem.show();
 }

--- a/src/utils/registerDockerContextStatusBarItems.ts
+++ b/src/utils/registerDockerContextStatusBarItems.ts
@@ -32,7 +32,7 @@ export function registerDockerContextStatusBarEvent(ctx: vscode.ExtensionContext
     void scheduleUpdateStatusBar();
 }
 
-export async function showStatusBarItemIfNeeded() {
+async function showStatusBarItemIfNeeded() {
 
     const config = vscode.workspace.getConfiguration('docker');
     let currentDockerContext: ListContextItem | undefined;

--- a/src/utils/registerDockerContextStatusBarItems.ts
+++ b/src/utils/registerDockerContextStatusBarItems.ts
@@ -12,7 +12,7 @@ const dockerContextStatusBarSetting = 'contexts.showInStatusBar';
 
 export function registerDockerContextStatusBarEvent(ctx: vscode.ExtensionContext): void {
     // Register an event to watch for changes to config, reconfigure if needed
-    registerEvent('docker.command.changed', vscode.workspace.onDidChangeConfiguration, (actionContext: IActionContext, e: vscode.ConfigurationChangeEvent) => {
+    registerEvent('docker.context.showInStatusBar.changed', vscode.workspace.onDidChangeConfiguration, (actionContext: IActionContext, e: vscode.ConfigurationChangeEvent) => {
 
         actionContext.telemetry.suppressAll = true;
         actionContext.errorHandling.suppressDisplay = true;


### PR DESCRIPTION
This PR closes issue #3690 by adding an option to display the current Docker context in VSCode's status bar. 