### PR TITLE
Support multiple .dockerignore files for language id discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1558,6 +1558,9 @@
                 "id": "ignore",
                 "filenames": [
                     ".dockerignore"
+                ],
+                "filenamePatterns": [
+                    "*.dockerignore"
                 ]
             }
         ],


### PR DESCRIPTION
Update package.json with a 'filenamePatterns' of "*.dockerignore" since that is the convention to use when using multiple .dockerignore files when having multiple Dockerfiles.

Fixes #4059 