### PR TITLE
Support new .NET SDK image build changes

### DIFF
--- a/src/tasks/netSdk/NetSdkRunTaskProvider.ts
+++ b/src/tasks/netSdk/NetSdkRunTaskProvider.ts
@@ -9,7 +9,7 @@ import { DockerPseudoterminal } from "../DockerPseudoterminal";
 import { DockerRunTask } from "../DockerRunTaskProvider";
 import { DockerTaskProvider } from '../DockerTaskProvider';
 import { DockerRunTaskContext } from '../TaskHelper';
-import { NetCoreRunTaskDefinition, NetCoreTaskHelper } from "../netcore/NetCoreTaskHelper";
+import { NetCoreRunTaskDefinition } from "../netcore/NetCoreTaskHelper";
 import { NetSdkRunTaskType, getNetSdkBuildCommand, getNetSdkRunCommand } from './netSdkTaskUtils';
 
 const NetSdkDebugTaskName = 'debug';
@@ -26,11 +26,10 @@ export class NetSdkRunTaskProvider extends DockerTaskProvider {
 
     protected async executeTaskInternal(context: DockerRunTaskContext, task: DockerRunTask): Promise<void> {
         const projectPath = task.definition.netCore?.appProject;
-        const isProjectWebApp = await NetCoreTaskHelper.isWebApp(projectPath);
         const projectFolderPath = path.dirname(projectPath);
 
         // use dotnet to build the image
-        const buildCommand = await getNetSdkBuildCommand(isProjectWebApp, task.definition.dockerRun.image);
+        const buildCommand = await getNetSdkBuildCommand();
         await context.terminal.execAsyncInTerminal(
             buildCommand,
             {
@@ -41,7 +40,7 @@ export class NetSdkRunTaskProvider extends DockerTaskProvider {
         );
 
         // use docker run to run the image
-        const runCommand = await getNetSdkRunCommand(isProjectWebApp, task.definition.dockerRun.image);
+        const runCommand = await getNetSdkRunCommand(task.definition.dockerRun.image);
         await context.terminal.execAsyncInTerminal(
             runCommand,
             {

--- a/src/tasks/netSdk/netSdkTaskUtils.ts
+++ b/src/tasks/netSdk/netSdkTaskUtils.ts
@@ -29,20 +29,13 @@ export type RidCpuArchitecture =
 export const NetSdkRunTaskType = 'dotnet-container-sdk';
 const NetSdkDefaultImageTag = 'dev'; // intentionally default to dev tag for phase 1 of this feature
 
-export async function getNetSdkBuildCommand(isProjectWebApp: boolean, imageName: string): Promise<string> {
-    const configuration = 'Debug'; // intentionally default to Debug configuration for phase 1 of this feature
-
-    // {@link https://github.com/dotnet/sdk-container-builds/issues/141} this could change in the future
-    const publishFlag = isProjectWebApp
-        ? '-p:PublishProfile=DefaultContainer'
-        : '/t:PublishContainer';
-
+export async function getNetSdkBuildCommand(): Promise<string> {
     const args = composeArgs(
         withArg('dotnet', 'publish'),
         withNamedArg('--os', await normalizeOsToRidOs()),
         withNamedArg('--arch', await normalizeArchitectureToRidArchitecture()),
-        withArg(publishFlag),
-        withNamedArg('--configuration', configuration),
+        withArg('/t:PublishContainer'),
+        withNamedArg('--configuration', 'Debug'),
         withNamedArg('-p:ContainerImageTag', NetSdkDefaultImageTag, { assignValue: true })
     )();
 
@@ -50,7 +43,7 @@ export async function getNetSdkBuildCommand(isProjectWebApp: boolean, imageName:
     return quotedArgs.join(' ');
 }
 
-export async function getNetSdkRunCommand(isProjectWebApp: boolean, imageName: string): Promise<string> {
+export async function getNetSdkRunCommand(imageName: string): Promise<string> {
     const client = await ext.runtimeManager.getClient();
 
     const options: RunContainerCommandOptions = {


### PR DESCRIPTION
In https://github.com/dotnet/sdk/pull/47064, console apps will get `EnableSdkContainerSupport` set to true by default. Consequently, we no longer need to have different image build command lines for console vs. web apps. This true for .NET 8 and 9 as well, so we can remove the code to use `-p:PublishProfile=DefaultContainer` altogether. It was only needed for .NET 7 which is out of support.

/cc @baronfel @patverb @danegsta 