### PR TITLE
Roll back the display name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-docker",
     "version": "2.0.0",
     "publisher": "ms-azuretools",
-    "displayName": "Docker Extension Pack",
+    "displayName": "Docker",
     "description": "Makes it easy to create, manage, and debug containerized applications.",
     "license": "SEE LICENSE IN LICENSE.md",
     "icon": "resources/docker_blue.png",


### PR DESCRIPTION
There are other extensions called "Docker Extension Pack" and VSCE won't let us upload. Rolling back the name for now, we'll try to fix it later.