### PR TITLE
Added Discoveribility .NET SDK Build feature 

### DIFF
--- a/package.json
+++ b/package.json
@@ -643,7 +643,9 @@
                 "languages": [
                     "csharp",
                     "razor",
-                    "aspnetcorerazor"
+                    "aspnetcorerazor",
+                    "vb",
+                    "fsharp"
                 ],
                 "configurationAttributes": {
                     "launch": {

--- a/src/debugging/netSdk/NetSdkDebugHelper.ts
+++ b/src/debugging/netSdk/NetSdkDebugHelper.ts
@@ -37,7 +37,7 @@ export class NetSdkDebugHelper extends NetCoreDebugHelper {
         };
 
         await netContainerBuild(netCoreBuildContext); // prompt user whether to use .NET container SDK build
-        if (netCoreBuildContext?.containerBuildOptions === AllNetContainerBuildOptions[1]) {
+        if (netCoreBuildContext?.containerBuildOption === AllNetContainerBuildOptions[1]) {
             options = options || {};
             options.appProject = options.appProject || await NetCoreTaskHelper.inferAppProject(context); // This method internally checks the user-defined input first
 

--- a/src/scaffolding/wizard/net/NetContainerBuild.ts
+++ b/src/scaffolding/wizard/net/NetContainerBuild.ts
@@ -6,10 +6,10 @@
 import { AzureWizard, AzureWizardPromptStep, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ScaffoldingWizardContext } from '../ScaffoldingWizardContext';
-import { NetContainerBuildOptions, NetSdkChooseBuildStep } from './NetSdkChooseBuildStep';
+import { NetContainerBuildOption, NetSdkChooseBuildStep } from './NetSdkChooseBuildStep';
 
 export interface NetChooseBuildTypeContext extends ScaffoldingWizardContext {
-    containerBuildOptions?: NetContainerBuildOptions;
+    containerBuildOption?: NetContainerBuildOption;
 }
 
 export async function netContainerBuild(wizardContext: Partial<NetChooseBuildTypeContext>, apiInput?: NetChooseBuildTypeContext): Promise<void> {

--- a/src/scaffolding/wizard/net/NetSdkChooseBuildStep.ts
+++ b/src/scaffolding/wizard/net/NetSdkChooseBuildStep.ts
@@ -19,18 +19,18 @@ export const AllNetContainerBuildOptions = [
 ] as const;
 
 type NetContainerBuildOptionsTuple = typeof AllNetContainerBuildOptions;
-export type NetContainerBuildOptions = NetContainerBuildOptionsTuple[number];
+export type NetContainerBuildOption = NetContainerBuildOptionsTuple[number];
 
 export class NetSdkChooseBuildStep extends TelemetryPromptStep<NetChooseBuildTypeContext> {
     public async prompt(wizardContext: NetChooseBuildTypeContext): Promise<void> {
         await this.ensureCSharpExtension(wizardContext);
 
         // get workspace momento storage
-        const containerBuildOptions = await ext.context.workspaceState.get<NetContainerBuildOptions>(NetContainerBuildOptionsKey);
+        const containerBuildOption = await ext.context.workspaceState.get<NetContainerBuildOption>(NetContainerBuildOptionsKey);
 
         // only remember if it was 'Use .NET SDK', otherwise prompt again
-        if (containerBuildOptions === AllNetContainerBuildOptions[1]) {
-            wizardContext.containerBuildOptions = containerBuildOptions;
+        if (containerBuildOption === AllNetContainerBuildOptions[1]) {
+            wizardContext.containerBuildOption = containerBuildOption;
             return;
         }
 
@@ -40,22 +40,22 @@ export class NetSdkChooseBuildStep extends TelemetryPromptStep<NetChooseBuildTyp
             placeHolder: vscode.l10n.t('How would you like to build your container image?'),
         };
 
-        const buildOptions = AllNetContainerBuildOptions as readonly NetContainerBuildOptions[];
-        const items = buildOptions.map(p => <IAzureQuickPickItem<NetContainerBuildOptions>>{ label: p, data: p });
+        const buildOptions = AllNetContainerBuildOptions as readonly NetContainerBuildOption[];
+        const items = buildOptions.map(p => <IAzureQuickPickItem<NetContainerBuildOption>>{ label: p, data: p });
 
         const response = await wizardContext.ui.showQuickPick(items, opt);
-        wizardContext.containerBuildOptions = response.data;
+        wizardContext.containerBuildOption = response.data;
 
         // update workspace momento storage
-        await ext.context.workspaceState.update(NetContainerBuildOptionsKey, wizardContext.containerBuildOptions);
+        await ext.context.workspaceState.update(NetContainerBuildOptionsKey, wizardContext.containerBuildOption);
     }
 
     public shouldPrompt(wizardContext: NetChooseBuildTypeContext): boolean {
-        return !wizardContext.containerBuildOptions;
+        return !wizardContext.containerBuildOption;
     }
 
     protected setTelemetry(wizardContext: NetChooseBuildTypeContext): void {
-        wizardContext.telemetry.properties.netSdkBuildStep = wizardContext.containerBuildOptions;
+        wizardContext.telemetry.properties.netSdkBuildStep = wizardContext.containerBuildOption;
     }
 
     private async ensureCSharpExtension(wizardContext: NetChooseBuildTypeContext): Promise<void> {


### PR DESCRIPTION
This change allows our debugger to be discoverable when users `f5` on more .NET files. (.vb, fsharp). 

(It also includes a name change of `NetContainerBuildOptions` to `NetContainerBuildOption` since it should be singular)