### PR TITLE
Scaffold Python Dockerfile with a floatier tag

### DIFF
--- a/resources/templates/python/Dockerfile.template
+++ b/resources/templates/python/Dockerfile.template
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.12-slim
+FROM python:3-slim
 
 {{#if (isRootPort ports)}}
 # Warning: A port below 1024 has been exposed. This requires the image to run as a root user which is not a best practice.


### PR DESCRIPTION
Uses a floatier tag for scaffolding Python apps. So we don't have to update this every year when a new Python release comes out.