### PR TITLE
added chaining operator to registry

### DIFF
--- a/src/commands/images/tagImage.ts
+++ b/src/commands/images/tagImage.ts
@@ -21,7 +21,7 @@ export async function tagImage(context: IActionContext, node?: ImageTreeItem, re
     }
 
     addImageTaggingTelemetry(context, node.fullTag, '.before');
-    const baseImagePath = isRegistry(registry.wrappedItem) ? getBaseImagePathFromRegistry(registry.wrappedItem) : undefined;
+    const baseImagePath = isRegistry(registry?.wrappedItem) ? getBaseImagePathFromRegistry(registry.wrappedItem) : undefined;
     const newTaggedName: string = await getTagFromUserInput(context, node.fullTag, baseImagePath);
     addImageTaggingTelemetry(context, newTaggedName, '.after');
 


### PR DESCRIPTION
This PR fixes the tag image command. A lot of the times, registry is undefined, so `registry.wrappedItem` will throw an error. 