### PR TITLE
Ignore commented <UserSecretsId> tag in .csproj

### DIFF
--- a/src/tasks/netcore/NetCoreTaskHelper.ts
+++ b/src/tasks/netcore/NetCoreTaskHelper.ts
@@ -195,7 +195,9 @@ export class NetCoreTaskHelper implements TaskHelper {
 
     private async inferUserSecrets(helperOptions: NetCoreTaskOptions): Promise<boolean> {
         const contents = await fse.readFile(helperOptions.appProject);
-        return UserSecretsRegex.test(contents.toString());
+        // Remove comments so we don't match a commented tag
+        const noComments = contents.toString().replace(/<!--.*?-->/gs, "");
+        return UserSecretsRegex.test(noComments);
     }
 
     private async inferVolumes(folder: WorkspaceFolder, runOptions: DockerRunOptions, helperOptions: NetCoreTaskOptions, ssl: boolean, userSecrets: boolean): Promise<DockerContainerVolume[]> {


### PR DESCRIPTION
Currently the extension employs this simple regex /UserSecretsId/i to detect if .NET project file uses values stored in Secret Manager. If this string is found in the project file, than the "docker-run" task generates a command that attempts to mount the secrets folder onto the container. If this folder does not exist than the command fails.
Problem is that this regex doesn't consider that the tag may be commented out.
I propose removing all commented sections from the .csproj contents before testing UserSecretsId regex against it.


