### PR TITLE
ci: Harden workflows against supply-chain attacks

### DIFF
--- a/.github/workflows/guard-old-version-issues.yml
+++ b/.github/workflows/guard-old-version-issues.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/info-needed-closer.yml
+++ b/.github/workflows/info-needed-closer.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   main:
-    uses: microsoft/vscode-azuretools/.github/workflows/info-needed-closer.yml@main
+    uses: microsoft/vscode-azuretools/.github/workflows/info-needed-closer.yml@6784f2e199764bcb1c2214b7d4866b14fcdab5ba # main

--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   main:
-    uses: microsoft/vscode-azuretools/.github/workflows/locker.yml@main
+    uses: microsoft/vscode-azuretools/.github/workflows/locker.yml@6784f2e199764bcb1c2214b7d4866b14fcdab5ba # main


### PR DESCRIPTION
This Pull Request hardens the supply-chain security of the repository's GitHub Actions configuration by pinning mutable tags (`@v7`) and cross-repository references (`@main`) to strict immutable commit SHAs. 

By avoiding floating tags, this guarantees pipeline reproducibility and protects against potential malicious upstream branch overrides.