### PR TITLE
Throw Better Error when running registries commands when No Registries are Connected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@microsoft/vscode-azext-azureutils": "^2.0.0",
                 "@microsoft/vscode-azext-utils": "^2.1.1",
                 "@microsoft/vscode-container-client": "^0.1.0",
-                "@microsoft/vscode-docker-registries": "^0.1.1",
+                "@microsoft/vscode-docker-registries": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.1.2.tgz",
                 "dayjs": "^1.11.7",
                 "dockerfile-language-server-nodejs": "^0.11.0",
                 "fs-extra": "^11.1.1",
@@ -812,9 +812,10 @@
             }
         },
         "node_modules/@microsoft/vscode-docker-registries": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-docker-registries/-/vscode-docker-registries-0.1.1.tgz",
-            "integrity": "sha512-cDO8iMTtx0wsBfN4MHWJimv8JQggx1SjRsbksaJoU3VUmsR55EypSKenSAZf9TvNLy2kKQzguihYzAQCNXQedw==",
+            "version": "0.1.2",
+            "resolved": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.1.2.tgz",
+            "integrity": "sha512-z1aYQaKlgLrM/Ru2fMgEHx/fCflwRtY1Loi8WB/pGHP0J9qiH9zbqaYXCotJS/AqnbYxOyJZmh3en0ldchZbnA==",
+            "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "dayjs": "^1.11.7",
                 "node-fetch": "^2.6.11"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@microsoft/vscode-azext-azureutils": "^2.0.0",
                 "@microsoft/vscode-azext-utils": "^2.1.1",
                 "@microsoft/vscode-container-client": "^0.1.0",
-                "@microsoft/vscode-docker-registries": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.1.2.tgz",
+                "@microsoft/vscode-docker-registries": "^0.1.2",
                 "dayjs": "^1.11.7",
                 "dockerfile-language-server-nodejs": "^0.11.0",
                 "fs-extra": "^11.1.1",
