### PR TITLE
Go back to using `python` instead of `python3` and bump Python dependency versions

### DIFF
--- a/resources/python/launcher.py
+++ b/resources/python/launcher.py
@@ -14,7 +14,7 @@ adapterHost = args[0]
 if adapterHost.isnumeric():
     args[0] = 'host.docker.internal:' + adapterHost
 
-dockerExecArgs = [containerExePath, 'exec', '-d', containerId, 'python3', '/debugpy/launcher'] + args
+dockerExecArgs = [containerExePath, 'exec', '-d', containerId, 'python', '/debugpy/launcher'] + args
 
 command = ' '.join(dockerExecArgs)
 

--- a/resources/templates/python/Dockerfile.template
+++ b/resources/templates/python/Dockerfile.template
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 {{#if (isRootPort ports)}}
 # Warning: A port below 1024 has been exposed. This requires the image to run as a root user which is not a best practice.

--- a/resources/templates/python/requirements.txt.template
+++ b/resources/templates/python/requirements.txt.template
@@ -1,14 +1,14 @@
 # To ensure app dependencies are ported from your virtual environment/host machine into your container, run 'pip freeze > requirements.txt' in the terminal to overwrite this file
 {{#if (eq platform 'Python: Django')}}
-django==4.1.5
+django==5.0.1
 {{/if}}
 {{#if (eq platform 'Python: FastAPI')}}
-fastapi[all]==0.89.0
-uvicorn[standard]==0.20.0
+fastapi[all]==0.109.0
+uvicorn[standard]==0.27.0
 {{/if}}
 {{#if (eq platform 'Python: Flask')}}
-flask==3.0.0
+flask==3.0.1
 {{/if}}
 {{#unless (eq platform 'Python: General')}}
-gunicorn==20.1.0
+gunicorn==21.2.0
 {{/unless}}

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -113,13 +113,12 @@ export class PythonDebugHelper implements DebugHelper {
 
             // debugLauncherPython controls the interpreter used by the debug adapter to start the launcher, also on the local client
             // We want it to use what it would normally use for local Python debugging, i.e. the chosen local interpreter
-            // This actually launches our launcher in resources/python/launcher.py, which uses `docker exec -d <containerId> python3 /debugpy/launcher ...` to launch the real debugpy launcher in the container
+            // This actually launches our launcher in resources/python/launcher.py, which uses `docker exec -d <containerId> python /debugpy/launcher ...` to launch the real debugpy launcher in the container
             debugLauncherPython: '${command:python.interpreterPath}',
             /* eslint-enable no-template-curly-in-string */
 
             // python controls the interpreter used by the launcher to start the application itself
-            // Since this is in the container it should always use `python3`
-            python: 'python3',
+            python: 'python',
         };
     }
 

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -117,8 +117,8 @@ export class PythonTaskHelper implements TaskHelper {
         // User input is honored in all of the below.
         runOptions.volumes = this.inferVolumes(runOptions, launcherFolder);
 
-        // If the user specifies command, we won't set entrypoint; otherwise if they set entrypoint we will respect it; otherwise use 'python3' to start an idle container
-        runOptions.entrypoint = runOptions.command ? undefined : runOptions.entrypoint || 'python3';
+        // If the user specifies command, we won't set entrypoint; otherwise if they set entrypoint we will respect it; otherwise use 'python' to start an idle container
+        runOptions.entrypoint = runOptions.command ? undefined : runOptions.entrypoint || 'python';
 
         return runOptions;
     }


### PR DESCRIPTION
Fixes #4209

I tested:
- [x] Flask
- [x] FastAPI
- [x] Django
- [x] General