### PR TITLE
Update targets to work correctly with 8.0.100-rc2 and up

### DIFF
--- a/resources/netCore/GetProjectProperties.targets
+++ b/resources/netCore/GetProjectProperties.targets
@@ -1,7 +1,12 @@
 <Project>
     <PropertyGroup>
+        <!-- Handle the varying properties across the SDK version/PackageReference methods for enabling containerization.
+             For the PackageReference, SDKContainerSupportEnabled is present. For the SDK built-in version,  EnableSdkContainerSupport is the primary flag. 
+             Certain project types have it set automatically, while others require users to manually set the property.
+             So for compat, we need to make sure and be responsive to both flags to check if a project supports containerization.  -->
         <EnableSdkContainerSupport Condition=" '$(EnableSdkContainerSupport)' == '' ">$(SDKContainerSupportEnabled)</EnableSdkContainerSupport>
         <GetProjectPropertiesDependsOn Condition=" '$(EnableSdkContainerSupport)' == 'true' ">$(GetProjectPropertiesDependsOn);ComputeContainerConfig;</GetProjectPropertiesDependsOn>
+
     </PropertyGroup>
 
     <Target Name="GetProjectProperties" DependsOnTargets="$(GetProjectPropertiesDependsOn)">

--- a/resources/netCore/GetProjectProperties.targets
+++ b/resources/netCore/GetProjectProperties.targets
@@ -1,6 +1,7 @@
 <Project>
     <PropertyGroup>
-        <GetProjectPropertiesDependsOn Condition=" '$(SDKContainerSupportEnabled)' == 'true' ">$(GetProjectPropertiesDependsOn);ComputeContainerConfig;</GetProjectPropertiesDependsOn>
+        <EnableSdkContainerSupport Condition=" '$(EnableSdkContainerSupport)' == '' ">$(SDKContainerSupportEnabled)</EnableSdkContainerSupport>
+        <GetProjectPropertiesDependsOn Condition=" '$(EnableSdkContainerSupport)' == 'true' ">$(GetProjectPropertiesDependsOn);ComputeContainerConfig;</GetProjectPropertiesDependsOn>
     </PropertyGroup>
 
     <Target Name="GetProjectProperties" DependsOnTargets="$(GetProjectPropertiesDependsOn)">
@@ -14,7 +15,7 @@
 $(TargetFramework)$(TargetFrameworks.Split(';')[0])
 $(OutputPath)$(AssemblyName).dll
 $(ContainerWorkingDirectory)/$(AssemblyName).dll
-$(SDKContainerSupportEnabled)
+$(EnableSdkContainerSupport)
 $(InferImageName)"
             Overwrite="True" />
     </Target>


### PR DESCRIPTION
Fixes #4199
Closes #3988 since the debugging Just Works (TM) with .NET 8 console projects as long as the `EnableSdkContainerSupport` property is manually set to `true` (e.g. in the .csproj file)

/cc @baronfel does this look about right?