### PR TITLE
Partially revert "Go back to using `python` instead of `python3`

### DIFF
--- a/resources/python/launcher.py
+++ b/resources/python/launcher.py
@@ -14,7 +14,7 @@ adapterHost = args[0]
 if adapterHost.isnumeric():
     args[0] = 'host.docker.internal:' + adapterHost
 
-dockerExecArgs = [containerExePath, 'exec', '-d', containerId, 'python', '/debugpy/launcher'] + args
+dockerExecArgs = [containerExePath, 'exec', '-d', containerId, 'python3', '/debugpy/launcher'] + args
 
 command = ' '.join(dockerExecArgs)
 

--- a/src/debugging/python/PythonDebugHelper.ts
+++ b/src/debugging/python/PythonDebugHelper.ts
@@ -113,12 +113,13 @@ export class PythonDebugHelper implements DebugHelper {
 
             // debugLauncherPython controls the interpreter used by the debug adapter to start the launcher, also on the local client
             // We want it to use what it would normally use for local Python debugging, i.e. the chosen local interpreter
-            // This actually launches our launcher in resources/python/launcher.py, which uses `docker exec -d <containerId> python /debugpy/launcher ...` to launch the real debugpy launcher in the container
+            // This actually launches our launcher in resources/python/launcher.py, which uses `docker exec -d <containerId> python3 /debugpy/launcher ...` to launch the real debugpy launcher in the container
             debugLauncherPython: '${command:python.interpreterPath}',
             /* eslint-enable no-template-curly-in-string */
 
             // python controls the interpreter used by the launcher to start the application itself
-            python: 'python',
+            // Since this is in the container it should always use `python3`
+            python: 'python3',
         };
     }
 

--- a/src/tasks/python/PythonTaskHelper.ts
+++ b/src/tasks/python/PythonTaskHelper.ts
@@ -117,8 +117,8 @@ export class PythonTaskHelper implements TaskHelper {
         // User input is honored in all of the below.
         runOptions.volumes = this.inferVolumes(runOptions, launcherFolder);
 
-        // If the user specifies command, we won't set entrypoint; otherwise if they set entrypoint we will respect it; otherwise use 'python' to start an idle container
-        runOptions.entrypoint = runOptions.command ? undefined : runOptions.entrypoint || 'python';
+        // If the user specifies command, we won't set entrypoint; otherwise if they set entrypoint we will respect it; otherwise use 'python3' to start an idle container
+        runOptions.entrypoint = runOptions.command ? undefined : runOptions.entrypoint || 'python3';
 
         return runOptions;
     }


### PR DESCRIPTION
This partially reverts commit 7b57512a3f57419880c401fceef4cf35e71038ab.

We'll go back to `python3` as that works on Mac and Linux. The `python3` command opening the Windows store page seems to be new and may have caused this regression in Insiders. Still not clear why only Insiders is affected.