### PR TITLE
Use image name property supported by .NET preview 5 

### DIFF
--- a/src/tasks/netSdk/netSdkTaskUtils.ts
+++ b/src/tasks/netSdk/netSdkTaskUtils.ts
@@ -43,7 +43,7 @@ export async function getNetSdkBuildCommand(isProjectWebApp: boolean, projectFol
         withNamedArg('--arch', await normalizeArchitectureToRidArchitecture()),
         withArg(publishFlag),
         withNamedArg('--configuration', configuration),
-        withNamedArg('-p:ContainerRepository', getValidImageName(projectFolderName), { assignValue: true }),
+        withNamedArg('-p:ContainerImageName', getValidImageName(projectFolderName), { assignValue: true }),
         withNamedArg('-p:ContainerImageTag', NetSdkDefaultImageTag, { assignValue: true })
     )();
 


### PR DESCRIPTION
I'm going to use `ContainerImageName` instead of `ContainerRepository` since `ContainerRepository` is not in .NET preview 5 yet. 