### PR TITLE
Fixed Registries Url Changes 

### DIFF
--- a/src/commands/images/pushImage.ts
+++ b/src/commands/images/pushImage.ts
@@ -91,6 +91,8 @@ async function tryGetConnectedRegistryForPath(context: IActionContext, imageItem
 
 function getFullRegistryPath(registry: CommonRegistry): string {
     let fullRegistryName = getBaseImagePathFromRegistry(registry);
+
+    // If it's a GitHub registry, we need to add the owner name to the path
     if (isGitHubRegistry(registry)) {
         fullRegistryName = `${fullRegistryName}/${registry.label}`;
     }

--- a/src/commands/images/tagImage.ts
+++ b/src/commands/images/tagImage.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
 import { ImageTreeItem } from '../../tree/images/ImageTreeItem';
 import { UnifiedRegistryItem } from '../../tree/registries/UnifiedRegistryTreeDataProvider';
-import { getBaseUrlFromItem } from '../../tree/registries/registryTreeUtils';
+import { getBaseImagePathFromRegistry } from '../../tree/registries/registryTreeUtils';
 
 export async function tagImage(context: IActionContext, node?: ImageTreeItem, registry?: UnifiedRegistryItem<CommonRegistry>): Promise<string> {
     if (!node) {
@@ -21,7 +21,7 @@ export async function tagImage(context: IActionContext, node?: ImageTreeItem, re
     }
 
     addImageTaggingTelemetry(context, node.fullTag, '.before');
-    const baseImagePath = isRegistry(registry.wrappedItem) ? getBaseUrlFromItem(registry.wrappedItem) : undefined;
+    const baseImagePath = isRegistry(registry.wrappedItem) ? getBaseImagePathFromRegistry(registry.wrappedItem) : undefined;
     const newTaggedName: string = await getTagFromUserInput(context, node.fullTag, baseImagePath);
     addImageTaggingTelemetry(context, newTaggedName, '.after');
 

--- a/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
+++ b/src/commands/registries/azure/DockerAssignAcrPullRoleStep.ts
@@ -11,7 +11,7 @@ import { Progress, l10n } from "vscode";
 import { ext } from "../../../extensionVariables";
 import { AzureRegistry, isAzureTag } from "../../../tree/registries/Azure/AzureRegistryDataProvider";
 import { UnifiedRegistryItem } from "../../../tree/registries/UnifiedRegistryTreeDataProvider";
-import { getBaseUrlFromItem, getFullImageNameFromRegistryTagItem, getResourceGroupFromAzureRegistryItem } from "../../../tree/registries/registryTreeUtils";
+import { getBaseImagePathFromRegistry, getFullImageNameFromTag, getResourceGroupFromAzureRegistryItem } from "../../../tree/registries/registryTreeUtils";
 import { getArmAuth, getArmContainerRegistry, getAzExtAppService, getAzExtAzureUtils } from "../../../utils/lazyPackages";
 
 export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
@@ -42,7 +42,7 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
 
         if (!(registry?.id)) {
             throw new Error(
-                l10n.t('Unable to get details from Container Registry {0}', getBaseUrlFromItem(registryTreeItem.wrappedItem))
+                l10n.t('Unable to get details from Container Registry {0}', getBaseImagePathFromRegistry(registryTreeItem.wrappedItem))
             );
         }
 
@@ -80,7 +80,7 @@ export class DockerAssignAcrPullRoleStep extends AzureWizardExecuteStep<IAppServ
             );
         }
 
-        const fullTag = getFullImageNameFromRegistryTagItem(this.tagTreeItem.wrappedItem);
+        const fullTag = getFullImageNameFromTag(this.tagTreeItem.wrappedItem);
         config.linuxFxVersion = `DOCKER|${fullTag}`;
         await appSvcClient.webApps.updateConfiguration(context.site.resourceGroup, context.site.name, config);
     }

--- a/src/commands/registries/azure/DockerSiteCreateStep.ts
+++ b/src/commands/registries/azure/DockerSiteCreateStep.ts
@@ -12,7 +12,7 @@ import { Progress, l10n } from "vscode";
 import { ext } from "../../../extensionVariables";
 import { AzureRegistryDataProvider, isAzureRegistry } from '../../../tree/registries/Azure/AzureRegistryDataProvider';
 import { UnifiedRegistryItem } from '../../../tree/registries/UnifiedRegistryTreeDataProvider';
-import { getFullImageNameFromRegistryTagItem } from '../../../tree/registries/registryTreeUtils';
+import { getFullImageNameFromTag } from '../../../tree/registries/registryTreeUtils';
 import { getAzExtAppService, getAzExtAzureUtils } from '../../../utils/lazyPackages';
 import { IAppServiceContainerWizardContext } from './deployImageToAzure';
 
@@ -119,7 +119,7 @@ export class DockerSiteCreateStep extends AzureWizardExecuteStep<IAppServiceCont
             appSettings.push({ name: "WEBSITES_PORT", value: context.webSitesPort.toString() });
         }
 
