### PR TITLE
Changed scaffolding for .NET 8 Windows Images

### DIFF
--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -60,10 +60,16 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             wizardContext.netCoreRuntimeBaseImage = wizardContext.platform === '.NET: ASP.NET Core' ? `${aspNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}` : `${consoleNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}`;
             wizardContext.netCoreSdkBaseImage = `${netSdkImage}:${netCoreVersion.major}.${netCoreVersion.minor}`;
 
-            // append '-preview' at the end of version string to support new .NET 8 preview release naming
             if (netCoreVersion.major === 8) {
-                wizardContext.netCoreRuntimeBaseImage = `${wizardContext.netCoreRuntimeBaseImage}-preview`;
-                wizardContext.netCoreSdkBaseImage = `${wizardContext.netCoreSdkBaseImage}-preview`;
+                if (wizardContext.netCorePlatformOS === 'Windows') {
+                    // append '-preview-nanoserver-ltsc2022' for windows base images for .NET 8's new naming convention
+                    wizardContext.netCoreRuntimeBaseImage = `${wizardContext.netCoreRuntimeBaseImage}-preview-nanoserver-ltsc2022`;
+                    wizardContext.netCoreSdkBaseImage = `${wizardContext.netCoreSdkBaseImage}-preview-nanoserver-ltsc2022`;
+                } else {
+                    // append '-preview' for everything else
+                    wizardContext.netCoreRuntimeBaseImage = `${wizardContext.netCoreRuntimeBaseImage}-preview`;
+                    wizardContext.netCoreSdkBaseImage = `${wizardContext.netCoreSdkBaseImage}-preview`;
+                }
             }
 
             // change default user to adapt to Debian 12


### PR DESCRIPTION
This PR closes issue #3878 by conforming to the new image naming convention documented in https://github.com/dotnet/dotnet-docker/issues/4492, https://hub.docker.com/_/microsoft-dotnet-nightly-sdk/, and https://hub.docker.com/_/microsoft-dotnet-nightly-aspnet/