### PR TITLE
Add release pipeline

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -1,0 +1,36 @@
+trigger: none # Only run this pipeline when manually triggered
+
+parameters:
+  - name: publishVersion
+    displayName: Version to publish
+    type: string
+  - name: dryRun
+    displayName: Dry run
+    type: boolean
+    default: false
+
+resources:
+  pipelines:
+    - pipeline: build # identifier to use in pipeline resource variables
+      source: \Azure Tools\VSCode\Extensions\vscode-docker # name of the pipeline that produces the artifacts
+  repositories:
+    - repository: azExtTemplates
+      type: github
+      name: microsoft/vscode-azuretools
+      ref: main
+      endpoint: GitHub-AzureTools # The service connection to use when accessing this repository
+
+variables:
+  # Required by MicroBuild template
+  - name: TeamName
+    value: "Container Tools Team"
+
+# Use those templates
+extends:
+  template: azure-pipelines/release-extension.yml@azExtTemplates
+  parameters:
+    pipelineID: $(resources.pipeline.build.pipelineID)
+    runID: $(resources.pipeline.build.runID)
+    publishVersion: ${{ parameters.publishVersion }}
+    dryRun: ${{ parameters.dryRun }}
+    environmentName: VSCodeDockerExtensionPublish


### PR DESCRIPTION
To make a release, you'll manually run the pipeline and need to fill out the parameters:
<img width="471" alt="image" src="https://github.com/user-attachments/assets/84c147bf-d6ff-40c0-a82c-a23c8bdccad3">

A version string is required at pipeline run time that will be matched against the version present in the package.json downloaded from the build pipeline artifacts. The "Dry Run" parameter will skip the last step that actually publishes the extension.

Under Resources you can change target build pipeline. It defaults to the latest successful build.

Releases will need to be approved by one member of the deployment environment. View the environment I created: https://dev.azure.com/devdiv/DevDiv/_environments/1258?view=checks. For now I've left the "allow self approval" setting enabled.