### PR TITLE
Add back `onLanguage:dockerfile` activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "onDebugInitialConfigurations",
         "onDebugResolve:docker",
         "onFileSystem:docker",
+        "onLanguage:dockerfile",
         "onLanguage:dockercompose"
     ],
     "main": "main",


### PR DESCRIPTION
Previously we rely on the inferred activation event for `dockerfile`, but https://github.com/microsoft/vscode/pull/179287 breaks this behavior for us.

This PR adds back the `onLanguage:dockerfile` activation event in package.json.

Fixes https://github.com/microsoft/vscode-docker/issues/3899