### PR TITLE
Update Dockerfile language server to 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@microsoft/vscode-azext-utils": "^1.2.2",
                 "@microsoft/vscode-container-client": "^0.1.0",
                 "dayjs": "^1.11.7",
-                "dockerfile-language-server-nodejs": "^0.10.2",
+                "dockerfile-language-server-nodejs": "^0.11.0",
                 "fs-extra": "^11.1.1",
                 "gradle-to-js": "^2.0.1",
                 "handlebars": "^4.7.7",
@@ -2384,25 +2384,26 @@
             "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
         },
         "node_modules/dockerfile-ast": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.5.0.tgz",
-            "integrity": "sha512-YsRrWww6mKRS1HK32gbherPlgfvwS593ZeDegb5glNCBJgByICAYZCP5F+njY6TSB0eiPdFgCU9RkuO516mLFQ==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.6.1.tgz",
+            "integrity": "sha512-m3rH2qHHU2pSTCppXgJT+1KLxhvkdROOxVPof5Yz4IPGSw6K+x0B0/RFdYgXN5zsIUTlbOSRyfDCv3/uVhnNmg==",
             "dependencies": {
-                "vscode-languageserver-textdocument": "^1.0.1",
-                "vscode-languageserver-types": "^3.17.0-next.3"
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3"
             },
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.10.2.tgz",
-            "integrity": "sha512-vLbaeYv4h3XEzrZ9JOhP6bD1eLzbzGzFFF03F3Ofd6kh9PU2aGBS/LVjd/w1omCyNV2LHviFX0ZGHINmWsZYyw==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.11.0.tgz",
+            "integrity": "sha512-kv97EVYcKXh4SiteaVX8LDSwpcdAOIJM/3Wm6rWxTH4gLbozocDekoU5YpX1X2kKOI4L5gvzFIhzgxqPhFnRzg==",
             "dependencies": {
-                "dockerfile-language-service": "0.10.2",
-                "dockerfile-utils": "0.11.0",
-                "vscode-languageserver": "^8.0.0-next.2"
+                "dockerfile-language-service": "0.11.0",
+                "dockerfile-utils": "0.15.0",
+                "vscode-languageserver": "~8.0.0",
+                "vscode-languageserver-textdocument": "~1.0.8"
             },
             "bin": {
                 "docker-langserver": "bin/docker-langserver"
@@ -2411,27 +2412,61 @@
                 "node": "*"
             }
         },
-        "node_modules/dockerfile-language-service": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.10.2.tgz",
-            "integrity": "sha512-W561U9gj5Eol55j/hanLRPVarXDq+WXPai1lG5f1fW7/kYElsmWJZoRd585SQBahvC9VlJfFAs6IpzZlvN41Hg==",
+        "node_modules/dockerfile-language-server-nodejs/node_modules/vscode-jsonrpc": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+            "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/dockerfile-language-server-nodejs/node_modules/vscode-languageserver": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz",
+            "integrity": "sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==",
             "dependencies": {
-                "dockerfile-ast": "0.5.0",
-                "dockerfile-utils": "0.11.0",
-                "vscode-languageserver-types": "3.17.0-next.3"
+                "vscode-languageserver-protocol": "3.17.2"
+            },
+            "bin": {
+                "installServerIntoExtension": "bin/installServerIntoExtension"
+            }
+        },
+        "node_modules/dockerfile-language-server-nodejs/node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+            "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.0.2",
+                "vscode-languageserver-types": "3.17.2"
+            }
+        },
+        "node_modules/dockerfile-language-server-nodejs/node_modules/vscode-languageserver-types": {
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+        },
+        "node_modules/dockerfile-language-service": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.11.0.tgz",
+            "integrity": "sha512-Y0TtqZNnI3EC5g/zCZitNV191oZoYCva2r6lt0T1k+W5VX1kjz0vwKbkgBIpk2Rzh4fQlYFJALALtvd/kw5ixA==",
+            "dependencies": {
+                "dockerfile-ast": "0.6.1",
+                "dockerfile-utils": "0.15.0",
+                "vscode-languageserver-textdocument": "1.0.8",
+                "vscode-languageserver-types": "3.17.3"
             },
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/dockerfile-utils": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.11.0.tgz",
-            "integrity": "sha512-b7uGmYAeneg/zP63vfUrkIWw4frvtviXe7QGV0Vw58kJwyEYmrKxjm+N+NbBgk6mwq5FEIDT5rx08pBpjstpEw==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.15.0.tgz",
+            "integrity": "sha512-hV2OExB797C3/GlOloywmMZzu3MPmzMziGuCaPWh/m9qHgTyfN4+EI3b6xhHDXy78PU0GqwvHnZVX7wfpqOCkg==",
             "dependencies": {
-                "dockerfile-ast": "0.5.0",
-                "vscode-languageserver-textdocument": "^1.0.1",
-                "vscode-languageserver-types": "^3.17.0-next.3"
+                "dockerfile-ast": "0.6.1",
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3"
             },
             "bin": {
                 "dockerfile-utils": "bin/dockerfile-utils"
@@ -6189,20 +6224,15 @@
                 "vscode-languageserver-types": "3.17.3"
             }
         },