-        const linuxFxVersion = `DOCKER|${getFullImageNameFromRegistryTagItem(this.tagItem.wrappedItem)}`;
+        const linuxFxVersion = `DOCKER|${getFullImageNameFromTag(this.tagItem.wrappedItem)}`;
 
         return {
             linuxFxVersion,

--- a/src/commands/registries/azure/deployImageToAca.ts
+++ b/src/commands/registries/azure/deployImageToAca.ts
@@ -10,7 +10,7 @@ import * as semver from 'semver';
 import * as vscode from 'vscode';
 import { ext } from '../../../extensionVariables';
 import { isAzureRegistry } from '../../../tree/registries/Azure/AzureRegistryDataProvider';
-import { getFullImageNameFromRegistryTagItem } from '../../../tree/registries/registryTreeUtils';
+import { getFullImageNameFromTag } from '../../../tree/registries/registryTreeUtils';
 import { UnifiedRegistryItem } from '../../../tree/registries/UnifiedRegistryTreeDataProvider';
 import { installExtension } from '../../../utils/installExtension';
 import { addImageTaggingTelemetry } from '../../images/tagImage';
@@ -39,7 +39,7 @@ export async function deployImageToAca(context: IActionContext, node?: UnifiedRe
     }
 
     const commandOptions: Partial<DeployImageToAcaOptionsContract> = {
-        image: getFullImageNameFromRegistryTagItem(node.wrappedItem),
+        image: getFullImageNameFromTag(node.wrappedItem),
     };
 
     addImageTaggingTelemetry(context, commandOptions.image, '');

--- a/src/commands/registries/azure/untagAzureImage.ts
+++ b/src/commands/registries/azure/untagAzureImage.ts
@@ -7,7 +7,7 @@ import { contextValueExperience, IActionContext } from "@microsoft/vscode-azext-
 import { l10n, ProgressLocation, window } from "vscode";
 import { ext } from "../../../extensionVariables";
 import { AzureRegistryDataProvider, AzureTag } from "../../../tree/registries/Azure/AzureRegistryDataProvider";
-import { getFullImageNameFromRegistryTagItem } from "../../../tree/registries/registryTreeUtils";
+import { getFullImageNameFromTag } from "../../../tree/registries/registryTreeUtils";
 import { UnifiedRegistryItem } from "../../../tree/registries/UnifiedRegistryTreeDataProvider";
 
 export async function untagAzureImage(context: IActionContext, node?: UnifiedRegistryItem<AzureTag>): Promise<void> {
@@ -15,7 +15,7 @@ export async function untagAzureImage(context: IActionContext, node?: UnifiedReg
         node = await contextValueExperience(context, ext.azureRegistryDataProvider, { include: 'azureContainerTag' });
     }
 
-    const fullTag = getFullImageNameFromRegistryTagItem(node.wrappedItem);
+    const fullTag = getFullImageNameFromTag(node.wrappedItem);
     const confirmUntag: string = l10n.t('Are you sure you want to untag image "{0}"? This does not delete the manifest referenced by the tag.', fullTag);
     // no need to check result - cancel will throw a UserCancelledError
     await context.ui.showWarningMessage(confirmUntag, { modal: true }, { title: "Untag" });

--- a/src/commands/registries/copyRemoteFullTag.ts
+++ b/src/commands/registries/copyRemoteFullTag.ts
@@ -8,13 +8,13 @@ import { CommonTag } from '@microsoft/vscode-docker-registries';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
 import { UnifiedRegistryItem } from '../../tree/registries/UnifiedRegistryTreeDataProvider';
-import { getFullImageNameFromRegistryTagItem } from '../../tree/registries/registryTreeUtils';
+import { getFullImageNameFromTag } from '../../tree/registries/registryTreeUtils';
 
 export async function copyRemoteFullTag(context: IActionContext, node?: UnifiedRegistryItem<CommonTag>): Promise<string> {
     if (!node) {
         node = await contextValueExperience(context, ext.registriesTree, { include: ['registryV2Tag', 'dockerHubTag'] });
     }
-    const fullTag = getFullImageNameFromRegistryTagItem(node.wrappedItem);
+    const fullTag = getFullImageNameFromTag(node.wrappedItem);
     void vscode.env.clipboard.writeText(fullTag);
     return fullTag;
 }

--- a/src/commands/registries/deleteRemoteImage.ts
+++ b/src/commands/registries/deleteRemoteImage.ts
@@ -8,7 +8,7 @@ import { RegistryV2DataProvider, V2Tag } from '@microsoft/vscode-docker-registri
 import { ProgressLocation, l10n, window } from 'vscode';
 import { ext } from '../../extensionVariables';
 import { UnifiedRegistryItem } from '../../tree/registries/UnifiedRegistryTreeDataProvider';
-import { getImageNameFromRegistryTagItem } from '../../tree/registries/registryTreeUtils';
+import { getFullImageNameFromTag } from '../../tree/registries/registryTreeUtils';
 import { registryExperience } from '../../utils/registryExperience';
 
 export async function deleteRemoteImage(context: IActionContext, node?: UnifiedRegistryItem<V2Tag>): Promise<void> {
@@ -16,7 +16,7 @@ export async function deleteRemoteImage(context: IActionContext, node?: UnifiedR
         node = await registryExperience(context, ext.registriesTree, { include: ['genericRegistryV2Tag', 'azureContainerTag'] }, false);
     }
 
-    const tagName = getImageNameFromRegistryTagItem(node.wrappedItem);
+    const tagName = getFullImageNameFromTag(node.wrappedItem);
     const confirmDelete = l10n.t('Are you sure you want to delete image "{0}"? This will delete all images that have the same digest.', tagName);
     // no need to check result - cancel will throw a UserCancelledError
     await context.ui.showWarningMessage(confirmDelete, { modal: true }, DialogResponses.deleteResponse);

--- a/src/commands/registries/pullImages.ts
+++ b/src/commands/registries/pullImages.ts
@@ -8,7 +8,7 @@ import { CommonRegistry, CommonRepository, CommonTag } from '@microsoft/vscode-d
 import { ext } from '../../extensionVariables';
 import { TaskCommandRunnerFactory } from '../../runtimes/runners/TaskCommandRunnerFactory';
 import { UnifiedRegistryItem } from '../../tree/registries/UnifiedRegistryTreeDataProvider';
-import { getFullImageNameFromRegistryTagItem, getFullRepositoryNameFromRepositoryItem } from '../../tree/registries/registryTreeUtils';
+import { getFullImageNameFromTag, getFullRepositoryNameFromRepositoryItem } from '../../tree/registries/registryTreeUtils';
 import { logInToDockerCli } from './logInToDockerCli';
 
 export async function pullRepository(context: IActionContext, node?: UnifiedRegistryItem<CommonRepository>): Promise<void> {
@@ -24,7 +24,7 @@ export async function pullImageFromRepository(context: IActionContext, node?: Un
         node = await contextValueExperience(context, ext.registriesTree, { include: 'commontag' });
     }
 
-    await pullImages(context, node.parent.parent, getFullImageNameFromRegistryTagItem(node.wrappedItem), false);
+    await pullImages(context, node.parent.parent, getFullImageNameFromTag(node.wrappedItem), false);
 }
 
 async function pullImages(context: IActionContext, node: UnifiedRegistryItem<unknown>, imageRequest: string, allTags: boolean): Promise<void> {

--- a/src/tree/registries/UnifiedRegistryTreeDataProvider.ts
+++ b/src/tree/registries/UnifiedRegistryTreeDataProvider.ts
@@ -138,13 +138,13 @@ export class UnifiedRegistryTreeDataProvider implements vscode.TreeDataProvider<
      * @returns A list of registries that are connected to the extension. If imageBaseName is provided, only registries that
      *          can be used to push to that image will be returned.
      */
-    public async getConnectedRegistries(imageBaseName?: vscode.Uri): Promise<UnifiedRegistryItem<CommonRegistry>[]> {
+    public async getConnectedRegistries(imageBaseName?: string): Promise<UnifiedRegistryItem<CommonRegistry>[]> {
         let registryRoots = await this.getChildren();
         let findAzureRegistryOnly = false;
 
         // filter out registry roots that don't match the image base name
         if (imageBaseName) {
-            const authority = imageBaseName.authority;
+            const authority = imageBaseName.split('/')[0];
 
             if (authority === 'docker.io') {
                 registryRoots = registryRoots.filter(r => (r.wrappedItem as CommonRegistryRoot).label === 'Docker Hub');

--- a/src/tree/registries/registryTreeUtils.ts
+++ b/src/tree/registries/registryTreeUtils.ts
@@ -25,9 +25,10 @@ export function getBaseImagePathFromRegistry(registry: CommonRegistry): string {
     } else if (isDockerHubRegistry(registry)) {
         registry = registry as CommonRegistry;
         return registry.label.toLowerCase();
+    } else {
+        registry = registry as CommonRegistry;
+        return registry.baseUrl.authority.toLowerCase();
     }
-
-    throw new Error(l10n.t('The type of registry is not supported. Unable to get base image path'));
 }
 
 export function getFullImageNameFromTag(tag: CommonTag): string {


### PR DESCRIPTION
These changes fixes the extra steps an user has to go through when pushing an image to a registry. In other words, these changes allow users to skip the step to choose which registry they want to push to if the image name matches a connected registry name. (which was our original behavior)

- Reverted this change https://github.com/microsoft/vscode-docker/pull/4026/commits/b49d849b1d2ca391ba2f26c843f942401f3183c2 as it was causing extra steps for push image
- Changed getBaseUrlFromItem() to getImageNameFromTag()

Tested:
- [X] Github
- [X] Docker Hub 
- [X] Generic V2
- [X] Azure

