### PR TITLE
Implemented Delete Remote Image for GenericV2 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -824,7 +824,7 @@
         "node_modules/@microsoft/vscode-docker-registries": {
             "version": "0.0.1-alpha",
             "resolved": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.0.1-alpha.tgz",
-            "integrity": "sha512-AUa6YyRJgGzc96gJylSiI+EGm0B5s28LS7Hi8yHH4aIMz8vU/yK5O9PWrt/GxIxm2AHP4oFqQ59lWy2mk2xunA==",
+            "integrity": "sha512-fvCuxat8ByBF6e6i0Lb7JalHsa4cHv1fw4OK2yzloS5XmVDTgBgi5Oe/8NqaPpNsyP7siCM/jdmlrYwfO5KYxA==",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "dayjs": "^1.11.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -824,7 +824,7 @@
         "node_modules/@microsoft/vscode-docker-registries": {
             "version": "0.0.1-alpha",
             "resolved": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.0.1-alpha.tgz",
-            "integrity": "sha512-fvCuxat8ByBF6e6i0Lb7JalHsa4cHv1fw4OK2yzloS5XmVDTgBgi5Oe/8NqaPpNsyP7siCM/jdmlrYwfO5KYxA==",
+            "integrity": "sha512-a4VFd8J53q7n6KNzF34Msjr2nkrx1Z1hgsvYVd1/SXHSit7/ioFbs7wVUZU586a01NQQ9O32pNXI7KYinNSpvA==",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "dayjs": "^1.11.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -824,7 +824,7 @@
         "node_modules/@microsoft/vscode-docker-registries": {
             "version": "0.0.1-alpha",
             "resolved": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.0.1-alpha.tgz",
-            "integrity": "sha512-RHArIWavwP8kWkmgxkvW1o1XJ8tMnD22luG+Y5Ov+Ug8I3RxjadGaq0UoglZEmaFSv27PZy3CbWAKDidWMLRKQ==",
+            "integrity": "sha512-aAOr+IjP8NEWtdKqy1qtGU3LylgxkK5FOWRp38zIRVMy49V6LyxRESLWbKGjLiDIPbkSxi6fQlJqXaL59CaqfA==",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "dayjs": "^1.11.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -824,7 +824,7 @@
         "node_modules/@microsoft/vscode-docker-registries": {
             "version": "0.0.1-alpha",
             "resolved": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.0.1-alpha.tgz",
-            "integrity": "sha512-aAOr+IjP8NEWtdKqy1qtGU3LylgxkK5FOWRp38zIRVMy49V6LyxRESLWbKGjLiDIPbkSxi6fQlJqXaL59CaqfA==",
+            "integrity": "sha512-SA18suNyHYMsmrfWRN4fkgAHXHG29inYpy5vfhHv7TNs7ha7HRZp93NXpebD1DuPYxFPpmFx3rjdLyADc6DdNA==",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "dayjs": "^1.11.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -824,7 +824,7 @@
         "node_modules/@microsoft/vscode-docker-registries": {
             "version": "0.0.1-alpha",
             "resolved": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.0.1-alpha.tgz",
-            "integrity": "sha512-a4VFd8J53q7n6KNzF34Msjr2nkrx1Z1hgsvYVd1/SXHSit7/ioFbs7wVUZU586a01NQQ9O32pNXI7KYinNSpvA==",
+            "integrity": "sha512-RHArIWavwP8kWkmgxkvW1o1XJ8tMnD22luG+Y5Ov+Ug8I3RxjadGaq0UoglZEmaFSv27PZy3CbWAKDidWMLRKQ==",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "dayjs": "^1.11.7",

--- a/package.json
+++ b/package.json
@@ -531,7 +531,7 @@
                 },
                 {
                     "command": "vscode-docker.registries.deleteImage",
-                    "when": "view == dockerRegistries && viewItem =~ /DockerV2;Tag;/",
+                    "when": "view == dockerRegistries && viewItem =~ /genericRegistryV2Tag/i",
                     "group": "regs_tag_2_destructive@2"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -511,7 +511,7 @@
                 },
                 {
                     "command": "vscode-docker.registries.copyImageDigest",
-                    "when": "view == dockerRegistries && viewItem =~ /registryV2Tag/",
+                    "when": "view == dockerRegistries && viewItem =~ /(dockerHubTag|registryV2Tag|azureContainerTag|githubRegistryTag)/",
                     "group": "regs_tag_1_general@3"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -531,7 +531,7 @@
                 },
                 {
                     "command": "vscode-docker.registries.deleteImage",
-                    "when": "view == dockerRegistries && viewItem =~ /genericRegistryV2Tag/i",
+                    "when": "view == dockerRegistries && viewItem =~ /(genericRegistryV2Tag|azureContainerTag)/i",
                     "group": "regs_tag_2_destructive@2"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -531,7 +531,7 @@
                 },
                 {
                     "command": "vscode-docker.registries.deleteImage",
-                    "when": "view == dockerRegistries && viewItem =~ /(genericRegistryV2Tag|azureContainerTag)/i",
+                    "when": "view == dockerRegistries && viewItem =~ /(genericRegistryV2Tag|azureContainerTag|githubRegistryTag)/i",
                     "group": "regs_tag_2_destructive@2"
                 },
                 {

--- a/src/commands/images/pushImage.ts
+++ b/src/commands/images/pushImage.ts
@@ -59,8 +59,8 @@ export async function pushImage(context: IActionContext, node: ImageTreeItem | u
 
     // Give the user a chance to modify the tag however they want
     const finalTag = await tagImage(context, node, connectedRegistry);
-
-    if (connectedRegistry && finalTag.startsWith(getBaseImagePathFromRegistryItem(connectedRegistry.wrappedItem))) {
+    const baseImagePath = getBaseImagePathFromRegistryItem(connectedRegistry.wrappedItem);
+    if (connectedRegistry && finalTag.startsWith(baseImagePath)) {
         // If a registry was found/chosen and is still the same as the final tag's registry, try logging in
         await vscode.commands.executeCommand('vscode-docker.registries.logInToDockerCli', connectedRegistry);
     }

--- a/src/commands/images/tagImage.ts
+++ b/src/commands/images/tagImage.ts
@@ -11,7 +11,7 @@ import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { UnifiedRegistryItem } from '../../tree/registries/UnifiedRegistryTreeDataProvider';
 import { getBaseImagePathFromRegistryItem } from '../../tree/registries/registryTreeUtils';
 
-export async function tagImage(context: IActionContext, node?: ImageTreeItem, registry?: UnifiedRegistryItem<unknown>): Promise<string> {
+export async function tagImage(context: IActionContext, node?: ImageTreeItem, registry?: UnifiedRegistryItem<CommonRegistry>): Promise<string> {
     if (!node) {
         await ext.imagesTree.refresh(context);
         node = await ext.imagesTree.showTreeItemPicker<ImageTreeItem>(ImageTreeItem.contextValue, {
@@ -21,7 +21,7 @@ export async function tagImage(context: IActionContext, node?: ImageTreeItem, re
     }
 
     addImageTaggingTelemetry(context, node.fullTag, '.before');
-    const baseImagePath = isRegistry(registry) ? getBaseImagePathFromRegistryItem(registry.wrappedItem as CommonRegistry) : undefined;
+    const baseImagePath = isRegistry(registry.wrappedItem) ? getBaseImagePathFromRegistryItem(registry.wrappedItem) : undefined;
     const newTaggedName: string = await getTagFromUserInput(context, node.fullTag, baseImagePath);
     addImageTaggingTelemetry(context, newTaggedName, '.after');
 

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -64,6 +64,7 @@ import { viewAzureProperties } from "./registries/azure/viewAzureProperties";
 import { connectRegistry } from "./registries/connectRegistry";
 import { copyRemoteFullTag } from "./registries/copyRemoteFullTag";
 import { copyRemoteImageDigest } from "./registries/copyRemoteImageDigest";
+import { deleteRemoteImage } from "./registries/deleteRemoteImage";
 import { disconnectRegistry } from "./registries/disconnectRegistry";
 import { openDockerHubInBrowser } from "./registries/dockerHub/openDockerHubInBrowser";
 import { logInToDockerCli } from "./registries/logInToDockerCli";
@@ -165,7 +166,7 @@ export function registerCommands(): void {
     registerCommand('vscode-docker.registries.connectRegistry', connectRegistry);
     registerCommand('vscode-docker.registries.copyImageDigest', copyRemoteImageDigest);
     registerCommand('vscode-docker.registries.copyRemoteFullTag', copyRemoteFullTag);
-    // registerCommand('vscode-docker.registries.deleteImage', deleteRemoteImage);
+    registerCommand('vscode-docker.registries.deleteImage', deleteRemoteImage);
     registerCommand('vscode-docker.registries.deployImageToAzure', deployImageToAzure);
     registerCommand('vscode-docker.registries.deployImageToAca', deployImageToAca);
     registerCommand('vscode-docker.registries.disconnectRegistry', disconnectRegistry);

--- a/src/commands/registries/copyRemoteImageDigest.ts
+++ b/src/commands/registries/copyRemoteImageDigest.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, contextValueExperience } from "@microsoft/vscode-azext-utils";
-import { CommonTag, RegistryV2DataProvider, V2Tag } from "@microsoft/vscode-docker-registries";
+import { CommonRegistryDataProvider, CommonTag } from "@microsoft/vscode-docker-registries";
 import * as vscode from "vscode";
 import { ext } from "../../extensionVariables";
 import { UnifiedRegistryItem } from "../../tree/registries/UnifiedRegistryTreeDataProvider";
@@ -14,8 +14,8 @@ export async function copyRemoteImageDigest(context: IActionContext, node?: Unif
         node = await contextValueExperience(context, ext.registriesTree, { include: ['registryV2Tag'] });
     }
 
-    const v2DataProvider = node.provider as unknown as RegistryV2DataProvider;
-    const digest = await v2DataProvider.getImageDigest(node.wrappedItem as V2Tag);
+    const v2DataProvider = node.provider as unknown as CommonRegistryDataProvider;
+    const digest = await v2DataProvider.getImageDigest?.(node.wrappedItem as CommonTag);
 
     /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
     vscode.env.clipboard.writeText(digest);

--- a/src/commands/registries/deleteRemoteImage.ts
+++ b/src/commands/registries/deleteRemoteImage.ts
@@ -13,7 +13,7 @@ import { registryExperience } from '../../utils/registryExperience';
 
 export async function deleteRemoteImage(context: IActionContext, node?: UnifiedRegistryItem<CommonTag>): Promise<void> {
     if (!node) {
-        node = await registryExperience(context, ext.registriesTree, { include: ['genericRegistryV2Tag', 'azureContainerTag'] }, false);
+        node = await registryExperience(context, ext.registriesTree, { include: ['genericRegistryV2Tag', 'azureContainerTag', 'githubRegistryTag'] }, false);
     }
 
     const tagName = getImageNameFromRegistryTagItem(node.wrappedItem);

--- a/src/commands/registries/deleteRemoteImage.ts
+++ b/src/commands/registries/deleteRemoteImage.ts
@@ -13,7 +13,7 @@ import { registryExperience } from '../../utils/registryExperience';
 
 export async function deleteRemoteImage(context: IActionContext, node?: UnifiedRegistryItem<CommonTag>): Promise<void> {
     if (!node) {
-        node = await registryExperience(context, ext.genericRegistryV2DataProvider, { include: ['commontag'] });
+        node = await registryExperience(context, [ext.genericRegistryV2DataProvider, ext.azureRegistryDataProvider], { include: ['genericRegistryV2Tag', 'azureContainerTag'] }, false);
     }
 
     const tagName = getImageNameFromRegistryTagItem(node.wrappedItem);
@@ -39,6 +39,8 @@ export async function deleteRemoteImage(context: IActionContext, node?: UnifiedR
             }
         }
     });
+
+    // TODO: investigate if we can do this for GitHub
 
     // Other tags that also matched the image may have been deleted, so refresh the whole repository
     // don't wait

--- a/src/commands/registries/deleteRemoteImage.ts
+++ b/src/commands/registries/deleteRemoteImage.ts
@@ -13,7 +13,7 @@ import { registryExperience } from '../../utils/registryExperience';
 
 export async function deleteRemoteImage(context: IActionContext, node?: UnifiedRegistryItem<CommonTag>): Promise<void> {
     if (!node) {
-        node = await registryExperience(context, [ext.genericRegistryV2DataProvider, ext.azureRegistryDataProvider], { include: ['genericRegistryV2Tag', 'azureContainerTag'] }, false);
+        node = await registryExperience(context, ext.registriesTree, { include: ['genericRegistryV2Tag', 'azureContainerTag'] }, false);
     }
 
     const tagName = getImageNameFromRegistryTagItem(node.wrappedItem);

--- a/src/commands/registries/deleteRemoteImage.ts
+++ b/src/commands/registries/deleteRemoteImage.ts
@@ -1,37 +1,35 @@
-// /*---------------------------------------------------------------------------------------------
-//  *  Copyright (c) Microsoft Corporation. All rights reserved.
-//  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
-//  *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
-// import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
-// import { l10n, ProgressLocation, window } from 'vscode';
-// import { ext } from '../../extensionVariables';
-// import { DockerV2TagTreeItem } from '../../tree/registries/dockerV2/DockerV2TagTreeItem';
-// import { registryExpectedContextValues } from '../../tree/registries/registryContextValues';
+import { DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
+import { CommonTag, GenericRegistryV2DataProvider } from '@microsoft/vscode-docker-registries';
+import { ProgressLocation, l10n, window } from 'vscode';
+import { ext } from '../../extensionVariables';
+import { UnifiedRegistryItem } from '../../tree/registries/UnifiedRegistryTreeDataProvider';
+import { getImageNameFromRegistryTagItem } from '../../tree/registries/registryTreeUtils';
+import { registryExperience } from '../../utils/registryExperience';
 
-// export async function deleteRemoteImage(context: IActionContext, node?: DockerV2TagTreeItem): Promise<void> {
-//     if (!node) {
-//         node = await ext.registriesTree.showTreeItemPicker<DockerV2TagTreeItem>(registryExpectedContextValues.dockerV2.tag, {
-//             ...context,
-//             suppressCreatePick: true,
-//             noItemFoundErrorMessage: l10n.t('No remote images are available to delete')
-//         });
-//     }
+export async function deleteRemoteImage(context: IActionContext, node?: UnifiedRegistryItem<CommonTag>): Promise<void> {
+    if (!node) {
+        node = await registryExperience(context, ext.genericRegistryV2DataProvider, { include: ['commontag'] });
+    }
 
-//     const confirmDelete = l10n.t('Are you sure you want to delete image "{0}"? This will delete all images that have the same digest.', node.repoNameAndTag);
-//     // no need to check result - cancel will throw a UserCancelledError
-//     await context.ui.showWarningMessage(confirmDelete, { modal: true }, DialogResponses.deleteResponse);
+    const tagName = getImageNameFromRegistryTagItem(node.wrappedItem);
+    const confirmDelete = l10n.t('Are you sure you want to delete image "{0}"? This will delete all images that have the same digest.', tagName);
+    // no need to check result - cancel will throw a UserCancelledError
+    await context.ui.showWarningMessage(confirmDelete, { modal: true }, DialogResponses.deleteResponse);
 
-//     const repoTI = node.parent;
-//     const deleting = l10n.t('Deleting image "{0}"...', node.repoNameAndTag);
-//     await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async () => {
-//         await node.deleteTreeItem(context);
-//     });
+    const deleting = l10n.t('Deleting image "{0}"...', tagName);
+    await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async () => {
+        const provider = node.provider as unknown as GenericRegistryV2DataProvider;
+        await provider.deleteTag(node.wrappedItem);
+    });
 
-//     // Other tags that also matched the image may have been deleted, so refresh the whole repository
-//     await repoTI.refresh(context);
-//     const message = l10n.t('Successfully deleted image "{0}".', node.repoNameAndTag);
-//     // don't wait
-//     /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
-//     window.showInformationMessage(message);
-// }
+    // Other tags that also matched the image may have been deleted, so refresh the whole repository
+    const message = l10n.t('Successfully deleted image "{0}".', tagName);
+    // don't wait
+    /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
+    window.showInformationMessage(message);
+}

--- a/src/tree/registries/Azure/AzureRegistryDataProvider.ts
+++ b/src/tree/registries/Azure/AzureRegistryDataProvider.ts
@@ -181,7 +181,7 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
         await client.registries.beginDeleteAndWait(resourceGroup, item.label);
     }
 
-    public async deleteTag(item: AzureTag): Promise<void> {
+    public override async deleteTag(item: AzureTag): Promise<void> {
         const authenticationProvider = this.getAuthenticationProvider(item.parent.parent as unknown as AzureRegistryItem);
 
         const reponse = await registryV2Request({

--- a/src/tree/registries/Azure/AzureRegistryDataProvider.ts
+++ b/src/tree/registries/Azure/AzureRegistryDataProvider.ts
@@ -194,7 +194,6 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
 
         if (!reponse.succeeded) {
             throw new Error(`Failed to delete tag: ${reponse.statusText}`);
-
         }
     }
 

--- a/src/tree/registries/registryTreeUtils.ts
+++ b/src/tree/registries/registryTreeUtils.ts
@@ -25,8 +25,11 @@ export function getBaseImagePathFromRegistryItem(registry: CommonRegistry): stri
 
     switch (registry.additionalContextValues?.[0] ?? '') {
         case 'azureContainerRegistry':
-        case 'genericRegistryV2': {
+        case 'genericRegistryV2Registry': {
             return registry.baseUrl.authority.toLowerCase();
+        }
+        case 'githubRegistry': {
+            return `${registry.baseUrl.authority.toLowerCase()}/${registry.label}`;
         }
         case 'dockerHubRegistry':
         default:

--- a/src/utils/registryExperience.ts
+++ b/src/utils/registryExperience.ts
@@ -4,25 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, ContextValueFilter, IActionContext, QuickPickWizardContext, RecursiveQuickPickStep, runQuickPickWizard } from '@microsoft/vscode-azext-utils';
-import { CommonRegistryDataProvider } from '@microsoft/vscode-docker-registries';
-import { ext } from '../extensionVariables';
-import { UnifiedRegistryTreeDataProvider } from '../tree/registries/UnifiedRegistryTreeDataProvider';
+import * as vscode from 'vscode';
 
-export async function registryExperience<TPick>(context: IActionContext, tdp: CommonRegistryDataProvider | CommonRegistryDataProvider[], contextValueFilter: ContextValueFilter, skipIfOne: boolean = true): Promise<TPick> {
-    let unifiedProvider: UnifiedRegistryTreeDataProvider | undefined;
-    if (Array.isArray(tdp)) {
-        unifiedProvider = new UnifiedRegistryTreeDataProvider(ext.context.globalState);
-        for (const provider of tdp) {
-            unifiedProvider.registerProvider(provider);
-        }
-    }
-
+export async function registryExperience<TPick>(context: IActionContext, tdp: vscode.TreeDataProvider<unknown>, contextValueFilter: ContextValueFilter, skipIfOne: boolean = true): Promise<TPick> {
     const promptSteps: AzureWizardPromptStep<QuickPickWizardContext>[] = [
         new RecursiveQuickPickStep(
-            unifiedProvider || (tdp as CommonRegistryDataProvider),
+            tdp,
             {
                 contextValueFilter: contextValueFilter,
-                skipIfOne: skipIfOne
+                skipIfOne: true
             }
         )
     ];

--- a/src/utils/registryExperience.ts
+++ b/src/utils/registryExperience.ts
@@ -4,15 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, ContextValueFilter, IActionContext, QuickPickWizardContext, RecursiveQuickPickStep, runQuickPickWizard } from '@microsoft/vscode-azext-utils';
-import * as vscode from 'vscode';
+import { CommonRegistryDataProvider } from '@microsoft/vscode-docker-registries';
+import { ext } from '../extensionVariables';
+import { UnifiedRegistryTreeDataProvider } from '../tree/registries/UnifiedRegistryTreeDataProvider';
 
-export async function registryExperience<TPick>(context: IActionContext, tdp: vscode.TreeDataProvider<unknown>, contextValueFilter: ContextValueFilter): Promise<TPick> {
+export async function registryExperience<TPick>(context: IActionContext, tdp: CommonRegistryDataProvider | CommonRegistryDataProvider[], contextValueFilter: ContextValueFilter, skipIfOne: boolean = true): Promise<TPick> {
+    let unifiedProvider: UnifiedRegistryTreeDataProvider | undefined;
+    if (Array.isArray(tdp)) {
+        unifiedProvider = new UnifiedRegistryTreeDataProvider(ext.context.globalState);
+        for (const provider of tdp) {
+            unifiedProvider.registerProvider(provider);
+        }
+    }
+
     const promptSteps: AzureWizardPromptStep<QuickPickWizardContext>[] = [
         new RecursiveQuickPickStep(
-            tdp,
+            unifiedProvider || (tdp as CommonRegistryDataProvider),
             {
                 contextValueFilter: contextValueFilter,
-                skipIfOne: true
+                skipIfOne: skipIfOne
             }
         )
     ];

--- a/src/utils/registryExperience.ts
+++ b/src/utils/registryExperience.ts
@@ -12,7 +12,7 @@ export async function registryExperience<TPick>(context: IActionContext, tdp: vs
             tdp,
             {
                 contextValueFilter: contextValueFilter,
-                skipIfOne: true
+                skipIfOne: skipIfOne
             }
         )
     ];


### PR DESCRIPTION
This PR completes command 
- [X] deleteRemoteImage for GenericV2
- [X] getImageDigest for GenericV2

This PR also address a few things that I broke in my previous changes
- A bug with push image that I broke from refactoring the registries util functions

This PR also improves experience for `registryExperience()` 

I also realized I mixed up "Untag Azure Image" with "Delete Azure Image", so I'm going to work on "Untag Azure Image" as delete is already done. 