-        "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
-            "version": "3.17.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
-        },
         "node_modules/vscode-languageserver-textdocument": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
             "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.17.0-next.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.3.tgz",
-            "integrity": "sha512-VQcXnhKYxUW6OiRMhG++SzmZYMJwusXknJGd+FfdOnS1yHAo734OHyR0e2eEHDlv0/oWc8RZPgx/VKSKyondVg=="
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
         },
         "node_modules/vscode-tas-client": {
             "version": "0.1.63",

--- a/package.json
+++ b/package.json
@@ -3038,7 +3038,7 @@
         "@microsoft/vscode-azext-utils": "^1.2.2",
         "@microsoft/vscode-container-client": "^0.1.0",
         "dayjs": "^1.11.7",
-        "dockerfile-language-server-nodejs": "^0.10.2",
+        "dockerfile-language-server-nodejs": "^0.11.0",
         "fs-extra": "^11.1.1",
         "gradle-to-js": "^2.0.1",
         "handlebars": "^4.7.7",


### PR DESCRIPTION
This update adds support for a few new flags that have been added to Dockerfile so that they no longer get flagged as errors. The other big change is the introduction of a comment that can be inserted into the Dockerfile to instruct the linter to not flag something as an error. While most errors can be ignored this way, clearly fatal errors that suggest the Dockerfile is completely broken cannot be ignored.

This release fixes the following issues. As always, thank you all for your bug reports and suggestions!
- #4012
- #4051
- #4054
- #4056

Please use the following Dockerfile to test the new features and bug fixes.
```Dockerfile
FROM scratch
# 1. Use code completion at the end. You should now see --start-interval and --start-period.
HEALTHCHECK --start-
# 2. --start-interval used to be flagged as an error. This has been fixed.
# 3. (Issue #4054) Hover over --start-interval and you will get hover documentation help.
HEALTHCHECK --start-interval=5s CMD ls

# 4. You can now use a comment like the above to stop flagging an error.
# Now you can rid yourself of errors without having to wait for me to push out a fix first!
# dockerfile-utils: ignore
UNKNOWN instruction

# Note that the comment must be before the instruction itself rather than the line immediately before the error itself.
# In this case the comment being on line 20 means it will not take effect. Move it to up to before the HEALTHCHECK and it will work.
# Most errors can be ignored but clearly fatal errors (missing FROM) cannot be ignored.

HEALTHCHECK \
    --interval=30s \
    --retries=3 \
    # dockerfile-utils: ignore
    --start-interval-typo=5s \
    --start-period=5s \
    --timeout=30s \
    CMD ls

# 5. (Issue #4051) --checksum is now supported and no longer flagged as an error.
ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68d https://mirrors.edge.kernel.org/pub/linux/kernel/Historic/linux-0.01.tar.gz /
# 6. --keep-git-dir is now supported and no longer flagged as an error.
ADD --keep-git-dir=true https://github.com/moby/buildkit.git#v0.10.1 /buildkit

# 7. (Issue #4012) Predefined ARG variables are now assumed to be okay for FROM instructions.
FROM ${TARGETARCH}

# 8. (Issue #4056) The parser now parses tags with digests better. The link should now open correctly instead of going to a 404.
FROM microsoft/dotnet:non-existent-tag@sha256:5483e2b609c0f66c3ebd96666de7b0a74537613b43565879ecb0d0a73e845d7d
```