### PR TITLE
Update the language server to 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@microsoft/vscode-container-client": "^0.1.1",
                 "@microsoft/vscode-docker-registries": "^0.1.11",
                 "dayjs": "^1.11.7",
-                "dockerfile-language-server-nodejs": "^0.12.0",
+                "dockerfile-language-server-nodejs": "^0.13.0",
                 "fs-extra": "^11.1.1",
                 "gradle-to-js": "^2.0.1",
                 "handlebars": "^4.7.7",
@@ -2915,12 +2915,12 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.12.0.tgz",
-            "integrity": "sha512-HCQSd2B6EvHV6ag5ope0Is8fzq/sZG1A0DMXM1s4urKJLqvZF18hRl+FUbDNdC1AmCqbWWypK0zV322fWIyKLA==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.13.0.tgz",
+            "integrity": "sha512-r8GwQGVBHuRj83nFYoA7ulGfp6tgUH8gxlPRap0ewuroEb/XgP4KtLsIUIN9CvkTZge/IkX7cbFTVO0lq9gZ3A==",
             "dependencies": {
-                "dockerfile-language-service": "0.13.0",
-                "dockerfile-utils": "0.16.0",
+                "dockerfile-language-service": "0.14.0",
+                "dockerfile-utils": "0.16.1",
                 "vscode-languageserver": "~8.0.0",
                 "vscode-languageserver-textdocument": "~1.0.8"
             },
@@ -2965,12 +2965,12 @@
             "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.13.0.tgz",
-            "integrity": "sha512-Fr99umpm05X73YONXjmGGg5pkz4hMRRSew6ahklfi7WkwkcI31a23ZBOX88s0xyGPK7iosEv1b4s4ykuCb8nFA==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.14.0.tgz",
+            "integrity": "sha512-G3FDjCpuWQNrTuarSFtlOUNwwJl9ECJqsQdqGQN79nCmA1av0bbNSD++ipvfBqb/1fFeP2XxFy/N7WRIF12aBg==",
             "dependencies": {
                 "dockerfile-ast": "0.6.1",
-                "dockerfile-utils": "0.16.0",
+                "dockerfile-utils": "0.16.1",
                 "vscode-languageserver-textdocument": "1.0.8",
                 "vscode-languageserver-types": "3.17.3"
             },
@@ -2984,9 +2984,9 @@
             "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
         },
         "node_modules/dockerfile-utils": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.16.0.tgz",
-            "integrity": "sha512-EqLzeeNOm0V1apKfqoRSQrQbkGeypo0rMEdYdWgitHlEUqDQIywPLW+kRnjOoycbbSu+84yEYDnDPVthDzO78g==",
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.16.1.tgz",
+            "integrity": "sha512-kYj772IlJi8aVYB8fS/1ByJH3skQ/Nroa8NkSHrnHE51savvIXKV/9vpRrjnokL/qGWtSDeIWOVHev2S7zZpcA==",
             "dependencies": {
                 "dockerfile-ast": "0.6.1",
                 "vscode-languageserver-textdocument": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -3004,7 +3004,7 @@
         "@microsoft/vscode-container-client": "^0.1.1",
         "@microsoft/vscode-docker-registries": "^0.1.11",
         "dayjs": "^1.11.7",
-        "dockerfile-language-server-nodejs": "^0.12.0",
+        "dockerfile-language-server-nodejs": "^0.13.0",
         "fs-extra": "^11.1.1",
         "gradle-to-js": "^2.0.1",
         "handlebars": "^4.7.7",


### PR DESCRIPTION
This update includes a small linting fix as well as highlighting support for heredocs. You can use the file below to test the changes.

1. The `:-` syntax provides a default so we should not be flagging the `FROM` as an error (see https://github.com/rcjsuen/dockerfile-language-server/issues/269).
2. The language server now provides proper support for the start and end of a heredoc by highlighting the two ends and allowing you to jump from the end of the document to the original definition at the top.

```Dockerfile
# the FROM line should no longer be flagged as an error
FROM ${VAR:-alpine}

# 1. clicking on "file" on lines 6 or 8 should highlight the two occurrences
# 2. you can now use "Go to Definition" on line 8 to jump to line 6
RUN echo <<file
abc
file
```