### PR TITLE
Change run commands to use imageId instead of tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1615,7 +1615,7 @@
                             "type": "string"
                         }
                     ],
-                    "default": "${containerCommand} run --rm -d ${exposedPorts} ${tag}",
+                    "default": "${containerCommand} run --rm -d ${exposedPorts} ${imageId}",
                     "description": "%vscode-docker.config.template.run.description%"
                 },
                 "docker.commands.runInteractive": {
@@ -1647,7 +1647,7 @@
                             "type": "string"
                         }
                     ],
-                    "default": "${containerCommand} run --rm -it ${exposedPorts} ${tag}",
+                    "default": "${containerCommand} run --rm -it ${exposedPorts} ${imageId}",
                     "description": "%vscode-docker.config.template.runInteractive.description%"
                 },
                 "docker.commands.attach": {

--- a/src/commands/images/runImage.ts
+++ b/src/commands/images/runImage.ts
@@ -35,14 +35,14 @@ async function runImageCore(context: IActionContext, node: ImageTreeItem | undef
 
     const terminalCommand = await selectRunCommand(
         context,
-        node.fullTag,
+        node.imageId,
         interactive,
         inspectResult?.[0]?.ports
     );
 
     const taskCRF = new TaskCommandRunnerFactory(
         {
-            taskName: node.fullTag,
+            taskName: node.imageId,
             alwaysRunNew: interactive,
         }
     );

--- a/src/commands/selectCommandTemplate.ts
+++ b/src/commands/selectCommandTemplate.ts
@@ -38,7 +38,7 @@ export async function selectBuildCommand(context: IActionContext, folder: vscode
     );
 }
 
-export async function selectRunCommand(context: IActionContext, fullTag: string, interactive: boolean, exposedPorts?: PortBinding[]): Promise<VoidCommandResponse> {
+export async function selectRunCommand(context: IActionContext, imageId: string, interactive: boolean, exposedPorts?: PortBinding[]): Promise<VoidCommandResponse> {
     let portsString: string = '';
     if (exposedPorts) {
         portsString = exposedPorts.map(pb => `-p ${pb.containerPort}:${pb.containerPort}${pb.protocol ? '/' + pb.protocol : ''}`).join(' ');
@@ -47,9 +47,9 @@ export async function selectRunCommand(context: IActionContext, fullTag: string,
     return await selectCommandTemplate(
         context,
         interactive ? 'runInteractive' : 'run',
-        [fullTag],
+        [imageId],
         undefined,
-        { 'tag': fullTag, 'exposedPorts': portsString, 'containerCommand': await ext.runtimeManager.getCommand() }
+        { 'imageId': imageId, 'exposedPorts': portsString, 'containerCommand': await ext.runtimeManager.getCommand() }
     );
 }
 


### PR DESCRIPTION
Hello,

The purpose of this pull request is to solve issue #4100 .

Unit tests:

1- Build an untagged image:

Example Dockerfile
![image](https://github.com/microsoft/vscode-docker/assets/8070232/3d723290-f0df-4f75-a5a0-870aecdd7944)

Build
![image](https://github.com/microsoft/vscode-docker/assets/8070232/5ce112ee-9439-4375-85d7-1189a68adc67)

Untagged image built
![image](https://github.com/microsoft/vscode-docker/assets/8070232/8672a641-b2c7-4803-adff-23104f34c9b7)

2- Run it (interactive):

Run interactive
![image](https://github.com/microsoft/vscode-docker/assets/8070232/b8ca6039-ce0c-4965-a164-a7da8ec0ba8a)

Check running
![image](https://github.com/microsoft/vscode-docker/assets/8070232/1596abe0-4b43-4866-803c-404487121311)

Check image ID
![image](https://github.com/microsoft/vscode-docker/assets/8070232/2a340774-308d-4285-81f4-24bc3bc8ad89)
