### PR TITLE
No Longer Expose Ports Manually During Sdk Build & Launch

### DIFF
--- a/src/tasks/netSdk/netSdkTaskUtils.ts
+++ b/src/tasks/netSdk/netSdkTaskUtils.ts
@@ -65,10 +65,6 @@ export async function getNetSdkRunCommand(isProjectWebApp: boolean, imageName: s
         entrypoint: await getDockerOSType() === 'windows' ? 'cmd.exe' : '/bin/sh'
     };
 
-    if (isProjectWebApp) {
-        options.exposePorts = [8080, 80]; // the default port is 8080 for .NET 8 and 80 for .NET 7
-    }
-
     const command = await client.runContainer(options);
     const quotedArgs = Shell.getShellOrDefault().quote(command.args);
     const commandLine = [client.commandName, ...quotedArgs].join(' ');


### PR DESCRIPTION
With .NET 8 SDK RC1, images that are built has existing expose ports logic so we no longer need to export 8080 and 80 manually. 

This also closes https://github.com/microsoft/vscode-docker/issues/4006 since the old behavior in `browseContainer()` would just choose `80` by default and open a port that is not published for .NET 8. However, with the new SDK exposing ports change and us not exposing ports manually, the only available port is the port auto exposed by the .NET SDK (8080), therefore, fixing the problem. 