### PR TITLE
Revert back to normal ARM auth package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.25.5-alpha",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@azure/arm-authorization-profile-2020-09-01-hybrid": "^2.1.0",
+                "@azure/arm-authorization": "^9.0.0",
                 "@azure/arm-containerregistry": "^10.1.0",
                 "@azure/storage-blob": "^12.14.0",
                 "@microsoft/compose-language-service": "^0.1.3",
@@ -103,13 +103,13 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@azure/arm-authorization-profile-2020-09-01-hybrid": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-authorization-profile-2020-09-01-hybrid/-/arm-authorization-profile-2020-09-01-hybrid-2.1.0.tgz",
-            "integrity": "sha512-uOXhcj6Dv+TB8Yn2fguQQhoBZhafTf0ir5/QIZ8C7Rb2vS0nLcnoeesWRj9jmS0SerE7y2AF3qEhrowEZotX1Q==",
+        "node_modules/@azure/arm-authorization": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-authorization/-/arm-authorization-9.0.0.tgz",
+            "integrity": "sha512-GdiCA8IA1gO+qcCbFEPj+iLC4+3ByjfKzmeAnkP7MdlL84Yo30Huo/EwbZzwRjYybXYUBuFxGPBB+yeTT4Ebxg==",
             "dependencies": {
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.6.1",
+                "@azure/core-client": "^1.7.0",
                 "@azure/core-paging": "^1.2.0",
                 "@azure/core-rest-pipeline": "^1.8.0",
                 "tslib": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -2950,7 +2950,7 @@
         "webpack-cli": "^5.0.1"
     },
     "dependencies": {
-        "@azure/arm-authorization-profile-2020-09-01-hybrid": "^2.1.0",
+        "@azure/arm-authorization": "^9.0.0",
         "@azure/arm-containerregistry": "^10.1.0",
         "@azure/storage-blob": "^12.14.0",
         "@microsoft/compose-language-service": "^0.1.3",

--- a/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
+++ b/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
@@ -66,6 +66,7 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
         await authClient.roleAssignments.create(registry.id, randomUUID(), {
             principalId: siteInfo.identity.principalId,
             roleDefinitionId: acrPullRoleDefinition.id,
+            principalType: 'ServicePrincipal',
         });
 
         // 5. Set the web app to use the desired ACR image, which was not done in DockerSiteCreateStep. Get the config and then update it.

--- a/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
+++ b/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
@@ -64,10 +64,8 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
 
         // 4. On the registry, assign the AcrPull role to the principal representing the website
         await authClient.roleAssignments.create(registry.id, randomUUID(), {
-            properties: {
-                principalId: siteInfo.identity.principalId,
-                roleDefinitionId: acrPullRoleDefinition.id,
-            }
+            principalId: siteInfo.identity.principalId,
+            roleDefinitionId: acrPullRoleDefinition.id,
         });
 
         // 5. Set the web app to use the desired ACR image, which was not done in DockerSiteCreateStep. Get the config and then update it.

--- a/src/utils/lazyPackages.ts
+++ b/src/utils/lazyPackages.ts
@@ -5,9 +5,8 @@
 
 import { ext } from '../extensionVariables';
 
-// Switch back to `@azure/arm-authorization` when https://github.com/Azure/azure-sdk-for-js/issues/21210 is fixed
-export async function getArmAuth(): Promise<typeof import('@azure/arm-authorization-profile-2020-09-01-hybrid')> {
-    return await import('@azure/arm-authorization-profile-2020-09-01-hybrid');
+export async function getArmAuth(): Promise<typeof import('@azure/arm-authorization')> {
+    return await import('@azure/arm-authorization');
 }
 
 export async function getArmContainerRegistry(): Promise<typeof import('@azure/arm-containerregistry')> {


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-js/issues/21210 has been fixed. Version 9.0.0 of `@azure/arm-authorization` has been released and has the fix we needed. Reverts part of #3910. Tested appsvc deploy and it works as expected.