### PR TITLE
Add Dockerfile for grok2api container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# Use the published grok2api container image as the base image
+FROM ghcr.io/chenyme/grok2api:latest
+
+WORKDIR /app
+
+# Copy your config file into the image. Make sure your-config.yml exists in the same directory as this Dockerfile.
+COPY your-config.yml /app/your-config.yml
+
+# Start grok2api with a config file. Adjust the command if the image uses a different entrypoint or config path.
+CMD ["grok2api", "--config", "/app/your-config.yml"]


### PR DESCRIPTION
Add a Dockerfile that uses ghcr.io/chenyme/grok2api:latest as a base image and copies a local configuration file into the container.