### PR TITLE
Fix changelog inaccuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,8 @@
 - Node.js 18 is now used, requiring at minimum VSCode 1.82.0. [#4167](https://github.com/microsoft/vscode-docker/pull/4167)
 
 ### Fixed
-- Instead of `python3`, the Python debugging features now use `python`. Python 2 is far out of support, and Python 3 is the default on most systems. [#4209](https://github.com/microsoft/vscode-docker/issues/4209)
 - Fixed some issues with the registries view. [#4182](https://github.com/microsoft/vscode-docker/issues/4182), [#4192](https://github.com/microsoft/vscode-docker/issues/4192)
 - Fixed an issue with Dotnet SDK container based debugging. [#4199](https://github.com/microsoft/vscode-docker/issues/4199)
-
 
 ## 1.28.0 - 13 November 2023
 ### Added


### PR DESCRIPTION
https://github.com/microsoft/vscode-docker/pull/4228 reverted the change from `python` to `python3`, need to update the changelog too.