### PR TITLE
Fixed .NET Debugging with Docker Compose 

### DIFF
--- a/resources/templates/netCore/Dockerfile.template
+++ b/resources/templates/netCore/Dockerfile.template
@@ -30,11 +30,11 @@ COPY ["{{ workspaceRelative . artifact }}", "{{ dirname (workspaceRelative . art
 RUN dotnet restore "{{ workspaceRelative . artifact netCorePlatformOS }}"
 COPY . .
 WORKDIR "/src/{{ dirname (workspaceRelative . artifact 'Linux') 'Linux' }}"
-RUN dotnet build "{{ basename artifact }}" -c Release -o /app/build
+RUN dotnet build "{{ basename artifact }}" -c $configuration -o /app/build
 
 FROM build AS publish
 ARG configuration=Release
-RUN dotnet publish "{{ basename artifact }}" -c Release -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "{{ basename artifact }}" -c $configuration -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
 WORKDIR /app

--- a/resources/templates/netCore/Dockerfile.template
+++ b/resources/templates/netCore/Dockerfile.template
@@ -24,6 +24,7 @@ USER appuser
 {{/if}}
 {{/unless}}
 FROM {{ netCoreSdkBaseImage }} AS build
+ARG configuration=Release
 WORKDIR /src
 COPY ["{{ workspaceRelative . artifact }}", "{{ dirname (workspaceRelative . artifact) }}/"]
 RUN dotnet restore "{{ workspaceRelative . artifact netCorePlatformOS }}"
@@ -32,6 +33,7 @@ WORKDIR "/src/{{ dirname (workspaceRelative . artifact 'Linux') 'Linux' }}"
 RUN dotnet build "{{ basename artifact }}" -c Release -o /app/build
 
 FROM build AS publish
+ARG configuration=Release
 RUN dotnet publish "{{ basename artifact }}" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final

--- a/resources/templates/netCore/docker-compose.debug.yml.template
+++ b/resources/templates/netCore/docker-compose.debug.yml.template
@@ -10,6 +10,8 @@ services:
     build:
       context: {{ workspaceRelative . dockerBuildContext }}
       dockerfile: {{ contextRelative . dockerfileDirectory }}/Dockerfile
+      args:
+        - configuration=Debug
 {{#if ports}}
     ports:
 {{#each ports}}


### PR DESCRIPTION
Closes #3912 

Configuration is set to `Release` by default, but is overwritten to `Debug` when debugging

Tested:
- [x] Hit breakpoint with Docker compose debug after running `curl`
- [x] Not hit breakpoint with standard Docker compose after running `curl`