### PR TITLE
Convert default command template values into ShellQuotedString format

### DIFF
--- a/src/commands/selectCommandTemplate.ts
+++ b/src/commands/selectCommandTemplate.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { PortBinding, VoidCommandResponse } from '@microsoft/vscode-container-client';
+import { escaped, PortBinding, VoidCommandResponse } from '@microsoft/vscode-container-client';
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
 import { isDockerComposeClient } from '../runtimes/OrchestratorRuntimeManager';
@@ -168,14 +168,35 @@ export async function selectCommandTemplate(
         throw new Error(vscode.l10n.t('No command template was found for command \'{0}\'', command));
     }
 
-    actionContext.telemetry.properties.isDefaultCommand = defaultTemplates.some(t => t.template === selectedTemplate.template) ? 'true' : 'false';
+    const isDefault = defaultTemplates.some(t => t.template === selectedTemplate.template);
+    actionContext.telemetry.properties.isDefaultCommand = isDefault ? 'true' : 'false';
     actionContext.telemetry.properties.isCommandRegexMatched = selectedTemplate.match ? 'true' : 'false';
 
-    // This is not really ideal (putting the full command line into `command` instead of `command` + `args`), but parsing a string into a command + args like that is really hard
-    // Fortunately, `TaskCommandRunnerFactory` does not really care
+
+    let resolvedCommand = resolveVariables(selectedTemplate.template, folder, additionalVariables);
+
+    if (!isDefault) {
+        // This is not really ideal (putting the full command line into `command` instead of `command` + `args`), but parsing a string into a command + args like that is really hard
+        // Fortunately, `TaskCommandRunnerFactory` does not really care
+        return {
+            command: resolvedCommand,
+            args: undefined,
+        };
+    }
+
+    // For the default command, we can make assumptions that allow us to parse into command + args for better shell support
+
+    const argsRegex = /(?:"[^"]*")|(?:[^"\s]*)/g;
+    const commandAndArgs = resolvedCommand.match(argsRegex).filter(arg => arg.length !== 0).map(arg => arg.replace(/"/g, ''));
+    if (commandAndArgs.length > 0) {
+        resolvedCommand = commandAndArgs[0];
+    }
+
+    const resolvedArgs = commandAndArgs.slice(1).map(escaped);
+
     return {
-        command: resolveVariables(selectedTemplate.template, folder, additionalVariables),
-        args: undefined,
+        command: resolvedCommand,
+        args: resolvedArgs,
     };
 }
 

--- a/src/commands/selectCommandTemplate.ts
+++ b/src/commands/selectCommandTemplate.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { escaped, PortBinding, VoidCommandResponse } from '@microsoft/vscode-container-client';
+import { PortBinding, quoted, VoidCommandResponse } from '@microsoft/vscode-container-client';
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
 import { isDockerComposeClient } from '../runtimes/OrchestratorRuntimeManager';
@@ -187,12 +187,12 @@ export async function selectCommandTemplate(
     // For the default command, we can make assumptions that allow us to parse into command + args for better shell support
 
     const argsRegex = /(?:"[^"]*")|(?:[^"\s]*)/g;
-    const commandAndArgs = resolvedCommand.match(argsRegex).filter(arg => arg.length !== 0).map(arg => arg.replace(/"/g, ''));
+    const commandAndArgs = resolvedCommand.match(argsRegex).filter(arg => arg.length !== 0);
     if (commandAndArgs.length > 0) {
-        resolvedCommand = commandAndArgs[0];
+        resolvedCommand = commandAndArgs[0].replace(/"/g, '');
     }
 
-    const resolvedArgs = commandAndArgs.slice(1).map(escaped);
+    const resolvedArgs = commandAndArgs.slice(1).map(arg => arg.startsWith('"') ? quoted(arg.replace(/"/g, '')) : arg);
 
     return {
         command: resolvedCommand,


### PR DESCRIPTION
If a task command template has the default value, this attempts to parse it and convert into a ShellQuotedString format so that VSCode will perform appropriate argument escaping for the selected shell. The current logic will only run if a task is configured with the default value as the current parsing logic assumes certain conditions that may not be true for a user customized value.

This should resolve #4291.