@@ -813,9 +813,8 @@
         },
         "node_modules/@microsoft/vscode-docker-registries": {
             "version": "0.1.2",
-            "resolved": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-docker-registries/-/vscode-docker-registries-0.1.2.tgz",
             "integrity": "sha512-NWy0VYHZq7g+RbJWUrcre+1/DzObhMBUmPfZo/1zZMS4vHVqpQzVlSnnbLilK2Xl0+XnwKDSjp7zY7XbOMCTvg==",
-            "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "dayjs": "^1.11.7",
                 "node-fetch": "^2.6.11"

--- a/package-lock.json
+++ b/package-lock.json
@@ -814,7 +814,7 @@
         "node_modules/@microsoft/vscode-docker-registries": {
             "version": "0.1.2",
             "resolved": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.1.2.tgz",
-            "integrity": "sha512-z1aYQaKlgLrM/Ru2fMgEHx/fCflwRtY1Loi8WB/pGHP0J9qiH9zbqaYXCotJS/AqnbYxOyJZmh3en0ldchZbnA==",
+            "integrity": "sha512-NWy0VYHZq7g+RbJWUrcre+1/DzObhMBUmPfZo/1zZMS4vHVqpQzVlSnnbLilK2Xl0+XnwKDSjp7zY7XbOMCTvg==",
             "license": "See LICENSE in the project root for license information.",
             "dependencies": {
                 "dayjs": "^1.11.7",

--- a/package.json
+++ b/package.json
@@ -3007,7 +3007,7 @@
         "@microsoft/vscode-azext-azureutils": "^2.0.0",
         "@microsoft/vscode-azext-utils": "^2.1.1",
         "@microsoft/vscode-container-client": "^0.1.0",
-        "@microsoft/vscode-docker-registries": "^0.1.1",
+        "@microsoft/vscode-docker-registries": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.1.2.tgz",
         "dayjs": "^1.11.7",
         "dockerfile-language-server-nodejs": "^0.11.0",
         "fs-extra": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -3007,7 +3007,7 @@
         "@microsoft/vscode-azext-azureutils": "^2.0.0",
         "@microsoft/vscode-azext-utils": "^2.1.1",
         "@microsoft/vscode-container-client": "^0.1.0",
-        "@microsoft/vscode-docker-registries": "file:../vscode-docker-extensibility/packages/vscode-docker-registries/microsoft-vscode-docker-registries-0.1.2.tgz",
+        "@microsoft/vscode-docker-registries": "^0.1.2",
         "dayjs": "^1.11.7",
         "dockerfile-language-server-nodejs": "^0.11.0",
         "fs-extra": "^11.1.1",

--- a/src/commands/registries/genericV2/addTrackedGenericV2Registry.ts
+++ b/src/commands/registries/genericV2/addTrackedGenericV2Registry.ts
@@ -8,11 +8,8 @@ import { ext } from "../../../extensionVariables";
 import { UnifiedRegistryItem } from "../../../tree/registries/UnifiedRegistryTreeDataProvider";
 
 export async function addTrackedGenericV2Registry(context: IActionContext, node?: UnifiedRegistryItem<unknown>): Promise<void> {
-    const root = ext.genericRegistryV2DataProvider.getRoot();
-    const registries = await ext.genericRegistryV2DataProvider.getRegistries(root);
-
-    if (registries?.length > 0) {
-        // if there are already registries, add a new registry to the existing root node
+    // if there are already registries, add a new registry to the existing root node
+    if (ext.genericRegistryV2DataProvider.hasTrackedRegistries()) {
         await ext.genericRegistryV2DataProvider.addTrackedRegistry();
     } else {
         // if there are no registries, connect as usual

--- a/src/commands/registries/genericV2/addTrackedGenericV2Registry.ts
+++ b/src/commands/registries/genericV2/addTrackedGenericV2Registry.ts
@@ -8,7 +8,17 @@ import { ext } from "../../../extensionVariables";
 import { UnifiedRegistryItem } from "../../../tree/registries/UnifiedRegistryTreeDataProvider";
 
 export async function addTrackedGenericV2Registry(context: IActionContext, node?: UnifiedRegistryItem<unknown>): Promise<void> {
-    await ext.genericRegistryV2DataProvider.addTrackedRegistry();
+    const root = ext.genericRegistryV2DataProvider.getRoot();
+    const registries = await ext.genericRegistryV2DataProvider.getRegistries(root);
+
+    if (registries?.length > 0) {
+        // if there are already registries, add a new registry to the existing root node
+        await ext.genericRegistryV2DataProvider.addTrackedRegistry();
+    } else {
+        // if there are no registries, connect as usual
+        await ext.registriesTree.connectRegistryProvider(ext.genericRegistryV2DataProvider);
+    }
+
     // don't wait
     void ext.registriesTree.refresh();
 }

--- a/src/commands/registries/genericV2/removeTrackedGenericV2Registry.ts
+++ b/src/commands/registries/genericV2/removeTrackedGenericV2Registry.ts
@@ -20,7 +20,7 @@ export async function removeTrackedGenericV2Registry(context: IActionContext, no
     await ext.genericRegistryV2DataProvider.removeTrackedRegistry(node.wrappedItem);
 
     // remove the provider if it's the last one
-    if ((await ext.genericRegistryV2DataProvider.getRegistries(node.parent.wrappedItem)).length === 0) {
+    if (!ext.genericRegistryV2DataProvider.hasTrackedRegistries()) {
         await ext.registriesTree.disconnectRegistryProvider(node.parent);
     }
 

--- a/src/tree/registries/ConnectRegistryTreeItem.ts
+++ b/src/tree/registries/ConnectRegistryTreeItem.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CommonRegistryItem, isCommonRegistryItem } from '@microsoft/vscode-docker-registries';
+import * as vscode from 'vscode';
+import { UnifiedRegistryItem } from "./UnifiedRegistryTreeDataProvider";
+
+export const ConnectRegistryContextValue: string = 'connectregistry';
+
+export function isConnectRegistryTreeItem(item: unknown): item is UnifiedRegistryItem<CommonRegistryItem> {
+    return isCommonRegistryItem(item) && item.type === ConnectRegistryContextValue;
+}
+
+/**
+ * Creates a tree item that can be used to connect a new registry
+ */
+export function getConnectRegistryTreeItem(): UnifiedRegistryItem<CommonRegistryItem> {
+    return {
+        provider: undefined,
+        parent: undefined,
+        wrappedItem: {
+            label: vscode.l10n.t('Connect Registry...'),
+            type: ConnectRegistryContextValue,
+            iconPath: new vscode.ThemeIcon('plug'),
+            command: {
+                command: 'vscode-docker.registries.connectRegistry'
+            },
+            parent: undefined
+        }
+    };
+}

--- a/src/tree/registries/UnifiedRegistryTreeDataProvider.ts
+++ b/src/tree/registries/UnifiedRegistryTreeDataProvider.ts
@@ -2,6 +2,7 @@ import { CommonRegistry, CommonRegistryRoot, RegistryDataProvider, isCommonRegis
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
 import { isAzureSubscriptionRegistryItem } from './Azure/AzureRegistryDataProvider';
+import { getConnectRegistryTreeItem } from './ConnectRegistryTreeItem';
 
 interface WrappedElement {
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -85,18 +86,8 @@ export class UnifiedRegistryTreeDataProvider implements vscode.TreeDataProvider<
 
             // if there are no connected providers, show a command to connect one
             if (unifiedRegistryItems.length === 0) {
-                unifiedRegistryItems.push({
-                    provider: undefined,
-                    wrappedItem: {
-                        label: vscode.l10n.t('Connect Registry...'),
-                        type: 'connectregistry',
-                        iconPath: new vscode.ThemeIcon('plug'),
-                        command: {
-                            command: 'vscode-docker.registries.connectRegistry'
-                        }
-                    },
-                    parent: undefined,
-                });
+                const connectRegistryItem = getConnectRegistryTreeItem();
+                unifiedRegistryItems.push(connectRegistryItem);
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-docker/issues/4098
Closes https://github.com/microsoft/vscode-docker/issues/4097
Closes https://github.com/microsoft/vscode-docker/issues/4099

![image](https://github.com/microsoft/vscode-docker/assets/59073590/394b603c-a623-4148-99b9-42116bab1f48)

Also closes these as we have updated the registries package
Closes https://github.com/microsoft/vscode-docker/issues/4094
Closes https://github.com/microsoft/vscode-docker/issues/4092


TODO: 
- [X] Release new registries package
