### PR TITLE
Remove `-preview` in Dockerfile Scaffolding for .NET 8 RC release

### DIFF
--- a/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
+++ b/src/scaffolding/wizard/netCore/NetCoreGatherInformationStep.ts
@@ -53,16 +53,14 @@ export class NetCoreGatherInformationStep extends GatherInformationStep<NetCoreS
             wizardContext.netCoreRuntimeBaseImage = wizardContext.platform === '.NET: ASP.NET Core' ? `${aspNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}` : `${consoleNetBaseImage}:${netCoreVersion.major}.${netCoreVersion.minor}`;
             wizardContext.netCoreSdkBaseImage = `${netSdkImage}:${netCoreVersion.major}.${netCoreVersion.minor}`;
 
-            if (netCoreVersion.major === 8) {
-                if (wizardContext.netCorePlatformOS === 'Windows') {
-                    // append '-preview-nanoserver-ltsc2022' for windows base images for .NET 8's new naming convention
-                    wizardContext.netCoreRuntimeBaseImage = `${wizardContext.netCoreRuntimeBaseImage}-preview-nanoserver-1809`;
-                    wizardContext.netCoreSdkBaseImage = `${wizardContext.netCoreSdkBaseImage}-preview-nanoserver-1809`;
-                } else {
-                    // append '-preview' for everything else
-                    wizardContext.netCoreRuntimeBaseImage = `${wizardContext.netCoreRuntimeBaseImage}-preview`;
-                    wizardContext.netCoreSdkBaseImage = `${wizardContext.netCoreSdkBaseImage}-preview`;
-                }
+            if (netCoreVersion.major === 9) {
+                wizardContext.netCoreRuntimeBaseImage = `${wizardContext.netCoreRuntimeBaseImage}-preview`;
+                wizardContext.netCoreSdkBaseImage = `${wizardContext.netCoreSdkBaseImage}-preview`;
+            }
+            // append '-nanoserver-ltsc2022' for windows base images for .NET 8+'s new naming convention
+            if (wizardContext.netCorePlatformOS === 'Windows') {
+                wizardContext.netCoreRuntimeBaseImage = `${wizardContext.netCoreRuntimeBaseImage}-nanoserver-1809`;
+                wizardContext.netCoreSdkBaseImage = `${wizardContext.netCoreSdkBaseImage}-nanoserver-1809`;
             }
 
             // change default user to adapt to Debian 12


### PR DESCRIPTION
Don't merge until:
- [ ] Test/validate Dockerfile when new .NET 8 image gets released