### PR TITLE
Asynchronously fetch createdAt info

### DIFF
--- a/src/tree/registries/Azure/AzureRegistryDataProvider.ts
+++ b/src/tree/registries/Azure/AzureRegistryDataProvider.ts
@@ -136,12 +136,11 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
 
     public override async getTags(repository: AzureRepository): Promise<AzureTag[]> {
         const tags = await super.getTags(repository);
-        const tagsWithAdditionalContext = tags.map(tag => ({
-            ...tag,
-            additionalContextValues: ['azureContainerTag']
-        }));
+        tags.forEach(tag => {
+            tag.additionalContextValues = [...tag.additionalContextValues, 'azureContainerTag'];
+        });
 
-        return tagsWithAdditionalContext;
+        return tags;
     }
 
     public override getTreeItem(element: CommonRegistryItem): Promise<vscode.TreeItem> {

--- a/src/tree/registries/UnifiedRegistryTreeDataProvider.ts
+++ b/src/tree/registries/UnifiedRegistryTreeDataProvider.ts
@@ -97,7 +97,7 @@ export class UnifiedRegistryTreeDataProvider implements vscode.TreeDataProvider<
             if (canReferenceWrapper(child) && child._urtdp_wrapper) {
                 this.onDidChangeTreeDataEmitter.fire(child._urtdp_wrapper);
             } else {
-                // TODO this.onDidChangeTreeDataEmitter.fire(undefined);
+                this.onDidChangeTreeDataEmitter.fire(undefined);
             }
         });
 

--- a/src/tree/registries/UnifiedRegistryTreeDataProvider.ts
+++ b/src/tree/registries/UnifiedRegistryTreeDataProvider.ts
@@ -3,6 +3,15 @@ import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
 import { isAzureSubscriptionRegistryItem } from './Azure/AzureRegistryDataProvider';
 
+interface WrappedElement {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    _urtdp_wrapper: UnifiedRegistryItem<unknown>;
+}
+
+function canReferenceWrapper(item: unknown): item is WrappedElement {
+    return !!item && typeof item === 'object';
+}
+
 export interface UnifiedRegistryItem<T> {
     provider: RegistryDataProvider<T>;
     wrappedItem: T;
@@ -43,7 +52,7 @@ export class UnifiedRegistryTreeDataProvider implements vscode.TreeDataProvider<
                 };
 
                 if (canReferenceWrapper(child)) {
-                    child.urtdp_wrapper = wrapper;
+                    child._urtdp_wrapper = wrapper;
                 }
 
                 results.push(wrapper);
@@ -85,8 +94,8 @@ export class UnifiedRegistryTreeDataProvider implements vscode.TreeDataProvider<
     public registerProvider(provider: RegistryDataProvider<unknown>): vscode.Disposable {
         this.providers.set(provider.id, provider);
         const disposable = provider.onDidChangeTreeData((child) => {
-            if (canReferenceWrapper(child) && child.urtdp_wrapper) {
-                this.onDidChangeTreeDataEmitter.fire(child.urtdp_wrapper);
+            if (canReferenceWrapper(child) && child._urtdp_wrapper) {
+                this.onDidChangeTreeDataEmitter.fire(child._urtdp_wrapper);
             } else {
                 // TODO this.onDidChangeTreeDataEmitter.fire(undefined);
             }


### PR DESCRIPTION
This is incomplete. Still need to stop using `.map` in `getTags` in AzureRegistryDataProvider