### PR TITLE
Update the Dockerfile Language Server to 0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@microsoft/vscode-container-client": "^0.2.1",
                 "@microsoft/vscode-docker-registries": "^0.2.0",
                 "dayjs": "^1.11.7",
-                "dockerfile-language-server-nodejs": "^0.13.0",
+                "dockerfile-language-server-nodejs": "^0.14.0",
                 "fs-extra": "^11.1.1",
                 "gradle-to-js": "^2.0.1",
                 "handlebars": "^4.7.7",
@@ -3024,9 +3024,10 @@
             "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
         },
         "node_modules/dockerfile-ast": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.6.1.tgz",
-            "integrity": "sha512-m3rH2qHHU2pSTCppXgJT+1KLxhvkdROOxVPof5Yz4IPGSw6K+x0B0/RFdYgXN5zsIUTlbOSRyfDCv3/uVhnNmg==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.0.tgz",
+            "integrity": "sha512-HYpjuL0IEC2lYflTpWD0RLNSZYhQxLwYRYsoEjnCP7nu/OlFx1BVrU6X/Y8ETVsa2hojhG2OTJVxleH5Wrlq+Q==",
+            "license": "MIT",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.8",
                 "vscode-languageserver-types": "^3.17.3"
@@ -3036,12 +3037,13 @@
             }
         },
         "node_modules/dockerfile-language-server-nodejs": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.13.0.tgz",
-            "integrity": "sha512-r8GwQGVBHuRj83nFYoA7ulGfp6tgUH8gxlPRap0ewuroEb/XgP4KtLsIUIN9CvkTZge/IkX7cbFTVO0lq9gZ3A==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.14.0.tgz",
+            "integrity": "sha512-zbHDuaVHJrgnInOp+bGnMENikCDNGdEad8ro7WndQLGdRKjMC6Gndw2UKTv4WVlJTeAzwp8cOiu1VHkB4nmGgg==",
+            "license": "MIT",
             "dependencies": {
-                "dockerfile-language-service": "0.14.0",
-                "dockerfile-utils": "0.16.1",
+                "dockerfile-language-service": "0.15.0",
+                "dockerfile-utils": "0.16.2",
                 "vscode-languageserver": "~8.0.0",
                 "vscode-languageserver-textdocument": "~1.0.8"
             },
@@ -3086,12 +3088,13 @@
             "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
         },
         "node_modules/dockerfile-language-service": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.14.0.tgz",
-            "integrity": "sha512-G3FDjCpuWQNrTuarSFtlOUNwwJl9ECJqsQdqGQN79nCmA1av0bbNSD++ipvfBqb/1fFeP2XxFy/N7WRIF12aBg==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.15.0.tgz",
+            "integrity": "sha512-DvfabBrOQWhPzFtO6GvuEyv4ojdh3sr7+0uPc+TM+azJRrd7+zWvf6F8/AFVfmd2Kvdl9nvikmKIwSLEp0Wowg==",
+            "license": "MIT",
             "dependencies": {
-                "dockerfile-ast": "0.6.1",
-                "dockerfile-utils": "0.16.1",
+                "dockerfile-ast": "0.7.0",
+                "dockerfile-utils": "0.16.2",
                 "vscode-languageserver-textdocument": "1.0.8",
                 "vscode-languageserver-types": "3.17.3"
             },
@@ -3102,14 +3105,16 @@
         "node_modules/dockerfile-language-service/node_modules/vscode-languageserver-textdocument": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-            "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+            "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
+            "license": "MIT"
         },
         "node_modules/dockerfile-utils": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.16.1.tgz",
-            "integrity": "sha512-kYj772IlJi8aVYB8fS/1ByJH3skQ/Nroa8NkSHrnHE51savvIXKV/9vpRrjnokL/qGWtSDeIWOVHev2S7zZpcA==",
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.16.2.tgz",
+            "integrity": "sha512-0BHCYRYm5uk/xdL6jv1vLDxJ+FY812sQumRMkLB33f4FRB9VZsDk6ckUeSWlYOWHP9/VhmM0colmpXT/j2OTzA==",
+            "license": "MIT",
             "dependencies": {
-                "dockerfile-ast": "0.6.1",
+                "dockerfile-ast": "0.7.0",
                 "vscode-languageserver-textdocument": "^1.0.8",
                 "vscode-languageserver-types": "^3.17.3"
             },

--- a/package.json
+++ b/package.json
@@ -3028,7 +3028,7 @@
         "@microsoft/vscode-container-client": "^0.2.1",
         "@microsoft/vscode-docker-registries": "^0.2.0",
         "dayjs": "^1.11.7",
-        "dockerfile-language-server-nodejs": "^0.13.0",
+        "dockerfile-language-server-nodejs": "^0.14.0",
         "fs-extra": "^11.1.1",
         "gradle-to-js": "^2.0.1",
         "handlebars": "^4.7.7",


### PR DESCRIPTION
This update includes some general fixes as well as one to prevent the language server crashing (#4408). It also includes an update to how we handle links so that we no longer just blindly route everything to Docker Hub.

Please use the Dockerfile below to reproduce the crash and verify the fix.
```Dockerfile
FROM scratch
RUN <<<CRASH
CRASH

FROM scratch
```
Please use the Dockerfile below to test the other fixes and the update to the URL links.
```Dockerfile
# Ctrl+Clicking on alpine on line 3 should not jump to line 4,
# they're not referencing the same thing
FROM alpine
FROM hello AS alpine

# click on "base" on lines 11, 12, and 14
# only lines 11 and 14 will be highlighted,
# the new release highlights line 12 as well,
# then try repeating the steps with renaming,
# same problem, same fix
FROM busybox AS base
FROM base
FROM busybox
COPY --from=base . .

# links should go to the right place instead of all jumping to Docker Hub
# Docker Hub
FROM busybox
# GitHub Container Registry
FROM ghcr.io/super-linter/super-linter
FROM ghcr.io/super-linter/super-linter:latest-buildcache
# Microsoft Artifact Repository
FROM mcr.microsoft.com/powershell
FROM mcr.microsoft.com/powershell:3.17
FROM mcr.microsoft.com/windows/servercore
FROM mcr.microsoft.com/windows/servercore:ltsc2025
# Quay.io
FROM quay.io/prometheus/node-exporter:v1.9.1
```