### PR TITLE
Update Dockerfile language server to 0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@microsoft/vscode-azext-azureutils": "^1.1.5",
                 "@microsoft/vscode-azext-utils": "^1.2.2",
                 "dayjs": "^1.11.7",
-                "dockerfile-language-server-nodejs": "^0.10.0",
+                "dockerfile-language-server-nodejs": "^0.10.1",
                 "fs-extra": "^11.1.1",
                 "gradle-to-js": "^2.0.1",
                 "handlebars": "^4.7.7",
@@ -2366,9 +2366,9 @@
             "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
         },
         "node_modules/dockerfile-ast": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.4.2.tgz",
-            "integrity": "sha512-k770mVWaCm3KbyOSPFizP6WB2ucZjfAv8aun4UsKl+IivowK7ItwBixNbziBjN05yNpvCL1/IxBdZiSz6KQIvA==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.5.0.tgz",
+            "integrity": "sha512-YsRrWww6mKRS1HK32gbherPlgfvwS593ZeDegb5glNCBJgByICAYZCP5F+njY6TSB0eiPdFgCU9RkuO516mLFQ==",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
@@ -2378,11 +2378,11 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.10.0.tgz",
-            "integrity": "sha512-PlEXMna7q8DorZxKTLnzbYl0SidbppXeeuA0l4xDLO5UdimPIgXCQghcLBbBM97fduxQmzbRsH9Z+C68AZf5SA==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.10.1.tgz",
+            "integrity": "sha512-oTNjPAS1ty0Df/UNA2eglHQ/TH0qb/IwF8EGwgHim+zUbf3UIM9Yv/A3I0FtYZ1KPFDU81kjYA+1jqrdgjHCog==",
             "dependencies": {
-                "dockerfile-language-service": "0.10.0",
+                "dockerfile-language-service": "0.10.1",
                 "dockerfile-utils": "0.11.0",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
@@ -2394,11 +2394,11 @@
             }
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.10.0.tgz",
-            "integrity": "sha512-1EfLBQViRSzRFFet8co2r3CVudniKPbDB/Q595RUouewUs6UKpe4pdzrTuXIc4TzIGdRXUnBZCZdiN0T9fl+8w==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.10.1.tgz",
+            "integrity": "sha512-nGpqz+N2x1cFYMASlk3cnB+G+01yIhVAPkXFjmiRLoWSOpiKbFdKFi9ER0/EvZBTeyrTZ7a5W/sK/oUBM1J4Jg==",
             "dependencies": {
-                "dockerfile-ast": "0.4.2",
+                "dockerfile-ast": "0.5.0",
                 "dockerfile-utils": "0.11.0",
                 "vscode-languageserver-types": "3.17.0-next.3"
             },
