### PR TITLE
Add telemetry for capturing Azure subscription information

### DIFF
--- a/src/tree/registries/Azure/AzureRegistryDataProvider.ts
+++ b/src/tree/registries/Azure/AzureRegistryDataProvider.ts
@@ -66,7 +66,7 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
             }
 
             const subscriptions = await this.subscriptionProvider.getSubscriptions();
-            void this.sendSubscriptionTelemetryIfNeeded();
+            this.sendSubscriptionTelemetryIfNeeded();
 
             return subscriptions.map(sub => {
                 return {
@@ -200,14 +200,14 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
     }
 
     private hasSentSubscriptionTelemetry = false;
-    private async sendSubscriptionTelemetryIfNeeded(): Promise<void> {
+    private sendSubscriptionTelemetryIfNeeded(): void {
         if (this.hasSentSubscriptionTelemetry) {
             return;
         }
         this.hasSentSubscriptionTelemetry = true;
 
         // This event is relied upon by the DevDiv Analytics and Growth Team
-        await callWithTelemetryAndErrorHandling('updateSubscriptionsAndTenants', async (context: IActionContext) => {
+        void callWithTelemetryAndErrorHandling('updateSubscriptionsAndTenants', async (context: IActionContext) => {
             context.telemetry.properties.isActivationEvent = 'true';
 
             const subscriptions = await this.subscriptionProvider.getSubscriptions(false);
@@ -222,7 +222,6 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
             context.telemetry.properties.numtenants = tenantSet.size.toString();
             context.telemetry.properties.numsubscriptions = subscriptionSet.size.toString();
             context.telemetry.properties.subscriptions = JSON.stringify(Array.from(subscriptionSet));
-
         });
     }
 }

--- a/src/tree/registries/Azure/AzureRegistryDataProvider.ts
+++ b/src/tree/registries/Azure/AzureRegistryDataProvider.ts
@@ -220,6 +220,8 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
                 subscriptionSet.add(sub.subscriptionId);
             });
 
+            // Number of tenants and subscriptions really belong in Measurements but for backwards compatibility
+            // they will be put into Properties instead.
             context.telemetry.properties.numtenants = tenantSet.size.toString();
             context.telemetry.properties.numsubscriptions = subscriptionSet.size.toString();
             context.telemetry.properties.subscriptions = JSON.stringify(Array.from(subscriptionSet));

--- a/src/tree/registries/Azure/AzureRegistryDataProvider.ts
+++ b/src/tree/registries/Azure/AzureRegistryDataProvider.ts
@@ -209,6 +209,7 @@ export class AzureRegistryDataProvider extends RegistryV2DataProvider implements
         // This event is relied upon by the DevDiv Analytics and Growth Team
         void callWithTelemetryAndErrorHandling('updateSubscriptionsAndTenants', async (context: IActionContext) => {
             context.telemetry.properties.isActivationEvent = 'true';
+            context.errorHandling.suppressDisplay = true;
 
             const subscriptions = await this.subscriptionProvider.getSubscriptions(false);
 


### PR DESCRIPTION
The Azure Account extension is no longer used by the Docker extension and the `updateSubscriptionsAndTenants` event it had is relied upon to generate Azure-subscription-related telemetry. We need to mimic the old event so that Kusto queries can be minimally changed.