@@ -2417,18 +2417,6 @@
             },
             "bin": {
                 "dockerfile-utils": "bin/dockerfile-utils"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/dockerfile-utils/node_modules/dockerfile-ast": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.5.0.tgz",
-            "integrity": "sha512-YsRrWww6mKRS1HK32gbherPlgfvwS593ZeDegb5glNCBJgByICAYZCP5F+njY6TSB0eiPdFgCU9RkuO516mLFQ==",
-            "dependencies": {
-                "vscode-languageserver-textdocument": "^1.0.1",
-                "vscode-languageserver-types": "^3.17.0-next.3"
             },
             "engines": {
                 "node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@microsoft/vscode-azext-azureutils": "^1.1.5",
                 "@microsoft/vscode-azext-utils": "^1.2.2",
                 "dayjs": "^1.11.7",
-                "dockerfile-language-server-nodejs": "^0.10.1",
+                "dockerfile-language-server-nodejs": "^0.10.2",
                 "fs-extra": "^11.1.1",
                 "gradle-to-js": "^2.0.1",
                 "handlebars": "^4.7.7",
@@ -2378,11 +2378,11 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.10.1.tgz",
-            "integrity": "sha512-oTNjPAS1ty0Df/UNA2eglHQ/TH0qb/IwF8EGwgHim+zUbf3UIM9Yv/A3I0FtYZ1KPFDU81kjYA+1jqrdgjHCog==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.10.2.tgz",
+            "integrity": "sha512-vLbaeYv4h3XEzrZ9JOhP6bD1eLzbzGzFFF03F3Ofd6kh9PU2aGBS/LVjd/w1omCyNV2LHviFX0ZGHINmWsZYyw==",
             "dependencies": {
-                "dockerfile-language-service": "0.10.1",
+                "dockerfile-language-service": "0.10.2",
                 "dockerfile-utils": "0.11.0",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
@@ -2394,9 +2394,9 @@
             }
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.10.1.tgz",
-            "integrity": "sha512-nGpqz+N2x1cFYMASlk3cnB+G+01yIhVAPkXFjmiRLoWSOpiKbFdKFi9ER0/EvZBTeyrTZ7a5W/sK/oUBM1J4Jg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.10.2.tgz",
+            "integrity": "sha512-W561U9gj5Eol55j/hanLRPVarXDq+WXPai1lG5f1fW7/kYElsmWJZoRd585SQBahvC9VlJfFAs6IpzZlvN41Hg==",
             "dependencies": {
                 "dockerfile-ast": "0.5.0",
                 "dockerfile-utils": "0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@microsoft/vscode-azext-azureutils": "^1.1.5",
                 "@microsoft/vscode-azext-utils": "^1.2.2",
                 "dayjs": "^1.11.7",
-                "dockerfile-language-server-nodejs": "^0.9.0",
+                "dockerfile-language-server-nodejs": "^0.10.0",
                 "fs-extra": "^11.1.1",
                 "gradle-to-js": "^2.0.1",
                 "handlebars": "^4.7.7",
@@ -2378,12 +2378,12 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.9.0.tgz",
-            "integrity": "sha512-QPWcUxbbNTaWaRQrJKUBmCXI6iE8l7f81bCVaZizCIkVg4py/4o2mho+AKlLUsZcCml5ss8MkJ257SFV2BZWCg==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.10.0.tgz",
+            "integrity": "sha512-PlEXMna7q8DorZxKTLnzbYl0SidbppXeeuA0l4xDLO5UdimPIgXCQghcLBbBM97fduxQmzbRsH9Z+C68AZf5SA==",
             "dependencies": {
-                "dockerfile-language-service": "0.9.0",
-                "dockerfile-utils": "0.10.0",
+                "dockerfile-language-service": "0.10.0",
+                "dockerfile-utils": "0.11.0",
                 "vscode-languageserver": "^8.0.0-next.2"
             },
             "bin": {
@@ -2394,12 +2394,12 @@
             }
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.9.0.tgz",
-            "integrity": "sha512-sDUkTR4LUimEAWXDIbUTEx2CytCBlx+XlJkg4B2Ptvak9HkwPD4JpXesaWxXPpp6YHCzxqwsTDY7Gf79ic340g==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.10.0.tgz",
+            "integrity": "sha512-1EfLBQViRSzRFFet8co2r3CVudniKPbDB/Q595RUouewUs6UKpe4pdzrTuXIc4TzIGdRXUnBZCZdiN0T9fl+8w==",
             "dependencies": {
                 "dockerfile-ast": "0.4.2",
-                "dockerfile-utils": "0.10.0",
+                "dockerfile-utils": "0.11.0",
                 "vscode-languageserver-types": "3.17.0-next.3"
             },
             "engines": {
@@ -2407,16 +2407,28 @@
             }
         },
         "node_modules/dockerfile-utils": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.10.0.tgz",
-            "integrity": "sha512-gnEhxITHpOXNXdlwJgJEq3xnJokm0IZOmrmHlJv8zCB2EDsgZWwdYWuktMMslIywK2YT22gxgZEoFjtEaJqzhQ==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.11.0.tgz",
+            "integrity": "sha512-b7uGmYAeneg/zP63vfUrkIWw4frvtviXe7QGV0Vw58kJwyEYmrKxjm+N+NbBgk6mwq5FEIDT5rx08pBpjstpEw==",
             "dependencies": {
-                "dockerfile-ast": "0.4.2",
+                "dockerfile-ast": "0.5.0",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "^3.17.0-next.3"
             },
             "bin": {
                 "dockerfile-utils": "bin/dockerfile-utils"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/dockerfile-utils/node_modules/dockerfile-ast": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.5.0.tgz",
+            "integrity": "sha512-YsRrWww6mKRS1HK32gbherPlgfvwS593ZeDegb5glNCBJgByICAYZCP5F+njY6TSB0eiPdFgCU9RkuO516mLFQ==",
+            "dependencies": {
+                "vscode-languageserver-textdocument": "^1.0.1",
+                "vscode-languageserver-types": "^3.17.0-next.3"
             },
             "engines": {
                 "node": "*"

--- a/package.json
+++ b/package.json
@@ -2994,7 +2994,7 @@
         "@microsoft/vscode-azext-azureutils": "^1.1.5",
         "@microsoft/vscode-azext-utils": "^1.2.2",
         "dayjs": "^1.11.7",
-        "dockerfile-language-server-nodejs": "^0.10.0",
+        "dockerfile-language-server-nodejs": "^0.10.1",
         "fs-extra": "^11.1.1",
         "gradle-to-js": "^2.0.1",
         "handlebars": "^4.7.7",

--- a/package.json
+++ b/package.json
@@ -2994,7 +2994,7 @@
         "@microsoft/vscode-azext-azureutils": "^1.1.5",
         "@microsoft/vscode-azext-utils": "^1.2.2",
         "dayjs": "^1.11.7",
-        "dockerfile-language-server-nodejs": "^0.9.0",
+        "dockerfile-language-server-nodejs": "^0.10.0",
         "fs-extra": "^11.1.1",
         "gradle-to-js": "^2.0.1",
         "handlebars": "^4.7.7",

--- a/package.json
+++ b/package.json
@@ -2994,7 +2994,7 @@
         "@microsoft/vscode-azext-azureutils": "^1.1.5",
         "@microsoft/vscode-azext-utils": "^1.2.2",
         "dayjs": "^1.11.7",
-        "dockerfile-language-server-nodejs": "^0.10.1",
+        "dockerfile-language-server-nodejs": "^0.10.2",
         "fs-extra": "^11.1.1",
         "gradle-to-js": "^2.0.1",
         "handlebars": "^4.7.7",


### PR DESCRIPTION
First of all, apologies to everyone for having just disappeared into thin air and also thank you to everyone for your continued bug reports (even if I did not respond to them until now...) as it helps me identify things to fix to make everyone's Dockerfile editing experience a little better. I can't promise any turnaround times but I hope to be more responsive than I have been in the last year or so after seemingly dropping off the face of the earth. :P

---

This update adds heredoc support for `COPY` so that it does not try to format it or lint it for Dockerfile-specific errors. The update also includes a fix caused by quotes in comments that can cause the semantic highlighter to get into an infinite loop.

This should fix the following issues:
- #3576
- #3836
- #3950

This does *not* fix https://github.com/microsoft/vscode-docker/issues/3576#issuecomment-1437199184. I need to wrap my head around that one and I would suggest creating a separate issue about that.

The following file should trigger the above three problems so it can be verified on the current build. With the fix, you should:
1. not be spammed by the "Request textDocument/semanticTokens/full failed." error whenever you try to type anything in the file
2. formatting should indent `/folder` in the second `COPY` but ignore the first `COPY`
3. as noted in the file, line 11 should not get flagged by a false positive
```Dockerfile
FROM ubuntu 

RUN echo "hi there" &\
# Let's add a comment with a markdown link [here](https://www.google.com) hope nothing breaks...
echo "oops I broke something and I'm getting a lot of popup messages"

# there should not be an empty continuation line error on line 11
COPY <<EOF /bar/foo
a
b

c
EOF

COPY a b \
/folder/
```